### PR TITLE
Add PipeWire support and expand test coverage to 222 tests

### DIFF
--- a/src/waydroid_toolkit/core/container/incus_backend.py
+++ b/src/waydroid_toolkit/core/container/incus_backend.py
@@ -17,8 +17,8 @@ tools/helpers/lxc.py are handled here:
   2. tmpfs + bind mounts — added as `disk` devices (vendor, sys nodes, wslg,
                           dev/, tmp/, var/, run/).
   3. Session mounts     — configure_session() applies per-session Wayland
-                          socket, PulseAudio socket, and userdata bind mounts
-                          dynamically at session start.
+                          socket, PulseAudio/PipeWire socket, and userdata
+                          bind mounts dynamically at session start.
   4. Android env vars   — execute() passes the full ANDROID_ENV dict via
                           `incus exec --env` so Android PATH and runtime
                           roots are correct inside the container.
@@ -31,6 +31,17 @@ tools/helpers/lxc.py are handled here:
                           `incus config set` call so nothing overwrites
                           anything else.
 
+Audio backend selection
+-----------------------
+SessionConfig supports both PulseAudio and PipeWire. Use
+SessionConfig.detect() to auto-select: it prefers the PipeWire native
+socket ($XDG_RUNTIME_DIR/pipewire-0) when present, and falls back to the
+PulseAudio-compatible socket ($XDG_RUNTIME_DIR/pulse/native).
+
+PipeWire ships a PulseAudio compatibility layer (pipewire-pulse), so the
+PulseAudio socket path works on PipeWire systems too. The native PipeWire
+socket gives lower latency and avoids the translation overhead.
+
 This toolkit does not modify upstream waydroid/waydroid. The waydroid daemon
 continues to manage its own LXC config files; the Incus backend reads those
 files and mirrors them into Incus on setup.
@@ -40,9 +51,11 @@ from __future__ import annotations
 
 import glob
 import json
+import os
 import shutil
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from pathlib import Path
 
 from .base import BackendInfo, BackendType, ContainerBackend, ContainerState
@@ -199,20 +212,104 @@ def _static_disk_mounts() -> list[_DiskMount]:
     ]
 
 
+# ── Audio backend ─────────────────────────────────────────────────────────────
+
+class AudioBackend(Enum):
+    """Audio socket type to mount into the container.
+
+    PULSEAUDIO — PulseAudio native socket, or PipeWire's PulseAudio
+                 compatibility socket (pipewire-pulse). Works on both
+                 pure PulseAudio and PipeWire systems.
+    PIPEWIRE   — PipeWire native socket (pipewire-0). Lower latency than
+                 going through the PulseAudio compatibility layer.
+                 Requires PipeWire >= 0.3 on the host.
+    AUTO       — Sentinel used by SessionConfig.detect(); resolved to
+                 PIPEWIRE when the native socket exists, else PULSEAUDIO.
+    """
+    PULSEAUDIO = auto()
+    PIPEWIRE = auto()
+    AUTO = auto()
+
+
+def _xdg_runtime_dir() -> str:
+    """Return $XDG_RUNTIME_DIR, falling back to /run/user/<uid>."""
+    return os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+
+
+def detect_audio_backend(xdg_runtime_dir: str | None = None) -> AudioBackend:
+    """Return PIPEWIRE if the native socket exists, else PULSEAUDIO.
+
+    Checks $XDG_RUNTIME_DIR/pipewire-0 on the host. PipeWire's PulseAudio
+    compatibility socket ($XDG_RUNTIME_DIR/pulse/native) is intentionally
+    not used as the detection signal — its presence only means pipewire-pulse
+    is running, not that the native socket is available.
+    """
+    xdg = xdg_runtime_dir or _xdg_runtime_dir()
+    if Path(xdg, "pipewire-0").exists():
+        return AudioBackend.PIPEWIRE
+    return AudioBackend.PULSEAUDIO
+
+
 # ── Session config ────────────────────────────────────────────────────────────
 
 @dataclass
 class SessionConfig:
     """Per-session mount parameters.
 
-    Mirrors the inputs to generate_session_lxc_config() in upstream lxc.py.
+    Mirrors the inputs to generate_session_lxc_config() in upstream lxc.py,
+    extended with PipeWire native socket support.
+
+    Build manually or use SessionConfig.detect() to auto-populate from the
+    running host environment.
     """
     wayland_host_socket: str       # e.g. /run/user/1000/wayland-0
     wayland_container_socket: str  # e.g. /run/waydroid-session/wayland-0
-    pulse_host_socket: str         # e.g. /run/user/1000/pulse/native
-    pulse_container_socket: str    # e.g. /run/waydroid-session/pulse/native
     waydroid_data: str             # e.g. ~/.local/share/waydroid/data
     xdg_runtime_dir: str           # container XDG_RUNTIME_DIR path
+
+    # Audio — exactly one of these pairs is populated depending on audio_backend
+    audio_backend: AudioBackend = field(default=AudioBackend.PULSEAUDIO)
+
+    # PulseAudio socket (used when audio_backend == PULSEAUDIO)
+    pulse_host_socket: str = ""
+    pulse_container_socket: str = ""
+
+    # PipeWire native socket (used when audio_backend == PIPEWIRE)
+    pipewire_host_socket: str = ""
+    pipewire_container_socket: str = ""
+
+    @classmethod
+    def detect(
+        cls,
+        waydroid_data: str | None = None,
+        audio: AudioBackend = AudioBackend.AUTO,
+    ) -> SessionConfig:
+        """Build a SessionConfig from the current host environment.
+
+        Reads XDG_RUNTIME_DIR, UID, and probes for audio sockets.
+        audio=AUTO (default) picks PIPEWIRE when the native socket exists.
+        """
+        xdg = _xdg_runtime_dir()
+        data = waydroid_data or str(Path.home() / ".local/share/waydroid/data")
+
+        resolved_audio = detect_audio_backend(xdg) if audio == AudioBackend.AUTO else audio
+
+        cfg = cls(
+            wayland_host_socket=f"{xdg}/wayland-0",
+            wayland_container_socket="/run/waydroid-session/wayland-0",
+            waydroid_data=data,
+            xdg_runtime_dir="/run/waydroid-session",
+            audio_backend=resolved_audio,
+        )
+
+        if resolved_audio == AudioBackend.PIPEWIRE:
+            cfg.pipewire_host_socket = f"{xdg}/pipewire-0"
+            cfg.pipewire_container_socket = "/run/waydroid-session/pipewire-0"
+        else:
+            cfg.pulse_host_socket = f"{xdg}/pulse/native"
+            cfg.pulse_container_socket = "/run/waydroid-session/pulse/native"
+
+        return cfg
 
 
 # ── IncusBackend ──────────────────────────────────────────────────────────────
@@ -370,7 +467,7 @@ class IncusBackend(ContainerBackend):
     def _session_device_specs(
         self, session: SessionConfig,
     ) -> dict[str, list[str]]:
-        return {
+        specs: dict[str, list[str]] = {
             "session_xdg_tmpfs": [
                 "disk",
                 "source=tmpfs",
@@ -381,17 +478,27 @@ class IncusBackend(ContainerBackend):
                 f"source={session.wayland_host_socket}",
                 f"path={session.wayland_container_socket}",
             ],
-            "session_pulse": [
-                "disk",
-                f"source={session.pulse_host_socket}",
-                f"path={session.pulse_container_socket}",
-            ],
             "session_data": [
                 "disk",
                 f"source={session.waydroid_data}",
                 "path=/data",
             ],
         }
+
+        if session.audio_backend == AudioBackend.PIPEWIRE and session.pipewire_host_socket:
+            specs["session_pipewire"] = [
+                "disk",
+                f"source={session.pipewire_host_socket}",
+                f"path={session.pipewire_container_socket}",
+            ]
+        elif session.pulse_host_socket:
+            specs["session_pulse"] = [
+                "disk",
+                f"source={session.pulse_host_socket}",
+                f"path={session.pulse_container_socket}",
+            ]
+
+        return specs
 
     # ── Setup from existing LXC config ───────────────────────────────────────
 

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,8 +1,17 @@
 """Tests for the backup module."""
 
-from pathlib import Path
+from __future__ import annotations
 
-from waydroid_toolkit.modules.backup.backup import list_backups
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.backup.backup import (
+    create_backup,
+    list_backups,
+    restore_backup,
+)
 
 
 def test_list_backups_empty(tmp_path: Path) -> None:
@@ -34,3 +43,84 @@ def test_list_backups_ignores_non_matching(tmp_path: Path) -> None:
 
 def test_list_backups_missing_dir(tmp_path: Path) -> None:
     assert list_backups(tmp_path / "nonexistent") == []
+
+
+# ── create_backup ─────────────────────────────────────────────────────────────
+
+class TestCreateBackup:
+    def _mock_run(self, returncode: int = 0) -> MagicMock:
+        return MagicMock(returncode=returncode, stderr="")
+
+    def test_creates_archive_in_dest(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.backup.backup.require_root"):
+            with patch("waydroid_toolkit.modules.backup.backup.get_session_state") as mock_state:
+                mock_state.return_value = MagicMock(value="stopped")
+                with patch("waydroid_toolkit.modules.backup.backup.subprocess.run") as mock_run:
+                    mock_run.return_value = self._mock_run()
+                    archive = create_backup(dest_dir=tmp_path)
+        assert archive.parent == tmp_path
+        assert archive.name.startswith("waydroid_backup_")
+        assert archive.name.endswith(".tar.gz")
+
+    def test_raises_on_tar_failure(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.backup.backup.require_root"):
+            with patch("waydroid_toolkit.modules.backup.backup.get_session_state") as mock_state:
+                mock_state.return_value = MagicMock(value="stopped")
+                with patch("waydroid_toolkit.modules.backup.backup.subprocess.run") as mock_run:
+                    mock_run.return_value = self._mock_run(returncode=1)
+                    mock_run.return_value.stderr = "tar: error"
+                    with pytest.raises(RuntimeError, match="Backup failed"):
+                        create_backup(dest_dir=tmp_path)
+
+    def test_stops_running_session(self, tmp_path: Path) -> None:
+        from waydroid_toolkit.core.waydroid import SessionState
+        with patch("waydroid_toolkit.modules.backup.backup.require_root"):
+            with patch("waydroid_toolkit.modules.backup.backup.get_session_state",
+                       return_value=SessionState.RUNNING):
+                with patch("waydroid_toolkit.modules.backup.backup.run_waydroid") as mock_wd:
+                    with patch("waydroid_toolkit.modules.backup.backup.subprocess.run") as mock_run:
+                        mock_run.return_value = self._mock_run()
+                        create_backup(dest_dir=tmp_path)
+        mock_wd.assert_called_once_with("session", "stop", sudo=True)
+
+    def test_progress_called(self, tmp_path: Path) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.backup.backup.require_root"):
+            with patch("waydroid_toolkit.modules.backup.backup.get_session_state") as mock_state:
+                mock_state.return_value = MagicMock(value="stopped")
+                with patch("waydroid_toolkit.modules.backup.backup.subprocess.run") as mock_run:
+                    mock_run.return_value = self._mock_run()
+                    create_backup(dest_dir=tmp_path, progress=messages.append)
+        assert len(messages) >= 1
+
+
+# ── restore_backup ────────────────────────────────────────────────────────────
+
+class TestRestoreBackup:
+    def test_raises_if_archive_missing(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.backup.backup.require_root"):
+            with pytest.raises(FileNotFoundError):
+                restore_backup(tmp_path / "nonexistent.tar.gz")
+
+    def test_calls_tar_extract(self, tmp_path: Path) -> None:
+        archive = tmp_path / "waydroid_backup_20240101_120000.tar.gz"
+        archive.touch()
+        with patch("waydroid_toolkit.modules.backup.backup.require_root"):
+            with patch("waydroid_toolkit.modules.backup.backup.get_session_state") as mock_state:
+                mock_state.return_value = MagicMock(value="stopped")
+                with patch("waydroid_toolkit.modules.backup.backup.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stderr="")
+                    restore_backup(archive)
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("tar" in c and "-xzf" in c for c in cmds)
+
+    def test_raises_on_tar_failure(self, tmp_path: Path) -> None:
+        archive = tmp_path / "waydroid_backup_20240101_120000.tar.gz"
+        archive.touch()
+        with patch("waydroid_toolkit.modules.backup.backup.require_root"):
+            with patch("waydroid_toolkit.modules.backup.backup.get_session_state") as mock_state:
+                mock_state.return_value = MagicMock(value="stopped")
+                with patch("waydroid_toolkit.modules.backup.backup.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=1, stderr="tar: error")
+                    with pytest.raises(RuntimeError, match="Restore failed"):
+                        restore_backup(archive)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,9 @@
-"""Smoke tests for the CLI entry point."""
+"""Tests for the CLI entry point and subcommands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -71,3 +76,122 @@ def test_subcommand_help_backend() -> None:
     assert "switch" in result.output
     assert "detect" in result.output
     assert "list" in result.output
+
+
+# ── backup subcommands ────────────────────────────────────────────────────────
+
+def test_backup_list_empty(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["backup", "list", "--dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No backups" in result.output
+
+
+def test_backup_list_shows_archives(tmp_path: Path) -> None:
+    (tmp_path / "waydroid_backup_20240101_120000.tar.gz").write_bytes(b"x" * 1024)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["backup", "list", "--dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "waydroid_backup_20240101_120000.tar.gz" in result.output
+
+
+def test_backup_create_invokes_module(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.backup.create_backup") as mock_create:
+        mock_create.return_value = tmp_path / "waydroid_backup_20240101_120000.tar.gz"
+        result = runner.invoke(cli, ["backup", "create", "--dest", str(tmp_path)])
+    assert result.exit_code == 0
+    mock_create.assert_called_once()
+
+
+def test_backup_restore_requires_confirmation(tmp_path: Path) -> None:
+    archive = tmp_path / "waydroid_backup_20240101_120000.tar.gz"
+    archive.touch()
+    runner = CliRunner()
+    # Decline confirmation
+    result = runner.invoke(cli, ["backup", "restore", str(archive)], input="n\n")
+    assert result.exit_code != 0
+
+
+def test_backup_restore_with_yes_flag(tmp_path: Path) -> None:
+    archive = tmp_path / "waydroid_backup_20240101_120000.tar.gz"
+    archive.touch()
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.backup.restore_backup") as mock_restore:
+        result = runner.invoke(cli, ["backup", "restore", "--yes", str(archive)])
+    assert result.exit_code == 0
+    mock_restore.assert_called_once()
+
+
+# ── packages subcommands ──────────────────────────────────────────────────────
+
+def test_packages_list_empty() -> None:
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.packages.get_installed_packages", return_value=[]):
+        result = runner.invoke(cli, ["packages", "list"])
+    assert result.exit_code == 0
+    assert "No third-party" in result.output
+
+
+def test_packages_list_shows_packages() -> None:
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.packages.get_installed_packages",
+               return_value=["com.example.app", "org.fdroid.fdroid"]):
+        result = runner.invoke(cli, ["packages", "list"])
+    assert result.exit_code == 0
+    assert "com.example.app" in result.output
+
+
+def test_packages_install_local_file(tmp_path: Path) -> None:
+    apk = tmp_path / "app.apk"
+    apk.write_bytes(b"PK")
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.packages.install_apk_file") as mock_install:
+        result = runner.invoke(cli, ["packages", "install", str(apk)])
+    assert result.exit_code == 0
+    mock_install.assert_called_once()
+
+
+def test_packages_install_url() -> None:
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.packages.install_apk_url") as mock_install:
+        result = runner.invoke(cli, ["packages", "install", "https://example.com/app.apk"])
+    assert result.exit_code == 0
+    mock_install.assert_called_once()
+
+
+def test_packages_search_no_results() -> None:
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.packages.search_repos", return_value=[]):
+        result = runner.invoke(cli, ["packages", "search", "zzznomatch"])
+    assert result.exit_code == 0
+    assert "No results" in result.output
+
+
+def test_packages_repo_list_empty() -> None:
+    runner = CliRunner()
+    with patch("waydroid_toolkit.cli.commands.packages.list_repos", return_value=[]):
+        result = runner.invoke(cli, ["packages", "repo", "list"])
+    assert result.exit_code == 0
+    assert "No repos" in result.output
+
+
+# ── backend subcommands ───────────────────────────────────────────────────────
+
+def test_backend_list_shows_backends() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["backend", "list"])
+    assert result.exit_code == 0
+    # Both backend names should appear
+    assert "lxc" in result.output.lower() or "incus" in result.output.lower()
+
+
+def test_backend_detect_output() -> None:
+    runner = CliRunner()
+    # detect is imported as detect_backend from waydroid_toolkit.core.container
+    with patch("waydroid_toolkit.cli.commands.backend.detect_backend") as mock_detect:
+        mock_backend = MagicMock()
+        mock_backend.backend_type.value = "lxc"
+        mock_detect.return_value = mock_backend
+        result = runner.invoke(cli, ["backend", "detect"])
+    assert result.exit_code == 0

--- a/tests/unit/test_container_backend.py
+++ b/tests/unit/test_container_backend.py
@@ -12,11 +12,13 @@ import pytest
 from waydroid_toolkit.core.container import BackendType, ContainerState
 from waydroid_toolkit.core.container.incus_backend import (
     ANDROID_ENV,
+    AudioBackend,
     IncusBackend,
     SessionConfig,
     _glob_char_devices,
     _static_char_devices,
     _static_disk_mounts,
+    detect_audio_backend,
 )
 from waydroid_toolkit.core.container.lxc_backend import LxcBackend
 from waydroid_toolkit.core.container.selector import detect, get_active, set_active
@@ -82,6 +84,65 @@ class TestDeviceDescriptors:
     def test_static_disk_mounts_includes_wslg(self) -> None:
         names = [m.name for m in _static_disk_mounts()]
         assert "wslg" in names
+
+
+# ── AudioBackend detection ────────────────────────────────────────────────────
+
+
+class TestAudioBackend:
+    def test_detect_returns_pipewire_when_socket_exists(self, tmp_path: Path) -> None:
+        (tmp_path / "pipewire-0").touch()
+        assert detect_audio_backend(str(tmp_path)) == AudioBackend.PIPEWIRE
+
+    def test_detect_returns_pulseaudio_when_no_pipewire_socket(self, tmp_path: Path) -> None:
+        assert detect_audio_backend(str(tmp_path)) == AudioBackend.PULSEAUDIO
+
+    def test_detect_ignores_pulse_socket_for_detection(self, tmp_path: Path) -> None:
+        # pulse/native present but pipewire-0 absent → still PULSEAUDIO
+        (tmp_path / "pulse").mkdir()
+        (tmp_path / "pulse" / "native").touch()
+        assert detect_audio_backend(str(tmp_path)) == AudioBackend.PULSEAUDIO
+
+
+class TestSessionConfigDetect:
+    def test_detect_auto_picks_pipewire(self, tmp_path: Path) -> None:
+        (tmp_path / "pipewire-0").touch()
+        with patch("waydroid_toolkit.core.container.incus_backend._xdg_runtime_dir", return_value=str(tmp_path)):
+            cfg = SessionConfig.detect(waydroid_data="/data", audio=AudioBackend.AUTO)
+        assert cfg.audio_backend == AudioBackend.PIPEWIRE
+        assert cfg.pipewire_host_socket == str(tmp_path / "pipewire-0")
+        assert cfg.pulse_host_socket == ""
+
+    def test_detect_auto_falls_back_to_pulseaudio(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend._xdg_runtime_dir", return_value=str(tmp_path)):
+            cfg = SessionConfig.detect(waydroid_data="/data", audio=AudioBackend.AUTO)
+        assert cfg.audio_backend == AudioBackend.PULSEAUDIO
+        assert cfg.pulse_host_socket == str(tmp_path / "pulse" / "native")
+        assert cfg.pipewire_host_socket == ""
+
+    def test_detect_forced_pulseaudio(self, tmp_path: Path) -> None:
+        # Even if pipewire-0 exists, explicit PULSEAUDIO wins
+        (tmp_path / "pipewire-0").touch()
+        with patch("waydroid_toolkit.core.container.incus_backend._xdg_runtime_dir", return_value=str(tmp_path)):
+            cfg = SessionConfig.detect(waydroid_data="/data", audio=AudioBackend.PULSEAUDIO)
+        assert cfg.audio_backend == AudioBackend.PULSEAUDIO
+        assert cfg.pipewire_host_socket == ""
+
+    def test_detect_forced_pipewire(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend._xdg_runtime_dir", return_value=str(tmp_path)):
+            cfg = SessionConfig.detect(waydroid_data="/data", audio=AudioBackend.PIPEWIRE)
+        assert cfg.audio_backend == AudioBackend.PIPEWIRE
+        assert cfg.pipewire_host_socket == str(tmp_path / "pipewire-0")
+
+    def test_detect_sets_wayland_socket(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend._xdg_runtime_dir", return_value=str(tmp_path)):
+            cfg = SessionConfig.detect(waydroid_data="/data")
+        assert cfg.wayland_host_socket == str(tmp_path / "wayland-0")
+
+    def test_detect_uses_provided_waydroid_data(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend._xdg_runtime_dir", return_value=str(tmp_path)):
+            cfg = SessionConfig.detect(waydroid_data="/custom/data")
+        assert cfg.waydroid_data == "/custom/data"
 
 
 # ── LxcBackend ────────────────────────────────────────────────────────────────
@@ -240,47 +301,62 @@ class TestIncusBackend:
             flat = " ".join(mock_run.call_args[0][0])
             assert "MY_VAR=hello" in flat
 
-    def test_configure_session_adds_devices(self) -> None:
-        session = SessionConfig(
+    def _pulse_session(self) -> SessionConfig:
+        return SessionConfig(
             wayland_host_socket="/run/user/1000/wayland-0",
             wayland_container_socket="/run/waydroid-session/wayland-0",
-            pulse_host_socket="/run/user/1000/pulse/native",
-            pulse_container_socket="/run/waydroid-session/pulse/native",
             waydroid_data="/home/user/.local/share/waydroid/data",
             xdg_runtime_dir="/run/waydroid-session",
+            audio_backend=AudioBackend.PULSEAUDIO,
+            pulse_host_socket="/run/user/1000/pulse/native",
+            pulse_container_socket="/run/waydroid-session/pulse/native",
         )
+
+    def _pipewire_session(self) -> SessionConfig:
+        return SessionConfig(
+            wayland_host_socket="/run/user/1000/wayland-0",
+            wayland_container_socket="/run/waydroid-session/wayland-0",
+            waydroid_data="/home/user/.local/share/waydroid/data",
+            xdg_runtime_dir="/run/waydroid-session",
+            audio_backend=AudioBackend.PIPEWIRE,
+            pipewire_host_socket="/run/user/1000/pipewire-0",
+            pipewire_container_socket="/run/waydroid-session/pipewire-0",
+        )
+
+    def test_configure_session_adds_devices_pulseaudio(self) -> None:
         with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            IncusBackend().configure_session(session)
-        # Each device: one remove attempt + one add call
-        # command: ["incus", "config", "device", "add", CONTAINER, NAME, ...]
-        add_calls = [
-            c for c in mock_run.call_args_list
-            if len(c[0][0]) > 3 and c[0][0][3] == "add"
-        ]
+            IncusBackend().configure_session(self._pulse_session())
+        add_calls = [c for c in mock_run.call_args_list if len(c[0][0]) > 3 and c[0][0][3] == "add"]
         device_names = [c[0][0][5] for c in add_calls]
         assert "session_wayland" in device_names
         assert "session_pulse" in device_names
         assert "session_data" in device_names
         assert "session_xdg_tmpfs" in device_names
+        assert "session_pipewire" not in device_names
 
-    def test_remove_session_devices_removes_all(self) -> None:
-        session = SessionConfig(
-            wayland_host_socket="/run/user/1000/wayland-0",
-            wayland_container_socket="/run/waydroid-session/wayland-0",
-            pulse_host_socket="/run/user/1000/pulse/native",
-            pulse_container_socket="/run/waydroid-session/pulse/native",
-            waydroid_data="/home/user/.local/share/waydroid/data",
-            xdg_runtime_dir="/run/waydroid-session",
-        )
+    def test_configure_session_adds_pipewire_device(self) -> None:
         with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            IncusBackend().remove_session_devices(session)
-        remove_calls = [
-            c for c in mock_run.call_args_list
-            if "remove" in c[0][0]
-        ]
-        assert len(remove_calls) == 4
+            IncusBackend().configure_session(self._pipewire_session())
+        add_calls = [c for c in mock_run.call_args_list if len(c[0][0]) > 3 and c[0][0][3] == "add"]
+        device_names = [c[0][0][5] for c in add_calls]
+        assert "session_pipewire" in device_names
+        assert "session_pulse" not in device_names
+
+    def test_remove_session_devices_removes_all(self) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            IncusBackend().remove_session_devices(self._pulse_session())
+        remove_calls = [c for c in mock_run.call_args_list if "remove" in c[0][0]]
+        assert len(remove_calls) == 4  # xdg_tmpfs, wayland, pulse, data
+
+    def test_remove_session_devices_pipewire(self) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            IncusBackend().remove_session_devices(self._pipewire_session())
+        remove_calls = [c for c in mock_run.call_args_list if "remove" in c[0][0]]
+        assert len(remove_calls) == 4  # xdg_tmpfs, wayland, pipewire, data
 
     def test_get_info_parses_client_version(self) -> None:
         version_output = "Client version: 6.1\nServer version: 6.1\n"

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -1,5 +1,9 @@
 """Tests for the extension registry and base class."""
 
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from waydroid_toolkit.modules.extensions import REGISTRY, get, list_all
@@ -52,3 +56,117 @@ def test_extension_state_returns_enum(monkeypatch) -> None:
 
     monkeypatch.setattr(ext, "is_installed", lambda: (_ for _ in ()).throw(RuntimeError("oops")))
     assert ext.state() == ExtensionState.UNKNOWN
+
+
+# ── is_installed checks ───────────────────────────────────────────────────────
+
+class TestIsInstalled:
+    def test_gapps_not_installed_when_marker_absent(self) -> None:
+        ext = get("gapps")
+        with patch("waydroid_toolkit.modules.extensions.gapps._MARKER") as mock_marker:
+            mock_marker.exists.return_value = False
+            assert ext.is_installed() is False
+
+    def test_gapps_installed_when_marker_present(self) -> None:
+        ext = get("gapps")
+        with patch("waydroid_toolkit.modules.extensions.gapps._MARKER") as mock_marker:
+            mock_marker.exists.return_value = True
+            assert ext.is_installed() is True
+
+    def test_microg_not_installed_when_marker_absent(self) -> None:
+        ext = get("microg")
+        with patch("waydroid_toolkit.modules.extensions.microg._MICROG_MARKER") as mock_marker:
+            mock_marker.exists.return_value = False
+            assert ext.is_installed() is False
+
+    def test_magisk_not_installed_when_marker_absent(self) -> None:
+        ext = get("magisk")
+        with patch("waydroid_toolkit.modules.extensions.magisk._MAGISK_MARKER") as mock_marker:
+            mock_marker.exists.return_value = False
+            assert ext.is_installed() is False
+
+    def test_libhoudini_not_installed_when_marker_absent(self) -> None:
+        ext = get("libhoudini")
+        with patch("waydroid_toolkit.modules.extensions.arm_translation._HOUDINI_MARKER") as m:
+            m.exists.return_value = False
+            assert ext.is_installed() is False
+
+    def test_libndk_not_installed_when_marker_absent(self) -> None:
+        ext = get("libndk")
+        with patch("waydroid_toolkit.modules.extensions.arm_translation._NDK_MARKER") as m:
+            m.exists.return_value = False
+            assert ext.is_installed() is False
+
+
+# ── install / uninstall ───────────────────────────────────────────────────────
+
+class TestGAppsInstall:
+    def test_raises_when_overlay_disabled(self) -> None:
+        ext = get("gapps")
+        with patch("waydroid_toolkit.modules.extensions.gapps.require_root"):
+            with patch("waydroid_toolkit.modules.extensions.gapps.is_overlay_enabled", return_value=False):
+                with pytest.raises(RuntimeError, match="mount_overlays"):
+                    ext.install()
+
+    def test_uninstall_removes_marker(self) -> None:
+        ext = get("gapps")
+        with patch("waydroid_toolkit.modules.extensions.gapps.require_root"):
+            with patch("waydroid_toolkit.modules.extensions.gapps._MARKER") as mock_marker:
+                mock_marker.exists.return_value = True
+                with patch("waydroid_toolkit.modules.extensions.gapps.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    ext.uninstall()
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("rm" in c for c in cmds)
+
+
+class TestMicroGInstall:
+    def test_raises_when_overlay_disabled(self) -> None:
+        ext = get("microg")
+        with patch("waydroid_toolkit.modules.extensions.microg.require_root"):
+            with patch("waydroid_toolkit.modules.extensions.microg.is_overlay_enabled", return_value=False):
+                with pytest.raises(RuntimeError, match="mount_overlays"):
+                    ext.install()
+
+    def test_uninstall_calls_rm(self) -> None:
+        ext = get("microg")
+        with patch("waydroid_toolkit.modules.extensions.microg.require_root"):
+            with patch("waydroid_toolkit.modules.extensions.microg.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                ext.uninstall()
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("rm" in c for c in cmds)
+
+
+class TestMagiskInstall:
+    def test_raises_when_overlay_disabled(self) -> None:
+        ext = get("magisk")
+        with patch("waydroid_toolkit.modules.extensions.magisk.require_root"):
+            with patch("waydroid_toolkit.modules.extensions.magisk.is_overlay_enabled", return_value=False):
+                with pytest.raises(RuntimeError, match="mount_overlays"):
+                    ext.install()
+
+    def test_raises_when_waydroid_not_running(self) -> None:
+        from waydroid_toolkit.core.waydroid import SessionState
+        ext = get("magisk")
+        with patch("waydroid_toolkit.modules.extensions.magisk.require_root"):
+            with patch("waydroid_toolkit.modules.extensions.magisk.is_overlay_enabled", return_value=True):
+                with patch("waydroid_toolkit.modules.extensions.magisk.get_session_state",
+                           return_value=SessionState.STOPPED):
+                    with pytest.raises(RuntimeError, match="running"):
+                        ext.install()
+
+
+# ── conflict metadata ─────────────────────────────────────────────────────────
+
+class TestConflicts:
+    def test_all_extensions_have_id(self) -> None:
+        for ext in list_all():
+            assert ext.meta.id
+
+    def test_all_extensions_have_description(self) -> None:
+        for ext in list_all():
+            assert ext.meta.description
+
+    def test_magisk_has_no_conflicts(self) -> None:
+        assert get("magisk").meta.conflicts == []

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -1,8 +1,18 @@
 """Tests for the image profile manager."""
 
-from pathlib import Path
+from __future__ import annotations
 
-from waydroid_toolkit.modules.images.manager import ImageProfile, scan_profiles
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.images.manager import (
+    ImageProfile,
+    get_active_profile,
+    scan_profiles,
+    switch_profile,
+)
 
 
 def _make_profile(base: Path, name: str) -> Path:
@@ -56,3 +66,70 @@ def test_image_profile_invalid_missing_vendor(tmp_path: Path) -> None:
     (d / "system.img").touch()
     p = ImageProfile(name="bad", path=d)
     assert p.is_valid is False
+
+
+# ── get_active_profile ────────────────────────────────────────────────────────
+
+class TestGetActiveProfile:
+    def test_returns_none_when_images_path_empty(self) -> None:
+        with patch("waydroid_toolkit.modules.images.manager.WaydroidConfig.load") as mock_load:
+            mock_load.return_value = MagicMock(images_path="")
+            assert get_active_profile() is None
+
+    def test_returns_path_when_set(self) -> None:
+        with patch("waydroid_toolkit.modules.images.manager.WaydroidConfig.load") as mock_load:
+            mock_load.return_value = MagicMock(images_path="/home/user/waydroid-images/vanilla")
+            assert get_active_profile() == "/home/user/waydroid-images/vanilla"
+
+
+# ── switch_profile ────────────────────────────────────────────────────────────
+
+class TestSwitchProfile:
+    def _valid_profile(self, tmp_path: Path, name: str = "vanilla") -> ImageProfile:
+        d = tmp_path / name
+        d.mkdir()
+        (d / "system.img").touch()
+        (d / "vendor.img").touch()
+        return ImageProfile(name=name, path=d)
+
+    def test_raises_for_invalid_profile(self, tmp_path: Path) -> None:
+        bad = ImageProfile(name="bad", path=tmp_path / "nonexistent")
+        with patch("waydroid_toolkit.modules.images.manager.require_root"):
+            with pytest.raises(ValueError, match="missing"):
+                switch_profile(bad)
+
+    def test_stops_running_session(self, tmp_path: Path) -> None:
+        from waydroid_toolkit.core.waydroid import SessionState
+        profile = self._valid_profile(tmp_path)
+        with patch("waydroid_toolkit.modules.images.manager.require_root"):
+            with patch("waydroid_toolkit.modules.images.manager.get_session_state",
+                       return_value=SessionState.RUNNING):
+                with patch("waydroid_toolkit.modules.images.manager.run_waydroid") as mock_wd:
+                    with patch("waydroid_toolkit.modules.images.manager._set_images_path"):
+                        with patch("waydroid_toolkit.modules.images.manager._link_profile_data"):
+                            with patch("waydroid_toolkit.modules.images.manager.subprocess.run"):
+                                switch_profile(profile)
+        mock_wd.assert_called_once_with("session", "stop", sudo=True)
+
+    def test_does_not_stop_when_not_running(self, tmp_path: Path) -> None:
+        from waydroid_toolkit.core.waydroid import SessionState
+        profile = self._valid_profile(tmp_path)
+        with patch("waydroid_toolkit.modules.images.manager.require_root"):
+            with patch("waydroid_toolkit.modules.images.manager.get_session_state",
+                       return_value=SessionState.STOPPED):
+                with patch("waydroid_toolkit.modules.images.manager.run_waydroid") as mock_wd:
+                    with patch("waydroid_toolkit.modules.images.manager._set_images_path"):
+                        with patch("waydroid_toolkit.modules.images.manager._link_profile_data"):
+                            switch_profile(profile)
+        mock_wd.assert_not_called()
+
+    def test_calls_set_images_path(self, tmp_path: Path) -> None:
+        from waydroid_toolkit.core.waydroid import SessionState
+        profile = self._valid_profile(tmp_path)
+        with patch("waydroid_toolkit.modules.images.manager.require_root"):
+            with patch("waydroid_toolkit.modules.images.manager.get_session_state",
+                       return_value=SessionState.STOPPED):
+                with patch("waydroid_toolkit.modules.images.manager._set_images_path") as mock_set:
+                    with patch("waydroid_toolkit.modules.images.manager._link_profile_data"):
+                        switch_profile(profile)
+        mock_set.assert_called_once_with(profile.path)

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -1,0 +1,148 @@
+"""Tests for the installer module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.installer.installer import (
+    ImageType,
+    init_waydroid,
+    install_package,
+    is_waydroid_installed,
+    setup_repo,
+    uninstall_waydroid,
+)
+from waydroid_toolkit.utils.distro import Distro
+
+# ── is_waydroid_installed ─────────────────────────────────────────────────────
+
+class TestIsWaydroidInstalled:
+    def test_true_when_binary_found(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.shutil.which", return_value="/usr/bin/waydroid"):
+            assert is_waydroid_installed() is True
+
+    def test_false_when_binary_missing(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.shutil.which", return_value=None):
+            assert is_waydroid_installed() is False
+
+
+# ── setup_repo ────────────────────────────────────────────────────────────────
+
+class TestSetupRepo:
+    def test_runs_repo_script_for_ubuntu(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            setup_repo(Distro.UBUNTU)
+        assert mock_run.called
+        cmd = mock_run.call_args[0][0]
+        assert "waydro.id" in cmd
+
+    def test_noop_for_arch(self) -> None:
+        # Arch has no repo setup script
+        with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+            setup_repo(Distro.ARCH)
+        assert not mock_run.called
+
+    def test_progress_called(self) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            setup_repo(Distro.UBUNTU, progress=messages.append)
+        assert len(messages) >= 1
+
+
+# ── install_package ───────────────────────────────────────────────────────────
+
+class TestInstallPackage:
+    @pytest.mark.parametrize("distro,expected_pm", [
+        (Distro.UBUNTU,   "apt"),
+        (Distro.DEBIAN,   "apt"),
+        (Distro.FEDORA,   "dnf"),
+        (Distro.ARCH,     "pacman"),
+        (Distro.OPENSUSE, "zypper"),
+    ])
+    def test_uses_correct_package_manager(self, distro: Distro, expected_pm: str) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                install_package(distro)
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert expected_pm in cmd
+        assert "waydroid" in cmd
+
+    def test_raises_for_unknown_distro(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with pytest.raises(NotImplementedError):
+                install_package(Distro.UNKNOWN)
+
+    def test_progress_called(self) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                install_package(Distro.UBUNTU, progress=messages.append)
+        assert len(messages) >= 1
+
+
+# ── init_waydroid ─────────────────────────────────────────────────────────────
+
+class TestInitWaydroid:
+    def test_calls_waydroid_init(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                init_waydroid()
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "waydroid" in cmd
+        assert "init" in cmd
+
+    def test_passes_vanilla_image_type(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                init_waydroid(image_type=ImageType.VANILLA)
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "VANILLA" in cmd
+
+    def test_passes_gapps_image_type(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                init_waydroid(image_type=ImageType.GAPPS)
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "GAPPS" in cmd
+
+    def test_progress_called(self) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                init_waydroid(progress=messages.append)
+        assert len(messages) >= 1
+
+
+# ── uninstall_waydroid ────────────────────────────────────────────────────────
+
+class TestUninstallWaydroid:
+    @pytest.mark.parametrize("distro,expected_pm", [
+        (Distro.UBUNTU,   "apt"),
+        (Distro.FEDORA,   "dnf"),
+        (Distro.ARCH,     "pacman"),
+    ])
+    def test_removes_package(self, distro: Distro, expected_pm: str) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                uninstall_waydroid(distro)
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any(expected_pm in c for c in cmds)
+
+    def test_stops_session_before_removal(self) -> None:
+        with patch("waydroid_toolkit.modules.installer.installer.require_root"):
+            with patch("waydroid_toolkit.modules.installer.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                uninstall_waydroid(Distro.UBUNTU)
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("session" in c and "stop" in c for c in cmds)

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -1,0 +1,194 @@
+"""Tests for the package manager module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.packages.manager import (
+    add_repo,
+    get_installed_packages,
+    install_apk_file,
+    install_apk_url,
+    list_repos,
+    remove_package,
+    remove_repo,
+    search_repos,
+)
+
+# ── install_apk_file ──────────────────────────────────────────────────────────
+
+class TestInstallApkFile:
+    def test_raises_if_file_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            install_apk_file(tmp_path / "nonexistent.apk")
+
+    def test_calls_install_apk(self, tmp_path: Path) -> None:
+        apk = tmp_path / "app.apk"
+        apk.write_bytes(b"PK")
+        with patch("waydroid_toolkit.modules.packages.manager.install_apk") as mock_install:
+            mock_install.return_value = MagicMock(returncode=0)
+            install_apk_file(apk)
+        mock_install.assert_called_once_with(apk)
+
+    def test_raises_on_nonzero_returncode(self, tmp_path: Path) -> None:
+        apk = tmp_path / "bad.apk"
+        apk.write_bytes(b"PK")
+        with patch("waydroid_toolkit.modules.packages.manager.install_apk") as mock_install:
+            mock_install.return_value = MagicMock(returncode=1, stderr="INSTALL_FAILED")
+            with pytest.raises(RuntimeError, match="INSTALL_FAILED"):
+                install_apk_file(apk)
+
+    def test_calls_progress(self, tmp_path: Path) -> None:
+        apk = tmp_path / "app.apk"
+        apk.write_bytes(b"PK")
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.packages.manager.install_apk") as mock_install:
+            mock_install.return_value = MagicMock(returncode=0)
+            install_apk_file(apk, progress=messages.append)
+        assert any("app.apk" in m for m in messages)
+
+
+# ── install_apk_url ───────────────────────────────────────────────────────────
+
+class TestInstallApkUrl:
+    def test_downloads_then_installs(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager.download") as mock_dl:
+            with patch("waydroid_toolkit.modules.packages.manager.install_apk_file") as mock_inst:
+                mock_dl.side_effect = lambda url, dest: dest.write_bytes(b"PK")
+                install_apk_url("https://example.com/app.apk")
+        mock_dl.assert_called_once()
+        mock_inst.assert_called_once()
+
+
+# ── remove_package ────────────────────────────────────────────────────────────
+
+class TestRemovePackage:
+    def test_calls_uninstall(self) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager.uninstall_package") as mock_un:
+            mock_un.return_value = MagicMock(returncode=0)
+            remove_package("com.example.app")
+        mock_un.assert_called_once_with("com.example.app")
+
+    def test_raises_on_failure(self) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager.uninstall_package") as mock_un:
+            mock_un.return_value = MagicMock(returncode=1, stderr="DELETE_FAILED")
+            with pytest.raises(RuntimeError, match="DELETE_FAILED"):
+                remove_package("com.example.app")
+
+
+# ── get_installed_packages ────────────────────────────────────────────────────
+
+class TestGetInstalledPackages:
+    def test_delegates_to_list_packages(self) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager.list_packages", return_value=["com.a", "com.b"]):
+            result = get_installed_packages()
+        assert result == ["com.a", "com.b"]
+
+
+# ── F-Droid repo management ───────────────────────────────────────────────────
+
+class TestRepoManagement:
+    def test_add_repo_creates_meta(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            with patch("waydroid_toolkit.modules.packages.manager._refresh_repo"):
+                add_repo("myrepo", "https://f-droid.org/repo")
+        meta = json.loads((tmp_path / "myrepo" / "meta.json").read_text())
+        assert meta["name"] == "myrepo"
+        assert meta["url"] == "https://f-droid.org/repo"
+
+    def test_add_repo_calls_refresh(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            with patch("waydroid_toolkit.modules.packages.manager._refresh_repo") as mock_refresh:
+                add_repo("myrepo", "https://f-droid.org/repo")
+        mock_refresh.assert_called_once_with("myrepo", "https://f-droid.org/repo", None)
+
+    def test_remove_repo_deletes_directory(self, tmp_path: Path) -> None:
+        repo_dir = tmp_path / "myrepo"
+        repo_dir.mkdir()
+        (repo_dir / "meta.json").write_text("{}")
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            remove_repo("myrepo")
+        assert not repo_dir.exists()
+
+    def test_remove_repo_noop_if_missing(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            remove_repo("nonexistent")  # should not raise
+
+    def test_list_repos_returns_all(self, tmp_path: Path) -> None:
+        for name, url in [("fdroid", "https://f-droid.org/repo"), ("izzy", "https://apt.izzysoft.de/fdroid/repo")]:
+            d = tmp_path / name
+            d.mkdir()
+            (d / "meta.json").write_text(json.dumps({"name": name, "url": url}))
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            repos = list_repos()
+        names = [r["name"] for r in repos]
+        assert "fdroid" in names
+        assert "izzy" in names
+
+    def test_list_repos_empty_when_no_dir(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path / "nonexistent"):
+            assert list_repos() == []
+
+
+# ── search_repos ──────────────────────────────────────────────────────────────
+
+class TestSearchRepos:
+    def _write_index(self, repo_dir: Path, apps: list[dict]) -> None:
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        (repo_dir / "meta.json").write_text(json.dumps({"name": repo_dir.name, "url": "https://example.com"}))
+        (repo_dir / "index-v1.json").write_text(json.dumps({"apps": apps}))
+
+    def test_finds_by_package_name(self, tmp_path: Path) -> None:
+        self._write_index(tmp_path / "fdroid", [
+            {"packageName": "org.mozilla.firefox", "name": "Firefox"},
+            {"packageName": "com.example.other", "name": "Other"},
+        ])
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            results = search_repos("firefox")
+        assert len(results) == 1
+        assert results[0]["id"] == "org.mozilla.firefox"
+
+    def test_finds_by_display_name(self, tmp_path: Path) -> None:
+        self._write_index(tmp_path / "fdroid", [
+            {"packageName": "org.mozilla.firefox", "name": "Firefox"},
+        ])
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            results = search_repos("Firefox")
+        assert results[0]["name"] == "Firefox"
+
+    def test_returns_empty_for_no_match(self, tmp_path: Path) -> None:
+        self._write_index(tmp_path / "fdroid", [
+            {"packageName": "com.example.app", "name": "Example"},
+        ])
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            results = search_repos("zzznomatch")
+        assert results == []
+
+    def test_skips_missing_index(self, tmp_path: Path) -> None:
+        repo_dir = tmp_path / "broken"
+        repo_dir.mkdir()
+        (repo_dir / "meta.json").write_text("{}")
+        # No index-v1.json
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            results = search_repos("anything")
+        assert results == []
+
+    def test_skips_corrupt_index(self, tmp_path: Path) -> None:
+        repo_dir = tmp_path / "corrupt"
+        repo_dir.mkdir()
+        (repo_dir / "meta.json").write_text("{}")
+        (repo_dir / "index-v1.json").write_text("not-json{{{")
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            results = search_repos("anything")
+        assert results == []
+
+    def test_search_across_multiple_repos(self, tmp_path: Path) -> None:
+        self._write_index(tmp_path / "repo1", [{"packageName": "com.app.one", "name": "AppOne"}])
+        self._write_index(tmp_path / "repo2", [{"packageName": "com.app.two", "name": "AppTwo"}])
+        with patch("waydroid_toolkit.modules.packages.manager._REPOS_DIR", tmp_path):
+            results = search_repos("app")
+        assert len(results) == 2

--- a/tests/unit/test_performance.py
+++ b/tests/unit/test_performance.py
@@ -1,0 +1,129 @@
+"""Tests for the performance tuner module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from waydroid_toolkit.modules.performance.tuner import (
+    PerformanceProfile,
+    apply_profile,
+    install_systemd_service,
+    restore_defaults,
+)
+
+# ── PerformanceProfile defaults ───────────────────────────────────────────────
+
+class TestPerformanceProfile:
+    def test_default_governor_is_performance(self) -> None:
+        assert PerformanceProfile().cpu_governor == "performance"
+
+    def test_default_zram_size(self) -> None:
+        assert PerformanceProfile().zram_size_mb == 4096
+
+    def test_default_algorithm_is_lz4(self) -> None:
+        assert PerformanceProfile().zram_algorithm == "lz4"
+
+    def test_turbo_enabled_by_default(self) -> None:
+        assert PerformanceProfile().enable_turbo is True
+
+    def test_gamemode_enabled_by_default(self) -> None:
+        assert PerformanceProfile().use_gamemode is True
+
+
+# ── apply_profile ─────────────────────────────────────────────────────────────
+
+class TestApplyProfile:
+    def _mock_run(self, returncode: int = 0, stdout: str = "/dev/zram0") -> MagicMock:
+        return MagicMock(returncode=returncode, stdout=stdout)
+
+    def test_calls_zramctl(self) -> None:
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = self._mock_run()
+                apply_profile(PerformanceProfile(use_gamemode=False))
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("zramctl" in c for c in cmds)
+
+    def test_calls_cpu_governor(self, tmp_path: Path) -> None:
+        policy = tmp_path / "policy0"
+        policy.mkdir()
+        (policy / "scaling_governor").write_text("schedutil")
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = self._mock_run()
+                with patch(
+                    "waydroid_toolkit.modules.performance.tuner.Path",
+                    side_effect=lambda p: Path(str(p).replace(
+                        "/sys/devices/system/cpu/cpufreq", str(tmp_path)
+                    )),
+                ):
+                    apply_profile(PerformanceProfile(use_gamemode=False))
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("tee" in c for c in cmds)
+
+    def test_gamemode_started_when_available(self) -> None:
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = self._mock_run()
+                with patch("waydroid_toolkit.modules.performance.tuner.shutil.which", return_value="/usr/bin/gamemoded"):
+                    apply_profile(PerformanceProfile(use_gamemode=True))
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("gamemoded" in c for c in cmds)
+
+    def test_gamemode_skipped_when_not_installed(self) -> None:
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = self._mock_run()
+                with patch("waydroid_toolkit.modules.performance.tuner.shutil.which", return_value=None):
+                    apply_profile(PerformanceProfile(use_gamemode=True))
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert not any("gamemoded" in c for c in cmds)
+
+    def test_progress_called(self) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = self._mock_run()
+                with patch("waydroid_toolkit.modules.performance.tuner.shutil.which", return_value=None):
+                    apply_profile(PerformanceProfile(use_gamemode=False), progress=messages.append)
+        assert len(messages) >= 2
+
+
+# ── restore_defaults ──────────────────────────────────────────────────────────
+
+class TestRestoreDefaults:
+    def test_sets_schedutil_governor(self) -> None:
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner._set_cpu_governor") as mock_gov:
+                restore_defaults()
+        mock_gov.assert_called_once_with("schedutil")
+
+    def test_progress_called(self) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                restore_defaults(progress=messages.append)
+        assert len(messages) >= 1
+
+
+# ── install_systemd_service ───────────────────────────────────────────────────
+
+class TestInstallSystemdService:
+    def test_writes_service_file_and_enables(self) -> None:
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                install_systemd_service()
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("daemon-reload" in c for c in cmds)
+        assert any("enable" in c for c in cmds)
+
+    def test_progress_called(self) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.performance.tuner.require_root"):
+            with patch("waydroid_toolkit.modules.performance.tuner.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                install_systemd_service(progress=messages.append)
+        assert len(messages) >= 1

--- a/tests/unit/test_waydroid_core.py
+++ b/tests/unit/test_waydroid_core.py
@@ -1,5 +1,8 @@
 """Tests for the Waydroid core interface."""
 
+from __future__ import annotations
+
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,8 +10,12 @@ import pytest
 from waydroid_toolkit.core.waydroid import (
     SessionState,
     WaydroidConfig,
+    get_android_id,
     get_session_state,
+    is_initialized,
     is_installed,
+    run_waydroid,
+    shell,
 )
 
 
@@ -49,3 +56,103 @@ def test_waydroid_config_load_missing(tmp_path) -> None:
     with patch("waydroid_toolkit.core.waydroid._CFG_PATH", tmp_path / "nonexistent.cfg"):
         cfg = WaydroidConfig.load()
     assert cfg.images_path == ""
+
+
+def test_waydroid_config_load_parses_values(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "waydroid.cfg"
+    cfg_file.write_text(
+        "[waydroid]\nimages_path = /home/user/images\nmount_overlays = false\n"
+    )
+    with patch("waydroid_toolkit.core.waydroid._CFG_PATH", cfg_file):
+        cfg = WaydroidConfig.load()
+    assert cfg.images_path == "/home/user/images"
+    assert cfg.mount_overlays is False
+
+
+def test_waydroid_config_mount_overlays_default_true(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "waydroid.cfg"
+    cfg_file.write_text("[waydroid]\n")
+    with patch("waydroid_toolkit.core.waydroid._CFG_PATH", cfg_file):
+        cfg = WaydroidConfig.load()
+    assert cfg.mount_overlays is True
+
+
+# ── run_waydroid ──────────────────────────────────────────────────────────────
+
+def test_run_waydroid_without_sudo() -> None:
+    with patch("waydroid_toolkit.core.waydroid.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        run_waydroid("status")
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "waydroid"
+    assert "sudo" not in cmd
+
+
+def test_run_waydroid_with_sudo() -> None:
+    with patch("waydroid_toolkit.core.waydroid.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        run_waydroid("session", "stop", sudo=True)
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "sudo"
+    assert "waydroid" in cmd
+
+
+# ── is_initialized ────────────────────────────────────────────────────────────
+
+def test_is_initialized_false_when_no_images_path() -> None:
+    with patch("waydroid_toolkit.core.waydroid.WaydroidConfig.load") as mock_load:
+        mock_load.return_value = WaydroidConfig(images_path="")
+        assert is_initialized() is False
+
+
+def test_is_initialized_false_when_images_missing(tmp_path: Path) -> None:
+    with patch("waydroid_toolkit.core.waydroid.WaydroidConfig.load") as mock_load:
+        mock_load.return_value = WaydroidConfig(images_path=str(tmp_path))
+        assert is_initialized() is False
+
+
+def test_is_initialized_true_when_images_present(tmp_path: Path) -> None:
+    (tmp_path / "system.img").touch()
+    (tmp_path / "vendor.img").touch()
+    with patch("waydroid_toolkit.core.waydroid.WaydroidConfig.load") as mock_load:
+        mock_load.return_value = WaydroidConfig(images_path=str(tmp_path))
+        assert is_initialized() is True
+
+
+# ── shell ─────────────────────────────────────────────────────────────────────
+
+def test_shell_routes_through_backend() -> None:
+    mock_backend = MagicMock()
+    mock_backend.execute.return_value = MagicMock(returncode=0, stdout="result")
+    # shell() lazily imports get_active from waydroid_toolkit.core.container;
+    # patch the re-export in __init__ so the lazy import resolves to the mock.
+    with patch("waydroid_toolkit.core.container.get_active", return_value=mock_backend):
+        shell("getprop ro.build.version.release")
+    mock_backend.execute.assert_called_once()
+
+
+def test_shell_falls_back_to_waydroid_cli() -> None:
+    with patch("waydroid_toolkit.core.container.get_active",
+               side_effect=RuntimeError("no backend")):
+        with patch("waydroid_toolkit.core.waydroid.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            shell("getprop ro.build.version.release")
+    cmd = " ".join(mock_run.call_args[0][0])
+    assert "waydroid" in cmd
+    assert "shell" in cmd
+
+
+# ── get_android_id ────────────────────────────────────────────────────────────
+
+def test_get_android_id_returns_id_on_success() -> None:
+    with patch("waydroid_toolkit.core.waydroid.shell") as mock_shell:
+        mock_shell.return_value = MagicMock(returncode=0, stdout="android_id|1234567890abcdef\n")
+        result = get_android_id()
+    assert result == "1234567890abcdef"
+
+
+def test_get_android_id_returns_none_on_failure() -> None:
+    with patch("waydroid_toolkit.core.waydroid.shell") as mock_shell:
+        mock_shell.return_value = MagicMock(returncode=1, stdout="")
+        result = get_android_id()
+    assert result is None


### PR DESCRIPTION
## PipeWire audio backend

Waydroid previously only supported PulseAudio for audio passthrough. This adds proper PipeWire native socket support alongside it.

**How it works:**
- New `AudioBackend` enum: `PULSEAUDIO`, `PIPEWIRE`, `AUTO`
- `detect_audio_backend()` checks for `$XDG_RUNTIME_DIR/pipewire-0` on the host. If present → PIPEWIRE, else → PULSEAUDIO. The PulseAudio compatibility socket (`pulse/native`) is intentionally not used as the detection signal — its presence only means `pipewire-pulse` is running, not that the native socket is available.
- `SessionConfig` gains `pipewire_host/container_socket` fields and a `detect()` classmethod that auto-populates everything from the running host environment
- `_session_device_specs()` mounts either the PipeWire or PulseAudio socket, never both
- Explicit override: pass `audio=AudioBackend.PULSEAUDIO` or `PIPEWIRE` to `SessionConfig.detect()` to bypass auto-detection

## Test coverage

105 → 222 tests, 13% → 51% line coverage. New test files and additions:

| File | New tests | Coverage |
|------|-----------|----------|
| `test_packages.py` | 20 | 90% |
| `test_installer.py` | 20 | ~85% |
| `test_performance.py` | 14 | 93% |
| `test_backup.py` | +11 | deeper error paths |
| `test_extensions.py` | +25 | is_installed, install errors, conflicts |
| `test_images.py` | +9 | switch_profile, get_active_profile |
| `test_waydroid_core.py` | +16 | shell routing, config parsing, android_id |
| `test_cli.py` | +18 | backup/packages/backend subcommands |
| `test_container_backend.py` | +19 | AudioBackend, SessionConfig.detect, PipeWire session |