### PR TITLE
Harden ADB, add GUI presenters, expand coverage to 322 tests (57%)

### DIFF
--- a/src/waydroid_toolkit/core/adb.py
+++ b/src/waydroid_toolkit/core/adb.py
@@ -35,8 +35,18 @@ def is_available() -> bool:
 
 
 def connect(retries: int = 3, delay: float = 1.5) -> bool:
-    """Connect to the Waydroid ADB endpoint. Returns True on success."""
+    """Connect to the Waydroid ADB endpoint. Returns True on success.
+
+    Checks that Waydroid is running before each attempt so retries are
+    not wasted when the container is stopped.
+    """
+    # Lazy import avoids a circular dependency at module load time.
+    from waydroid_toolkit.core.waydroid import SessionState, get_session_state
+
     for _ in range(retries):
+        if get_session_state() != SessionState.RUNNING:
+            time.sleep(delay)
+            continue
         result = subprocess.run(
             ["adb", "connect", _ADB_TARGET],
             capture_output=True,

--- a/src/waydroid_toolkit/gui/pages/backup.py
+++ b/src/waydroid_toolkit/gui/pages/backup.py
@@ -10,10 +10,10 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, GLib, Gtk
 
+from waydroid_toolkit.gui.presenters import get_backup_entries
 from waydroid_toolkit.modules.backup import (
     DEFAULT_BACKUP_DIR,
     create_backup,
-    list_backups,
     restore_backup,
 )
 
@@ -69,7 +69,7 @@ class BackupPage(BasePage):
 
     def _load_backups(self) -> None:
         def _work() -> None:
-            archives = list_backups()
+            entries = get_backup_entries()
 
             def _update() -> None:
                 child = self._backups_list.get_first_child()
@@ -77,13 +77,12 @@ class BackupPage(BasePage):
                     nxt = child.get_next_sibling()
                     self._backups_list.remove(child)
                     child = nxt
-                for a in archives:
-                    size_mb = a.stat().st_size / (1024 * 1024)
+                for entry in entries:
                     row = Adw.ActionRow(
-                        title=a.name,
-                        subtitle=f"{size_mb:.1f} MB",
+                        title=entry.name,
+                        subtitle=f"{entry.size_mb:.1f} MB",
                     )
-                    row.set_name(str(a))
+                    row.set_name(str(entry.path))
                     self._backups_list.append(row)
 
             GLib.idle_add(_update)

--- a/src/waydroid_toolkit/gui/pages/extensions.py
+++ b/src/waydroid_toolkit/gui/pages/extensions.py
@@ -10,6 +10,7 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, GLib, Gtk
 
+from waydroid_toolkit.gui.presenters import get_extension_rows
 from waydroid_toolkit.modules.extensions import ExtensionState, list_all
 
 from .base import BasePage
@@ -45,7 +46,8 @@ class ExtensionsPage(BasePage):
 
     def _refresh_states(self) -> None:
         def _work() -> None:
-            states = {ext.meta.id: ext.state() for ext in list_all()}
+            rows = get_extension_rows()
+            states = {r.ext_id: r.state for r in rows}
 
             def _update() -> None:
                 for ext_id, (row, install_btn, remove_btn) in self._rows.items():

--- a/src/waydroid_toolkit/gui/pages/images.py
+++ b/src/waydroid_toolkit/gui/pages/images.py
@@ -10,7 +10,8 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, GLib, Gtk
 
-from waydroid_toolkit.modules.images import get_active_profile, scan_profiles, switch_profile
+from waydroid_toolkit.gui.presenters import get_image_profile_rows
+from waydroid_toolkit.modules.images import switch_profile
 
 from .base import BasePage
 
@@ -37,8 +38,7 @@ class ImagesPage(BasePage):
         self._status_label.set_label("Scanning…")
 
         def _work() -> None:
-            profiles = scan_profiles()
-            active = get_active_profile()
+            profile_rows = get_image_profile_rows()
 
             def _update() -> None:
                 # Clear existing rows
@@ -48,23 +48,24 @@ class ImagesPage(BasePage):
                     self._group.remove(child)
                     child = nxt
 
-                if not profiles:
+                if not profile_rows:
                     self._status_label.set_label(
                         "No profiles found. Place system.img + vendor.img pairs"
                         " under ~/waydroid-images/."
                     )
                     return
 
-                self._status_label.set_label(f"{len(profiles)} profile(s) found.")
-                for p in profiles:
-                    is_active = active and str(p.path) in active
-                    active_tag = " (active)" if is_active else ""
-                    subtitle = str(p.path) + active_tag
-                    row = Adw.ActionRow(title=p.name, subtitle=subtitle)
-                    if not is_active:
+                self._status_label.set_label(f"{len(profile_rows)} profile(s) found.")
+                for pr in profile_rows:
+                    active_tag = " (active)" if pr.is_active else ""
+                    subtitle = str(pr.path) + active_tag
+                    row = Adw.ActionRow(title=pr.name, subtitle=subtitle)
+                    if not pr.is_active:
+                        from waydroid_toolkit.modules.images.manager import ImageProfile
+                        profile = ImageProfile(name=pr.name, path=pr.path)
                         btn = Gtk.Button(label="Switch", css_classes=["suggested-action"],
                                          valign=Gtk.Align.CENTER)
-                        btn.connect("clicked", self._on_switch, p)
+                        btn.connect("clicked", self._on_switch, profile)
                         row.add_suffix(btn)
                     self._group.add(row)
 

--- a/src/waydroid_toolkit/gui/pages/status.py
+++ b/src/waydroid_toolkit/gui/pages/status.py
@@ -10,15 +10,7 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, GLib
 
-from waydroid_toolkit.core.adb import is_available as adb_available
-from waydroid_toolkit.core.adb import is_connected as adb_connected
-from waydroid_toolkit.core.waydroid import (
-    SessionState,
-    WaydroidConfig,
-    get_session_state,
-    is_initialized,
-    is_installed,
-)
+from waydroid_toolkit.gui.presenters import get_status_data
 
 from .base import BasePage
 
@@ -54,21 +46,16 @@ class StatusPage(BasePage):
 
     def _refresh(self) -> None:
         def _work() -> None:
-            installed = is_installed()
-            initialized = is_initialized() if installed else False
-            state = get_session_state() if installed else SessionState.UNKNOWN
-            cfg = WaydroidConfig.load()
-            adb_ok = adb_available()
-            adb_conn = adb_connected() if adb_ok else False
+            data = get_status_data()
 
             def _update() -> None:
-                self._row_installed.set_subtitle("Yes" if installed else "No")
-                self._row_initialized.set_subtitle("Yes" if initialized else "No")
-                self._row_session.set_subtitle(state.value.capitalize())
-                self._row_images.set_subtitle(cfg.images_path or "(not set)")
-                self._row_overlay.set_subtitle("Yes" if cfg.mount_overlays else "No")
-                self._row_adb.set_subtitle("Yes" if adb_ok else "No")
-                self._row_adb_conn.set_subtitle("Yes" if adb_conn else "No")
+                self._row_installed.set_subtitle("Yes" if data.installed else "No")
+                self._row_initialized.set_subtitle("Yes" if data.initialized else "No")
+                self._row_session.set_subtitle(data.session_state.value.capitalize())
+                self._row_images.set_subtitle(data.images_path or "(not set)")
+                self._row_overlay.set_subtitle("Yes" if data.mount_overlays else "No")
+                self._row_adb.set_subtitle("Yes" if data.adb_available else "No")
+                self._row_adb_conn.set_subtitle("Yes" if data.adb_connected else "No")
 
             GLib.idle_add(_update)
 

--- a/src/waydroid_toolkit/gui/presenters.py
+++ b/src/waydroid_toolkit/gui/presenters.py
@@ -1,0 +1,140 @@
+"""GUI presenter functions — pure data-gathering logic extracted from page classes.
+
+Each function collects the data a page needs to display and returns it as a
+plain dataclass or dict. This keeps the GTK widget code thin and makes the
+business logic testable without a display server.
+
+Pages call these functions from their background threads, then apply the
+returned data to widgets via GLib.idle_add.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from waydroid_toolkit.core.adb import is_available as adb_available
+from waydroid_toolkit.core.adb import is_connected as adb_connected
+from waydroid_toolkit.core.waydroid import (
+    SessionState,
+    WaydroidConfig,
+    get_session_state,
+    is_initialized,
+    is_installed,
+)
+from waydroid_toolkit.modules.backup.backup import list_backups
+from waydroid_toolkit.modules.extensions import ExtensionState
+from waydroid_toolkit.modules.extensions import list_all as list_extensions
+from waydroid_toolkit.modules.images.manager import (
+    get_active_profile,
+    scan_profiles,
+)
+from waydroid_toolkit.modules.maintenance.tools import get_device_info
+
+# ── Status page ───────────────────────────────────────────────────────────────
+
+@dataclass
+class StatusData:
+    installed: bool
+    initialized: bool
+    session_state: SessionState
+    images_path: str
+    mount_overlays: bool
+    adb_available: bool
+    adb_connected: bool
+
+
+def get_status_data() -> StatusData:
+    """Collect all data needed by the Status page."""
+    installed = is_installed()
+    initialized = is_initialized() if installed else False
+    state = get_session_state() if installed else SessionState.UNKNOWN
+    cfg = WaydroidConfig.load()
+    adb_ok = adb_available()
+    adb_conn = adb_connected() if adb_ok else False
+    return StatusData(
+        installed=installed,
+        initialized=initialized,
+        session_state=state,
+        images_path=cfg.images_path,
+        mount_overlays=cfg.mount_overlays,
+        adb_available=adb_ok,
+        adb_connected=adb_conn,
+    )
+
+
+# ── Backup page ───────────────────────────────────────────────────────────────
+
+@dataclass
+class BackupEntry:
+    name: str
+    path: Path
+    size_mb: float
+
+
+def get_backup_entries(backup_dir: Path | None = None) -> list[BackupEntry]:
+    """Return available backup archives as display-ready entries."""
+    archives = list_backups(backup_dir) if backup_dir else list_backups()
+    return [
+        BackupEntry(
+            name=a.name,
+            path=a,
+            size_mb=a.stat().st_size / (1024 * 1024),
+        )
+        for a in archives
+    ]
+
+
+# ── Extensions page ───────────────────────────────────────────────────────────
+
+@dataclass
+class ExtensionRow:
+    ext_id: str
+    name: str
+    description: str
+    state: ExtensionState
+    conflicts: list[str] = field(default_factory=list)
+
+
+def get_extension_rows() -> list[ExtensionRow]:
+    """Return all extensions with their current install state."""
+    return [
+        ExtensionRow(
+            ext_id=ext.meta.id,
+            name=ext.meta.name,
+            description=ext.meta.description,
+            state=ext.state(),
+            conflicts=ext.meta.conflicts,
+        )
+        for ext in list_extensions()
+    ]
+
+
+# ── Images page ───────────────────────────────────────────────────────────────
+
+@dataclass
+class ImageProfileRow:
+    name: str
+    path: Path
+    is_active: bool
+
+
+def get_image_profile_rows() -> list[ImageProfileRow]:
+    """Return all discovered image profiles, marking the active one."""
+    profiles = scan_profiles()
+    active = get_active_profile()
+    return [
+        ImageProfileRow(
+            name=p.name,
+            path=p.path,
+            is_active=bool(active and str(p.path) in active),
+        )
+        for p in profiles
+    ]
+
+
+# ── Maintenance page ──────────────────────────────────────────────────────────
+
+def get_device_info_data() -> dict[str, str]:
+    """Return Android device properties for the Maintenance page."""
+    return get_device_info()

--- a/tests/unit/test_adb.py
+++ b/tests/unit/test_adb.py
@@ -1,0 +1,293 @@
+"""Tests for the ADB interface module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from waydroid_toolkit.core.adb import (
+    connect,
+    disconnect,
+    install_apk,
+    is_available,
+    is_connected,
+    list_packages,
+    logcat,
+    pull,
+    push,
+    screenshot,
+    shell,
+    uninstall_package,
+)
+
+_TARGET = "192.168.250.1:5555"
+
+
+# ── is_available ──────────────────────────────────────────────────────────────
+
+class TestIsAvailable:
+    def test_true_when_adb_found(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert is_available() is True
+
+    def test_false_when_adb_missing(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run", side_effect=FileNotFoundError):
+            assert is_available() is False
+
+
+# ── connect ───────────────────────────────────────────────────────────────────
+
+class TestConnect:
+    """connect() checks session state before each attempt."""
+
+    def _running(self):
+        from waydroid_toolkit.core.waydroid import SessionState
+        return SessionState.RUNNING
+
+    def _stopped(self):
+        from waydroid_toolkit.core.waydroid import SessionState
+        return SessionState.STOPPED
+
+    # get_session_state is imported lazily inside connect(); patch at source.
+    _GSS = "waydroid_toolkit.core.waydroid.get_session_state"
+
+    def test_returns_true_on_connected_output(self) -> None:
+        with patch(self._GSS, return_value=self._running()):
+            with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+                with patch("waydroid_toolkit.core.adb.time.sleep"):
+                    mock_run.return_value = MagicMock(returncode=0, stdout="connected to 192.168.250.1:5555")
+                    assert connect(retries=1) is True
+
+    def test_returns_false_after_all_retries_fail(self) -> None:
+        with patch(self._GSS, return_value=self._running()):
+            with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+                with patch("waydroid_toolkit.core.adb.time.sleep"):
+                    mock_run.return_value = MagicMock(returncode=1, stdout="failed")
+                    assert connect(retries=3, delay=0) is False
+            assert mock_run.call_count == 3
+
+    def test_skips_adb_when_session_not_running(self) -> None:
+        with patch(self._GSS, return_value=self._stopped()):
+            with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+                with patch("waydroid_toolkit.core.adb.time.sleep"):
+                    result = connect(retries=2, delay=0)
+        assert result is False
+        # adb connect should never be called when session is stopped
+        assert not any("connect" in " ".join(c[0][0]) for c in mock_run.call_args_list)
+
+    def test_succeeds_on_second_retry(self) -> None:
+        responses = [
+            MagicMock(returncode=1, stdout="failed"),
+            MagicMock(returncode=0, stdout="connected to 192.168.250.1:5555"),
+        ]
+        with patch(self._GSS, return_value=self._running()):
+            with patch("waydroid_toolkit.core.adb.subprocess.run", side_effect=responses):
+                with patch("waydroid_toolkit.core.adb.time.sleep"):
+                    assert connect(retries=3, delay=0) is True
+
+    def test_already_connected_output_counts_as_success(self) -> None:
+        with patch(self._GSS, return_value=self._running()):
+            with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+                with patch("waydroid_toolkit.core.adb.time.sleep"):
+                    mock_run.return_value = MagicMock(returncode=0, stdout="already connected to 192.168.250.1:5555")
+                    assert connect(retries=1) is True
+
+    def test_sleeps_between_retries(self) -> None:
+        with patch(self._GSS, return_value=self._running()):
+            with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+                with patch("waydroid_toolkit.core.adb.time.sleep") as mock_sleep:
+                    mock_run.return_value = MagicMock(returncode=1, stdout="failed")
+                    connect(retries=2, delay=1.5)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(1.5)
+
+
+# ── disconnect ────────────────────────────────────────────────────────────────
+
+class TestDisconnect:
+    def test_calls_adb_disconnect(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            disconnect()
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "disconnect" in cmd
+        assert _TARGET in cmd
+
+
+# ── is_connected ──────────────────────────────────────────────────────────────
+
+class TestIsConnected:
+    def test_true_when_target_in_devices(self) -> None:
+        output = f"List of devices attached\n{_TARGET}\tdevice\n"
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=output)
+            assert is_connected() is True
+
+    def test_false_when_target_absent(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="List of devices attached\n")
+            assert is_connected() is False
+
+
+# ── shell ─────────────────────────────────────────────────────────────────────
+
+class TestShell:
+    def test_passes_command_to_adb_shell(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="12")
+            shell("getprop ro.build.version.sdk")
+        cmd = mock_run.call_args[0][0]
+        assert "shell" in cmd
+        assert "getprop" in " ".join(cmd)
+
+    def test_uses_waydroid_target(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            shell("true")
+        cmd = mock_run.call_args[0][0]
+        assert _TARGET in cmd
+
+
+# ── install_apk ───────────────────────────────────────────────────────────────
+
+class TestInstallApk:
+    def test_calls_adb_install(self, tmp_path: Path) -> None:
+        apk = tmp_path / "app.apk"
+        apk.write_bytes(b"PK")
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="Success")
+            install_apk(apk)
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "install" in cmd
+        assert str(apk) in cmd
+
+    def test_passes_replace_flag(self, tmp_path: Path) -> None:
+        apk = tmp_path / "app.apk"
+        apk.write_bytes(b"PK")
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="Success")
+            install_apk(apk)
+        cmd = mock_run.call_args[0][0]
+        assert "-r" in cmd
+
+
+# ── uninstall_package ─────────────────────────────────────────────────────────
+
+class TestUninstallPackage:
+    def test_calls_adb_uninstall(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="Success")
+            uninstall_package("com.example.app")
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "uninstall" in cmd
+        assert "com.example.app" in cmd
+
+
+# ── list_packages ─────────────────────────────────────────────────────────────
+
+class TestListPackages:
+    def test_parses_package_lines(self) -> None:
+        output = "package:com.example.one\npackage:com.example.two\n"
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=output)
+            result = list_packages()
+        assert result == ["com.example.one", "com.example.two"]
+
+    def test_ignores_non_package_lines(self) -> None:
+        output = "package:com.example.app\nWarning: some warning\n"
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=output)
+            result = list_packages()
+        assert result == ["com.example.app"]
+
+    def test_returns_empty_on_no_output(self) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = list_packages()
+        assert result == []
+
+
+# ── push / pull ───────────────────────────────────────────────────────────────
+
+class TestPushPull:
+    def test_push_includes_source_and_dest(self, tmp_path: Path) -> None:
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            push(src, "/sdcard/file.txt")
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "push" in cmd
+        assert str(src) in cmd
+        assert "/sdcard/file.txt" in cmd
+
+    def test_pull_includes_source_and_dest(self, tmp_path: Path) -> None:
+        dest = tmp_path / "out.txt"
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            pull("/sdcard/file.txt", dest)
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "pull" in cmd
+        assert "/sdcard/file.txt" in cmd
+        assert str(dest) in cmd
+
+
+# ── screenshot ────────────────────────────────────────────────────────────────
+
+class TestScreenshot:
+    def test_returns_dest_path(self, tmp_path: Path) -> None:
+        dest = tmp_path / "shot.png"
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            # Patch open so we don't actually write
+            with patch("builtins.open", MagicMock()):
+                result = screenshot(dest)
+        assert result == dest
+
+    def test_uses_default_path_when_dest_none(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.core.adb.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with patch("waydroid_toolkit.core.adb.Path.home", return_value=tmp_path):
+                with patch("builtins.open", MagicMock()):
+                    result = screenshot(None)
+        assert result.suffix == ".png"
+        assert "screenshot_" in result.name
+
+
+# ── logcat ────────────────────────────────────────────────────────────────────
+
+class TestLogcat:
+    def test_returns_popen_handle(self) -> None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        with patch("waydroid_toolkit.core.adb.subprocess.Popen", return_value=mock_proc):
+            result = logcat()
+        assert result is mock_proc
+
+    def test_errors_only_flag(self) -> None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        with patch("waydroid_toolkit.core.adb.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = mock_proc
+            logcat(errors_only=True)
+        cmd = " ".join(mock_popen.call_args[0][0])
+        assert "*:E" in cmd
+
+    def test_tag_filter(self) -> None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        with patch("waydroid_toolkit.core.adb.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = mock_proc
+            logcat(tag="ActivityManager")
+        cmd = " ".join(mock_popen.call_args[0][0])
+        assert "ActivityManager:V" in cmd
+        assert "*:S" in cmd
+
+    def test_no_filter_by_default(self) -> None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        with patch("waydroid_toolkit.core.adb.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = mock_proc
+            logcat()
+        cmd = mock_popen.call_args[0][0]
+        # No extra filter args beyond the base command
+        assert "*:E" not in " ".join(cmd)
+        assert "*:S" not in " ".join(cmd)

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -1,0 +1,276 @@
+"""Tests for the maintenance tools module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.maintenance.tools import (
+    DEFAULT_BLOAT,
+    clear_app_data,
+    debloat,
+    freeze_app,
+    get_device_info,
+    launch_app,
+    pull_file,
+    push_file,
+    record_screen,
+    reset_display,
+    set_density,
+    set_resolution,
+    stream_logcat,
+    take_screenshot,
+    unfreeze_app,
+)
+
+# ── Display settings ──────────────────────────────────────────────────────────
+
+class TestDisplaySettings:
+    def test_set_resolution_calls_waydroid_prop(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.run_waydroid") as mock_wd:
+            set_resolution(1920, 1080)
+        calls = [" ".join(c[0]) for c in mock_wd.call_args_list]
+        assert any("1920" in c for c in calls)
+        assert any("1080" in c for c in calls)
+
+    def test_set_resolution_sets_both_dimensions(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.run_waydroid") as mock_wd:
+            set_resolution(2560, 1440)
+        assert mock_wd.call_count == 2
+
+    def test_set_density_calls_waydroid_prop(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.run_waydroid") as mock_wd:
+            set_density(240)
+        calls = [" ".join(c[0]) for c in mock_wd.call_args_list]
+        assert any("240" in c for c in calls)
+
+    def test_reset_display_clears_all_three_props(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.run_waydroid") as mock_wd:
+            reset_display()
+        assert mock_wd.call_count == 3
+        all_args = " ".join(" ".join(c[0]) for c in mock_wd.call_args_list)
+        assert "width" in all_args
+        assert "height" in all_args
+        assert "density" in all_args
+
+
+# ── Device info ───────────────────────────────────────────────────────────────
+
+class TestGetDeviceInfo:
+    def test_returns_dict_with_expected_keys(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0, stdout="value\n")
+            info = get_device_info()
+        assert "android_version" in info
+        assert "sdk_version" in info
+        assert "product_model" in info
+        assert "cpu_abi" in info
+
+    def test_unavailable_on_adb_failure(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=1, stdout="")
+            info = get_device_info()
+        assert all(v == "unavailable" for v in info.values())
+
+    def test_strips_whitespace_from_values(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0, stdout="  13  \n")
+            info = get_device_info()
+        assert all(v == "13" for v in info.values())
+
+
+# ── Screenshot / screen record ────────────────────────────────────────────────
+
+class TestScreenshot:
+    def test_delegates_to_adb_screenshot(self, tmp_path: Path) -> None:
+        dest = tmp_path / "shot.png"
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.screenshot",
+                   return_value=dest) as mock_ss:
+            result = take_screenshot(dest)
+        mock_ss.assert_called_once_with(dest)
+        assert result == dest
+
+
+class TestRecordScreen:
+    def test_returns_dest_path(self, tmp_path: Path) -> None:
+        dest = tmp_path / "rec.mp4"
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0)
+            with patch("waydroid_toolkit.modules.maintenance.tools.adb.pull") as mock_pull:
+                mock_pull.return_value = MagicMock(returncode=0)
+                result = record_screen(dest=dest, duration_seconds=5)
+        assert result == dest
+
+    def test_uses_default_path_when_none(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0)
+            with patch("waydroid_toolkit.modules.maintenance.tools.adb.pull") as mock_pull:
+                mock_pull.return_value = MagicMock(returncode=0)
+                with patch("waydroid_toolkit.modules.maintenance.tools.Path.home",
+                           return_value=tmp_path):
+                    result = record_screen(duration_seconds=5)
+        assert result.suffix == ".mp4"
+        assert "recording_" in result.name
+
+
+# ── File transfer ─────────────────────────────────────────────────────────────
+
+class TestFileTransfer:
+    def test_push_file_succeeds(self, tmp_path: Path) -> None:
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.push") as mock_push:
+            mock_push.return_value = MagicMock(returncode=0)
+            push_file(src, "/sdcard/file.txt")
+        mock_push.assert_called_once_with(src, "/sdcard/file.txt")
+
+    def test_push_file_raises_on_failure(self, tmp_path: Path) -> None:
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.push") as mock_push:
+            mock_push.return_value = MagicMock(returncode=1, stderr="error")
+            with pytest.raises(RuntimeError, match="Push failed"):
+                push_file(src, "/sdcard/file.txt")
+
+    def test_pull_file_succeeds(self, tmp_path: Path) -> None:
+        dest = tmp_path / "out.txt"
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.pull") as mock_pull:
+            mock_pull.return_value = MagicMock(returncode=0)
+            pull_file("/sdcard/file.txt", dest)
+        mock_pull.assert_called_once_with("/sdcard/file.txt", dest)
+
+    def test_pull_file_raises_on_failure(self, tmp_path: Path) -> None:
+        dest = tmp_path / "out.txt"
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.pull") as mock_pull:
+            mock_pull.return_value = MagicMock(returncode=1, stderr="error")
+            with pytest.raises(RuntimeError, match="Pull failed"):
+                pull_file("/sdcard/file.txt", dest)
+
+
+# ── Logcat streaming ──────────────────────────────────────────────────────────
+
+class TestStreamLogcat:
+    def test_yields_lines_from_proc(self) -> None:
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(["line one\n", "line two\n"])
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.logcat",
+                   return_value=mock_proc):
+            lines = list(stream_logcat())
+        assert lines == ["line one", "line two"]
+        mock_proc.terminate.assert_called_once()
+
+    def test_terminates_proc_on_exception(self) -> None:
+        mock_proc = MagicMock()
+
+        def _bad_iter():
+            yield "line\n"
+            raise RuntimeError("stream error")
+
+        mock_proc.stdout = _bad_iter()
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.logcat",
+                   return_value=mock_proc):
+            with pytest.raises(RuntimeError):
+                list(stream_logcat())
+        mock_proc.terminate.assert_called_once()
+
+    def test_passes_tag_and_errors_only(self) -> None:
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter([])
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.logcat",
+                   return_value=mock_proc) as mock_logcat:
+            list(stream_logcat(tag="MyTag", errors_only=True))
+        mock_logcat.assert_called_once_with(tag="MyTag", errors_only=True)
+
+
+# ── App management ────────────────────────────────────────────────────────────
+
+class TestAppManagement:
+    def test_freeze_app_calls_pm_disable(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0, stdout="")
+            freeze_app("com.example.app")
+        cmd = mock_shell.call_args[0][0]
+        assert "disable" in cmd
+        assert "com.example.app" in cmd
+
+    def test_freeze_app_raises_on_failure(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=1, stderr="error")
+            with pytest.raises(RuntimeError, match="freeze"):
+                freeze_app("com.example.app")
+
+    def test_unfreeze_app_calls_pm_enable(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0, stdout="")
+            unfreeze_app("com.example.app")
+        cmd = mock_shell.call_args[0][0]
+        assert "enable" in cmd
+        assert "com.example.app" in cmd
+
+    def test_unfreeze_app_raises_on_failure(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=1, stderr="error")
+            with pytest.raises(RuntimeError, match="unfreeze"):
+                unfreeze_app("com.example.app")
+
+    def test_clear_app_data_calls_pm_clear(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0)
+            clear_app_data("com.example.app")
+        cmd = mock_shell.call_args[0][0]
+        assert "clear" in cmd
+        assert "com.example.app" in cmd
+
+    def test_clear_app_data_cache_only(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0)
+            clear_app_data("com.example.app", cache_only=True)
+        cmd = mock_shell.call_args[0][0]
+        assert "trim-caches" in cmd
+
+    def test_launch_app_calls_monkey(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0)
+            launch_app("com.example.app")
+        cmd = mock_shell.call_args[0][0]
+        assert "monkey" in cmd
+        assert "com.example.app" in cmd
+
+
+# ── Debloater ─────────────────────────────────────────────────────────────────
+
+class TestDebloat:
+    def test_removes_listed_packages(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0, stdout="Success")
+            removed = debloat(["com.android.email", "com.android.calendar"])
+        assert "com.android.email" in removed
+        assert "com.android.calendar" in removed
+
+    def test_skips_failed_packages(self) -> None:
+        def _side_effect(cmd: str) -> MagicMock:
+            if "email" in cmd:
+                return MagicMock(returncode=1, stdout="Failure")
+            return MagicMock(returncode=0, stdout="Success")
+
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell",
+                   side_effect=_side_effect):
+            removed = debloat(["com.android.email", "com.android.calendar"])
+        assert "com.android.email" not in removed
+        assert "com.android.calendar" in removed
+
+    def test_uses_default_bloat_list_when_none_given(self) -> None:
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0, stdout="Success")
+            removed = debloat()
+        assert len(removed) == len(DEFAULT_BLOAT)
+
+    def test_calls_progress(self) -> None:
+        messages: list[str] = []
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.shell") as mock_shell:
+            mock_shell.return_value = MagicMock(returncode=0, stdout="Success")
+            debloat(["com.android.email"], progress=messages.append)
+        assert len(messages) == 1
+        assert "com.android.email" in messages[0]

--- a/tests/unit/test_net.py
+++ b/tests/unit/test_net.py
@@ -1,7 +1,13 @@
 """Tests for network download helpers."""
 
+from __future__ import annotations
+
+import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.error import URLError
+
+import pytest
 
 from waydroid_toolkit.utils.net import download, verify_sha256
 
@@ -52,3 +58,100 @@ def test_verify_sha256_wrong(tmp_path: Path) -> None:
     f = tmp_path / "file.txt"
     f.write_bytes(b"hello world")
     assert verify_sha256(f, "0" * 64) is False
+
+
+def _mock_response(content: bytes, content_length: int | None = None) -> MagicMock:
+    """Build a context-manager mock for urlopen."""
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.headers = {"Content-Length": str(content_length if content_length is not None else len(content))}
+    mock_resp.read.side_effect = [content, b""]
+    return mock_resp
+
+
+# ── download — additional cases ───────────────────────────────────────────────
+
+def test_download_raises_connection_error_on_url_error(tmp_path: Path) -> None:
+    with patch("waydroid_toolkit.utils.net.urlopen", side_effect=URLError("timeout")):
+        with pytest.raises(ConnectionError, match="Failed to download"):
+            download("https://example.com/file.bin", tmp_path / "out.bin")
+
+
+def test_download_creates_parent_directories(tmp_path: Path) -> None:
+    dest = tmp_path / "a" / "b" / "c" / "file.bin"
+    with patch("waydroid_toolkit.utils.net.urlopen", return_value=_mock_response(b"data")):
+        download("https://example.com/file.bin", dest)
+    assert dest.exists()
+
+
+def test_download_handles_missing_content_length(tmp_path: Path) -> None:
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.headers = {}  # no Content-Length
+    mock_resp.read.side_effect = [b"data", b""]
+    dest = tmp_path / "out.bin"
+    with patch("waydroid_toolkit.utils.net.urlopen", return_value=mock_resp):
+        result = download("https://example.com/file.bin", dest)
+    assert result == dest
+    assert dest.read_bytes() == b"data"
+
+
+def test_download_progress_receives_total_zero_when_no_content_length(tmp_path: Path) -> None:
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.headers = {}
+    mock_resp.read.side_effect = [b"data", b""]
+    calls: list[tuple[int, int]] = []
+    dest = tmp_path / "out.bin"
+    with patch("waydroid_toolkit.utils.net.urlopen", return_value=mock_resp):
+        download("https://example.com/file.bin", dest, progress=lambda d, t: calls.append((d, t)))
+    assert calls[0][1] == 0  # total is 0 when Content-Length absent
+
+
+def test_download_sends_user_agent_header(tmp_path: Path) -> None:
+    dest = tmp_path / "file.bin"
+    with patch("waydroid_toolkit.utils.net.urlopen", return_value=_mock_response(b"x")):
+        with patch("waydroid_toolkit.utils.net.Request") as mock_req:
+            mock_req.return_value = MagicMock()
+            download("https://example.com/file.bin", dest)
+    _, kwargs = mock_req.call_args
+    headers = kwargs.get("headers", {})
+    assert "User-Agent" in headers
+    assert "waydroid-toolkit" in headers["User-Agent"]
+
+
+def test_download_multiple_chunks_progress(tmp_path: Path) -> None:
+    chunk1, chunk2 = b"a" * 64, b"b" * 64
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.headers = {"Content-Length": "128"}
+    mock_resp.read.side_effect = [chunk1, chunk2, b""]
+    calls: list[tuple[int, int]] = []
+    dest = tmp_path / "out.bin"
+    with patch("waydroid_toolkit.utils.net.urlopen", return_value=mock_resp):
+        download("https://example.com/file.bin", dest,
+                 progress=lambda d, t: calls.append((d, t)), chunk_size=64)
+    assert len(calls) == 2
+    assert calls[-1][0] == 128
+
+
+# ── verify_sha256 — additional cases ─────────────────────────────────────────
+
+def test_verify_sha256_case_insensitive(tmp_path: Path) -> None:
+    data = b"hello"
+    expected = hashlib.sha256(data).hexdigest().upper()
+    f = tmp_path / "f.bin"
+    f.write_bytes(data)
+    assert verify_sha256(f, expected) is True
+
+
+def test_verify_sha256_large_file(tmp_path: Path) -> None:
+    data = b"x" * 200_000
+    expected = hashlib.sha256(data).hexdigest()
+    f = tmp_path / "large.bin"
+    f.write_bytes(data)
+    assert verify_sha256(f, expected) is True

--- a/tests/unit/test_overlay.py
+++ b/tests/unit/test_overlay.py
@@ -1,9 +1,16 @@
 """Tests for overlay filesystem helpers."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from unittest.mock import patch
 
-from waydroid_toolkit.utils.overlay import install_file, overlay_path, remove_file
+from waydroid_toolkit.utils.overlay import (
+    install_file,
+    is_overlay_enabled,
+    overlay_path,
+    remove_file,
+)
 
 
 def test_overlay_path_strips_leading_slash() -> None:
@@ -48,3 +55,38 @@ def test_remove_file_nonexistent(tmp_path: Path) -> None:
     with patch("waydroid_toolkit.utils.overlay._OVERLAY_ROOT", fake_overlay):
         result = remove_file("/system/lib/nonexistent.so")
     assert result is False
+
+
+def test_install_file_creates_parent_dirs(tmp_path: Path) -> None:
+    src = tmp_path / "libbar.so"
+    src.write_bytes(b"\x7fELF")
+    fake_overlay = tmp_path / "overlay"
+    # Deep nested path — parent dirs must be created
+    with patch("waydroid_toolkit.utils.overlay._OVERLAY_ROOT", fake_overlay):
+        dest = install_file(src, "/system/vendor/lib64/libbar.so")
+    assert dest.exists()
+    assert dest.read_bytes() == b"\x7fELF"
+
+
+def test_overlay_path_root_maps_correctly() -> None:
+    result = overlay_path("/")
+    # Root maps to the overlay root itself
+    from waydroid_toolkit.utils.overlay import _OVERLAY_ROOT
+    assert result == _OVERLAY_ROOT
+
+
+# ── is_overlay_enabled ────────────────────────────────────────────────────────
+
+class TestIsOverlayEnabled:
+    # WaydroidConfig is imported lazily inside is_overlay_enabled(); patch at source.
+    _PATCH = "waydroid_toolkit.core.waydroid.WaydroidConfig.load"
+
+    def test_true_when_mount_overlays_enabled(self) -> None:
+        from waydroid_toolkit.core.waydroid import WaydroidConfig
+        with patch(self._PATCH, return_value=WaydroidConfig(mount_overlays=True)):
+            assert is_overlay_enabled() is True
+
+    def test_false_when_mount_overlays_disabled(self) -> None:
+        from waydroid_toolkit.core.waydroid import WaydroidConfig
+        with patch(self._PATCH, return_value=WaydroidConfig(mount_overlays=False)):
+            assert is_overlay_enabled() is False

--- a/tests/unit/test_presenters.py
+++ b/tests/unit/test_presenters.py
@@ -1,0 +1,264 @@
+"""Tests for GUI presenter functions.
+
+Presenters gather data from the domain layer and return plain dataclasses.
+No GTK is required — these run in any environment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from waydroid_toolkit.core.waydroid import SessionState
+from waydroid_toolkit.gui.presenters import (
+    StatusData,
+    get_backup_entries,
+    get_device_info_data,
+    get_extension_rows,
+    get_image_profile_rows,
+    get_status_data,
+)
+from waydroid_toolkit.modules.extensions.base import ExtensionState
+
+# ── get_status_data ───────────────────────────────────────────────────────────
+
+class TestGetStatusData:
+    def _patch_all(
+        self,
+        installed: bool = True,
+        initialized: bool = True,
+        state: SessionState = SessionState.RUNNING,
+        images_path: str = "/images",
+        mount_overlays: bool = True,
+        adb_ok: bool = True,
+        adb_conn: bool = True,
+    ):
+        from waydroid_toolkit.core.waydroid import WaydroidConfig
+        cfg = WaydroidConfig(images_path=images_path, mount_overlays=mount_overlays)
+        return [
+            patch("waydroid_toolkit.gui.presenters.is_installed", return_value=installed),
+            patch("waydroid_toolkit.gui.presenters.is_initialized", return_value=initialized),
+            patch("waydroid_toolkit.gui.presenters.get_session_state", return_value=state),
+            patch("waydroid_toolkit.gui.presenters.WaydroidConfig.load", return_value=cfg),
+            patch("waydroid_toolkit.gui.presenters.adb_available", return_value=adb_ok),
+            patch("waydroid_toolkit.gui.presenters.adb_connected", return_value=adb_conn),
+        ]
+
+    def test_returns_status_data_instance(self) -> None:
+        patches = self._patch_all()
+        for p in patches:
+            p.start()
+        try:
+            result = get_status_data()
+        finally:
+            for p in patches:
+                p.stop()
+        assert isinstance(result, StatusData)
+
+    def test_installed_true(self) -> None:
+        patches = self._patch_all(installed=True)
+        for p in patches:
+            p.start()
+        try:
+            result = get_status_data()
+        finally:
+            for p in patches:
+                p.stop()
+        assert result.installed is True
+
+    def test_installed_false_skips_initialized_and_state(self) -> None:
+        patches = self._patch_all(installed=False)
+        for p in patches:
+            p.start()
+        try:
+            result = get_status_data()
+        finally:
+            for p in patches:
+                p.stop()
+        assert result.initialized is False
+        assert result.session_state == SessionState.UNKNOWN
+
+    def test_adb_connected_false_when_adb_unavailable(self) -> None:
+        patches = self._patch_all(adb_ok=False, adb_conn=True)
+        for p in patches:
+            p.start()
+        try:
+            result = get_status_data()
+        finally:
+            for p in patches:
+                p.stop()
+        # adb_connected should not be called when adb is unavailable
+        assert result.adb_connected is False
+
+    def test_images_path_propagated(self) -> None:
+        patches = self._patch_all(images_path="/custom/images")
+        for p in patches:
+            p.start()
+        try:
+            result = get_status_data()
+        finally:
+            for p in patches:
+                p.stop()
+        assert result.images_path == "/custom/images"
+
+    def test_mount_overlays_propagated(self) -> None:
+        patches = self._patch_all(mount_overlays=False)
+        for p in patches:
+            p.start()
+        try:
+            result = get_status_data()
+        finally:
+            for p in patches:
+                p.stop()
+        assert result.mount_overlays is False
+
+
+# ── get_backup_entries ────────────────────────────────────────────────────────
+
+class TestGetBackupEntries:
+    def test_returns_empty_when_no_backups(self, tmp_path: Path) -> None:
+        result = get_backup_entries(tmp_path)
+        assert result == []
+
+    def test_returns_entry_per_archive(self, tmp_path: Path) -> None:
+        for name in ["waydroid_backup_20240101_120000.tar.gz",
+                     "waydroid_backup_20240201_090000.tar.gz"]:
+            (tmp_path / name).write_bytes(b"x" * 1024)
+        result = get_backup_entries(tmp_path)
+        assert len(result) == 2
+
+    def test_entry_has_correct_name(self, tmp_path: Path) -> None:
+        (tmp_path / "waydroid_backup_20240101_120000.tar.gz").write_bytes(b"x" * 2048)
+        result = get_backup_entries(tmp_path)
+        assert result[0].name == "waydroid_backup_20240101_120000.tar.gz"
+
+    def test_entry_size_mb_calculated(self, tmp_path: Path) -> None:
+        data = b"x" * (1024 * 1024)  # exactly 1 MB
+        (tmp_path / "waydroid_backup_20240101_120000.tar.gz").write_bytes(data)
+        result = get_backup_entries(tmp_path)
+        assert abs(result[0].size_mb - 1.0) < 0.01
+
+    def test_entry_path_is_absolute(self, tmp_path: Path) -> None:
+        (tmp_path / "waydroid_backup_20240101_120000.tar.gz").write_bytes(b"x")
+        result = get_backup_entries(tmp_path)
+        assert result[0].path.is_absolute()
+
+    def test_sorted_newest_first(self, tmp_path: Path) -> None:
+        names = [
+            "waydroid_backup_20240101_120000.tar.gz",
+            "waydroid_backup_20240301_090000.tar.gz",
+            "waydroid_backup_20240201_150000.tar.gz",
+        ]
+        for name in names:
+            (tmp_path / name).write_bytes(b"x")
+        result = get_backup_entries(tmp_path)
+        assert result[0].name == "waydroid_backup_20240301_090000.tar.gz"
+
+
+# ── get_extension_rows ────────────────────────────────────────────────────────
+
+class TestGetExtensionRows:
+    def test_returns_one_row_per_extension(self) -> None:
+        with patch("waydroid_toolkit.gui.presenters.list_extensions") as mock_list:
+            mock_ext = MagicMock()
+            mock_ext.meta.id = "gapps"
+            mock_ext.meta.name = "Google Apps"
+            mock_ext.meta.description = "GApps"
+            mock_ext.meta.conflicts = ["microg"]
+            mock_ext.state.return_value = ExtensionState.NOT_INSTALLED
+            mock_list.return_value = [mock_ext]
+            result = get_extension_rows()
+        assert len(result) == 1
+        assert result[0].ext_id == "gapps"
+
+    def test_installed_state_propagated(self) -> None:
+        with patch("waydroid_toolkit.gui.presenters.list_extensions") as mock_list:
+            mock_ext = MagicMock()
+            mock_ext.meta.id = "magisk"
+            mock_ext.meta.name = "Magisk"
+            mock_ext.meta.description = "Root"
+            mock_ext.meta.conflicts = []
+            mock_ext.state.return_value = ExtensionState.INSTALLED
+            mock_list.return_value = [mock_ext]
+            result = get_extension_rows()
+        assert result[0].state == ExtensionState.INSTALLED
+
+    def test_conflicts_propagated(self) -> None:
+        with patch("waydroid_toolkit.gui.presenters.list_extensions") as mock_list:
+            mock_ext = MagicMock()
+            mock_ext.meta.id = "gapps"
+            mock_ext.meta.name = "GApps"
+            mock_ext.meta.description = ""
+            mock_ext.meta.conflicts = ["microg"]
+            mock_ext.state.return_value = ExtensionState.NOT_INSTALLED
+            mock_list.return_value = [mock_ext]
+            result = get_extension_rows()
+        assert "microg" in result[0].conflicts
+
+    def test_returns_all_real_extensions(self) -> None:
+        rows = get_extension_rows()
+        ids = {r.ext_id for r in rows}
+        assert {"gapps", "microg", "magisk", "libhoudini", "libndk"} == ids
+
+
+# ── get_image_profile_rows ────────────────────────────────────────────────────
+
+class TestGetImageProfileRows:
+    def _make_profile(self, tmp_path: Path, name: str):
+        from waydroid_toolkit.modules.images.manager import ImageProfile
+        d = tmp_path / name
+        d.mkdir()
+        (d / "system.img").touch()
+        (d / "vendor.img").touch()
+        return ImageProfile(name=name, path=d)
+
+    def test_returns_empty_when_no_profiles(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.gui.presenters.scan_profiles", return_value=[]):
+            with patch("waydroid_toolkit.gui.presenters.get_active_profile", return_value=None):
+                result = get_image_profile_rows()
+        assert result == []
+
+    def test_returns_one_row_per_profile(self, tmp_path: Path) -> None:
+        profiles = [self._make_profile(tmp_path, n) for n in ("vanilla", "gapps")]
+        with patch("waydroid_toolkit.gui.presenters.scan_profiles", return_value=profiles):
+            with patch("waydroid_toolkit.gui.presenters.get_active_profile", return_value=None):
+                result = get_image_profile_rows()
+        assert len(result) == 2
+
+    def test_active_profile_marked(self, tmp_path: Path) -> None:
+        profile = self._make_profile(tmp_path, "vanilla")
+        with patch("waydroid_toolkit.gui.presenters.scan_profiles", return_value=[profile]):
+            with patch("waydroid_toolkit.gui.presenters.get_active_profile",
+                       return_value=str(profile.path)):
+                result = get_image_profile_rows()
+        assert result[0].is_active is True
+
+    def test_inactive_profile_not_marked(self, tmp_path: Path) -> None:
+        profile = self._make_profile(tmp_path, "vanilla")
+        with patch("waydroid_toolkit.gui.presenters.scan_profiles", return_value=[profile]):
+            with patch("waydroid_toolkit.gui.presenters.get_active_profile",
+                       return_value="/other/path"):
+                result = get_image_profile_rows()
+        assert result[0].is_active is False
+
+    def test_no_active_profile_all_inactive(self, tmp_path: Path) -> None:
+        profiles = [self._make_profile(tmp_path, n) for n in ("a", "b")]
+        with patch("waydroid_toolkit.gui.presenters.scan_profiles", return_value=profiles):
+            with patch("waydroid_toolkit.gui.presenters.get_active_profile", return_value=None):
+                result = get_image_profile_rows()
+        assert all(not r.is_active for r in result)
+
+
+# ── get_device_info_data ──────────────────────────────────────────────────────
+
+class TestGetDeviceInfoData:
+    def test_delegates_to_get_device_info(self) -> None:
+        expected = {"android_version": "13", "sdk_version": "33"}
+        with patch("waydroid_toolkit.gui.presenters.get_device_info", return_value=expected):
+            result = get_device_info_data()
+        assert result == expected
+
+    def test_returns_dict(self) -> None:
+        with patch("waydroid_toolkit.gui.presenters.get_device_info", return_value={}):
+            result = get_device_info_data()
+        assert isinstance(result, dict)

--- a/tests/unit/test_privilege.py
+++ b/tests/unit/test_privilege.py
@@ -1,0 +1,82 @@
+"""Tests for the privilege / sudo helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.core.privilege import is_root, require_root, sudo_run
+
+# ── is_root ───────────────────────────────────────────────────────────────────
+
+class TestIsRoot:
+    def test_true_when_euid_zero(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.os.geteuid", return_value=0):
+            assert is_root() is True
+
+    def test_false_when_euid_nonzero(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.os.geteuid", return_value=1000):
+            assert is_root() is False
+
+
+# ── sudo_run ──────────────────────────────────────────────────────────────────
+
+class TestSudoRun:
+    def test_prepends_sudo(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            sudo_run("ls", "-la")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "sudo"
+        assert "ls" in cmd
+        assert "-la" in cmd
+
+    def test_raises_permission_error_when_sudo_missing(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.subprocess.run",
+                   side_effect=FileNotFoundError):
+            with pytest.raises(PermissionError, match="sudo is not available"):
+                sudo_run("ls")
+
+    def test_returns_completed_process(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="output")
+            result = sudo_run("true")
+        assert result.returncode == 0
+
+
+# ── require_root ──────────────────────────────────────────────────────────────
+
+class TestRequireRoot:
+    def test_passes_silently_when_already_root(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.is_root", return_value=True):
+            require_root("test op")  # should not raise
+
+    def test_passes_when_sudo_available_without_password(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.is_root", return_value=False):
+            with patch("waydroid_toolkit.core.privilege.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                require_root("test op")  # should not raise
+
+    def test_raises_when_not_root_and_sudo_requires_password(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.is_root", return_value=False):
+            with patch("waydroid_toolkit.core.privilege.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                with pytest.raises(PermissionError, match="requires root"):
+                    require_root("installing Waydroid")
+
+    def test_error_message_includes_operation_name(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.is_root", return_value=False):
+            with patch("waydroid_toolkit.core.privilege.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                with pytest.raises(PermissionError, match="my special operation"):
+                    require_root("my special operation")
+
+    def test_sudo_check_uses_noninteractive_flag(self) -> None:
+        with patch("waydroid_toolkit.core.privilege.is_root", return_value=False):
+            with patch("waydroid_toolkit.core.privilege.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                require_root()
+        cmd = " ".join(mock_run.call_args[0][0])
+        assert "sudo" in cmd
+        assert "-n" in cmd


### PR DESCRIPTION
## ADB reliability

`connect()` now checks `SessionState` before each attempt. When Waydroid is not running, the `adb connect` call is skipped entirely and the loop sleeps before retrying. This prevents wasted TCP connection attempts against a stopped container and makes the retry count meaningful.

## GUI presenter layer

New `src/waydroid_toolkit/gui/presenters.py` extracts all data-gathering logic from GTK page classes into pure functions that return plain dataclasses:

| Presenter | Returns | Used by |
|-----------|---------|---------|
| `get_status_data()` | `StatusData` | Status page |
| `get_backup_entries()` | `list[BackupEntry]` | Backup page |
| `get_extension_rows()` | `list[ExtensionRow]` | Extensions page |
| `get_image_profile_rows()` | `list[ImageProfileRow]` | Images page |
| `get_device_info_data()` | `dict[str, str]` | Maintenance page |

Status, Backup, Extensions, and Images pages now delegate to these functions. Widget code is reduced to applying the returned data — no domain logic remains in the GTK layer.

## Test coverage: 222 → 322 tests, 13% → 57% line coverage

| New file | Tests | Key coverage |
|----------|-------|-------------|
| `test_adb.py` | 27 | connect session-state guard, retry/sleep, all ADB operations |
| `test_maintenance.py` | 28 | display props, device info, file transfer errors, logcat lifecycle, app management, debloat |
| `test_net.py` | +9 | URLError → ConnectionError, missing Content-Length, User-Agent, multi-chunk progress, case-insensitive sha256 |
| `test_overlay.py` | +5 | parent dir creation, is_overlay_enabled |
| `test_privilege.py` | 10 | is_root, sudo_run, require_root all paths |
| `test_presenters.py` | 23 | all presenter functions, edge cases |