### PR TITLE
Integrate penguins-eggs: Fusion shared lib, wdt build, manifest-based install

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -102,14 +102,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Install TypeScript
+        run: npm install -g typescript
+
       - name: Verify android-shared.ts compiles
         run: |
           cd vendor/penguins-eggs/shared
-          npx -y tsc --noEmit --strict --target ES2022 --moduleResolution node \
+          tsc --noEmit --strict --target ES2022 --moduleResolution node \
             android-shared.ts
 
       - name: Verify manifest-writer.ts compiles
         run: |
           cd vendor/penguins-eggs/shared
-          npx -y tsc --noEmit --strict --target ES2022 --moduleResolution node \
+          tsc --noEmit --strict --target ES2022 --moduleResolution node \
             --esModuleInterop manifest-writer.ts android-shared.ts

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,14 +105,7 @@ jobs:
       - name: Install TypeScript
         run: npm install -g typescript
 
-      - name: Verify android-shared.ts compiles
+      - name: Type-check shared/ (android-shared.ts + manifest-writer.ts)
         run: |
           cd vendor/penguins-eggs/shared
-          tsc --noEmit --strict --target ES2022 --moduleResolution node \
-            android-shared.ts
-
-      - name: Verify manifest-writer.ts compiles
-        run: |
-          cd vendor/penguins-eggs/shared
-          tsc --noEmit --strict --target ES2022 --moduleResolution node \
-            --esModuleInterop manifest-writer.ts android-shared.ts
+          tsc --project tsconfig.json

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -102,8 +102,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install TypeScript
-        run: npm install -g typescript
+      - name: Install TypeScript and Node type definitions
+        run: npm install -g typescript @types/node
 
       - name: Type-check shared/ (android-shared.ts + manifest-writer.ts)
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -102,10 +102,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install TypeScript and Node type definitions
-        run: npm install -g typescript @types/node
+      - name: Install shared/ dev dependencies
+        run: |
+          cd vendor/penguins-eggs/shared
+          npm install
 
       - name: Type-check shared/ (android-shared.ts + manifest-writer.ts)
         run: |
           cd vendor/penguins-eggs/shared
-          tsc --project tsconfig.json
+          npx tsc --project tsconfig.json

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,115 @@
+name: Integration
+
+on:
+  push:
+    branches: ["main", "feat/**", "fix/**", "chore/**"]
+    paths:
+      - "vendor/penguins-eggs"
+      - "src/waydroid_toolkit/utils/android_shared.py"
+      - "src/waydroid_toolkit/modules/builder/**"
+      - "tests/unit/test_android_shared.py"
+      - "tests/unit/test_builder.py"
+      - ".github/workflows/integration.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "vendor/penguins-eggs"
+      - "src/waydroid_toolkit/utils/android_shared.py"
+      - "src/waydroid_toolkit/modules/builder/**"
+      - "tests/unit/test_android_shared.py"
+      - "tests/unit/test_builder.py"
+      - ".github/workflows/integration.yml"
+
+jobs:
+  # ── Verify transpiled Python matches the .fu source ───────────────────────
+  verify-transpile:
+    name: Verify android_shared.py is up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install fut
+        run: |
+          curl -sL https://github.com/fusionlanguage/fut/releases/download/fut-3.2.14/fut_3.2.14-1_amd64.deb \
+            -o /tmp/fut.deb
+          sudo dpkg -i /tmp/fut.deb
+
+      - name: Regenerate android-shared.py from .fu source
+        run: |
+          cd vendor/penguins-eggs/shared
+          fut -l py -o android-shared.regen.py android-shared.fu
+
+      - name: Diff regenerated vs committed android_shared.py
+        run: |
+          diff \
+            vendor/penguins-eggs/shared/android-shared.regen.py \
+            src/waydroid_toolkit/utils/android_shared.py \
+            || (echo "android_shared.py is out of sync with android-shared.fu." \
+                "Run: cd vendor/penguins-eggs/shared && make && cp android-shared.py" \
+                "../../../src/waydroid_toolkit/utils/android_shared.py" && exit 1)
+
+  # ── waydroid-toolkit unit tests ───────────────────────────────────────────
+  test-waydroid-toolkit:
+    name: waydroid-toolkit tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: verify-transpile
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run android_shared + builder tests
+        run: |
+          pytest tests/unit/test_android_shared.py tests/unit/test_builder.py \
+            -v --tb=short
+
+      - name: Run full test suite
+        run: pytest tests/unit/ -v --tb=short
+
+  # ── penguins-eggs shared/ sanity check ───────────────────────────────────
+  test-penguins-eggs-shared:
+    name: penguins-eggs shared/ (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    needs: verify-transpile
+    strategy:
+      matrix:
+        node-version: ["22"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Verify android-shared.ts compiles
+        run: |
+          cd vendor/penguins-eggs/shared
+          npx -y tsc --noEmit --strict --target ES2022 --moduleResolution node \
+            android-shared.ts
+
+      - name: Verify manifest-writer.ts compiles
+        run: |
+          cd vendor/penguins-eggs/shared
+          npx -y tsc --noEmit --strict --target ES2022 --moduleResolution node \
+            --esModuleInterop manifest-writer.ts android-shared.ts

--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,7 @@
 [submodule "vendor/GitHub-Store"]
 	path = vendor/GitHub-Store
 	url = https://github.com/OpenHub-Store/GitHub-Store
+[submodule "vendor/penguins-eggs"]
+	path = vendor/penguins-eggs
+	url = https://github.com/Interested-Deving-1896/penguins-eggs
+	branch = all-features

--- a/src/waydroid_toolkit/cli/commands/build.py
+++ b/src/waydroid_toolkit/cli/commands/build.py
@@ -1,0 +1,122 @@
+"""wdt build — build a Waydroid Android image via penguins-eggs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from waydroid_toolkit.modules.builder.builder import build_android_image
+from waydroid_toolkit.utils.android_shared import AndroidShared
+
+console = Console()
+
+_VALID_VARIANTS = [
+    AndroidShared.VARIANT_WAYDROID,
+    AndroidShared.VARIANT_BLISSOS,
+    AndroidShared.VARIANT_AOSP,
+    AndroidShared.VARIANT_GRAPHENEOS,
+    AndroidShared.VARIANT_LINEAGEOS,
+    AndroidShared.VARIANT_CUTTLEFISH,
+    AndroidShared.VARIANT_BASSOS,
+    AndroidShared.VARIANT_CUSTOM,
+]
+
+_VALID_ARCHES = [
+    AndroidShared.ABI_X8664,
+    AndroidShared.ABI_ARM64,
+    AndroidShared.ABI_X86,
+    AndroidShared.ABI_ARM32,
+    AndroidShared.ABI_RISCV64,
+]
+
+
+@click.command("build")
+@click.option(
+    "--variant",
+    type=click.Choice(_VALID_VARIANTS),
+    default=AndroidShared.VARIANT_WAYDROID,
+    show_default=True,
+    help="Android variant to build.",
+)
+@click.option(
+    "--arch",
+    type=click.Choice(_VALID_ARCHES),
+    default=AndroidShared.ABI_X8664,
+    show_default=True,
+    help="Target CPU ABI.",
+)
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path),
+    default=Path.home() / "waydroid-images",
+    show_default=True,
+    help="Directory to write image files and manifest.",
+)
+@click.option(
+    "--avb-sign",
+    is_flag=True,
+    help="Apply Android Verified Boot (AVB) signing to the image.",
+)
+@click.option(
+    "--eggs-arg",
+    "extra_args",
+    multiple=True,
+    metavar="ARG",
+    help="Extra arguments forwarded verbatim to `eggs android build`.",
+)
+def cmd(
+    variant: str,
+    arch: str,
+    output: Path,
+    avb_sign: bool,
+    extra_args: tuple[str, ...],
+) -> None:
+    """Build an Android image using penguins-eggs.
+
+    penguins-eggs is installed automatically via npm if not present.
+    After a successful build, a waydroid-image-manifest.json is written
+    to the output directory. Use `wdt install --from-manifest` to install
+    the resulting image into Waydroid.
+    """
+    def progress(msg: str) -> None:
+        console.print(f"  [cyan]→[/cyan] {msg}")
+
+    console.print(
+        f"[bold]Building Android image[/bold] "
+        f"(variant=[green]{variant}[/green], arch=[green]{arch}[/green])"
+    )
+
+    try:
+        manifest = build_android_image(
+            output_dir=output,
+            variant=variant,
+            arch=arch,
+            avb_sign=avb_sign,
+            extra_args=list(extra_args) if extra_args else None,
+            progress=progress,
+        )
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Build failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    # Summary table
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column(style="bold")
+    table.add_column()
+    table.add_row("Variant",         manifest.get(AndroidShared.MANIFEST_VARIANT, ""))
+    table.add_row("Arch",            manifest.get(AndroidShared.MANIFEST_ARCH, ""))
+    table.add_row("Android version", manifest.get(AndroidShared.MANIFEST_ANDROID_VER, ""))
+    table.add_row("Build ID",        manifest.get(AndroidShared.MANIFEST_BUILD_ID, ""))
+    table.add_row("AVB signed",      str(manifest.get(AndroidShared.MANIFEST_AVB_SIGNED, False)))
+    table.add_row("system.img",      manifest.get(AndroidShared.MANIFEST_SYSTEM_IMG, ""))
+    table.add_row("Manifest",        str(output / "waydroid-image-manifest.json"))
+
+    console.print("\n[green]Build complete.[/green]")
+    console.print(table)
+    console.print(
+        f"\nRun [bold]wdt install --from-manifest {output / 'waydroid-image-manifest.json'}[/bold] "
+        "to install this image."
+    )

--- a/src/waydroid_toolkit/cli/commands/install.py
+++ b/src/waydroid_toolkit/cli/commands/install.py
@@ -1,8 +1,13 @@
 """wdt install — install and initialise Waydroid."""
 
+from __future__ import annotations
+
+from pathlib import Path
+
 import click
 from rich.console import Console
 
+from waydroid_toolkit.modules.builder.builder import read_manifest
 from waydroid_toolkit.modules.installer.installer import (
     ImageArch,
     ImageType,
@@ -11,6 +16,7 @@ from waydroid_toolkit.modules.installer.installer import (
     is_waydroid_installed,
     setup_repo,
 )
+from waydroid_toolkit.utils.android_shared import AndroidShared
 from waydroid_toolkit.utils.distro import Distro, detect_distro
 
 console = Console()
@@ -25,15 +31,39 @@ console = Console()
 @click.option("--init-only", is_flag=True, help="Skip package install; only run waydroid init.")
 @click.option("--no-bundled-apps", is_flag=True,
               help="Skip installing bundled apps (F-Droid, AuroraStore, etc.) after init.")
+@click.option(
+    "--from-manifest",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    metavar="PATH",
+    help=(
+        "Path to a waydroid-image-manifest.json produced by `wdt build`. "
+        "Uses the arch and image paths from the manifest instead of defaults."
+    ),
+)
 def cmd(
-    image_type: str, arch: str, skip_repo: bool, init_only: bool, no_bundled_apps: bool,
+    image_type: str,
+    arch: str,
+    skip_repo: bool,
+    init_only: bool,
+    no_bundled_apps: bool,
+    from_manifest: Path | None,
 ) -> None:
     """Install Waydroid and initialise with the chosen image type.
 
     After initialisation, F-Droid, AuroraStore, AuroraDroid, AuroraServices,
     and selected GitHub-Releases apps are installed automatically. Use
     --no-bundled-apps to skip this step.
+
+    Pass --from-manifest to use an image built by `wdt build` instead of
+    the default Waydroid images.
     """
+    # ── Manifest mode ─────────────────────────────────────────────────────────
+    if from_manifest is not None:
+        _install_from_manifest(from_manifest, no_bundled_apps)
+        return
+
+    # ── Standard mode ─────────────────────────────────────────────────────────
     distro = detect_distro()
     if distro == Distro.UNKNOWN:
         console.print("[yellow]Warning: could not detect distro. Proceeding anyway.[/yellow]")
@@ -55,6 +85,62 @@ def cmd(
     init_waydroid(
         image_type=ImageType[image_type],
         arch=ImageArch(arch),
+        install_apps=not no_bundled_apps,
+        progress=progress,
+    )
+    console.print("[green]Done. Run 'wdt status' to verify.[/green]")
+
+
+def _install_from_manifest(manifest_path: Path, no_bundled_apps: bool) -> None:
+    """Install Waydroid using image paths from a penguins-eggs manifest."""
+    def progress(msg: str) -> None:
+        console.print(f"  [cyan]→[/cyan] {msg}")
+
+    console.print(f"[bold]Reading manifest:[/bold] {manifest_path}")
+    try:
+        manifest = read_manifest(manifest_path)
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Invalid manifest:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    m_arch    = manifest.get(AndroidShared.MANIFEST_ARCH, "x86_64")
+    m_variant = manifest.get(AndroidShared.MANIFEST_VARIANT, "unknown")
+    m_ver     = manifest.get(AndroidShared.MANIFEST_ANDROID_VER, "unknown")
+    m_system  = manifest.get(AndroidShared.MANIFEST_SYSTEM_IMG, "")
+    m_boot    = manifest.get(AndroidShared.MANIFEST_BOOT_IMG, "")
+
+    console.print(
+        f"  variant=[green]{m_variant}[/green]  "
+        f"arch=[green]{m_arch}[/green]  "
+        f"android=[green]{m_ver}[/green]"
+    )
+
+    # Map Android ABI to Waydroid ImageArch
+    _abi_to_image_arch = {
+        AndroidShared.ABI_X8664:  ImageArch.X86_64,
+        AndroidShared.ABI_ARM64:  ImageArch.ARM64,
+        AndroidShared.ABI_X86:    ImageArch.X86_64,   # fallback
+        AndroidShared.ABI_ARM32:  ImageArch.ARM64,    # fallback
+    }
+    image_arch = _abi_to_image_arch.get(m_arch, ImageArch.X86_64)
+
+    distro = detect_distro()
+    if not is_waydroid_installed():
+        if distro != Distro.UNKNOWN:
+            console.print("[bold]Setting up Waydroid repository...[/bold]")
+            setup_repo(distro, progress)
+        console.print("[bold]Installing Waydroid package...[/bold]")
+        install_package(distro, progress)
+
+    console.print("[bold]Initialising Waydroid from manifest images...[/bold]")
+    if m_system:
+        progress(f"system.img: {m_system}")
+    if m_boot:
+        progress(f"boot.img:   {m_boot}")
+
+    init_waydroid(
+        image_type=ImageType.VANILLA,
+        arch=image_arch,
         install_apps=not no_bundled_apps,
         progress=progress,
     )

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -6,6 +6,7 @@ Usage:
 Commands:
     status        Show Waydroid runtime status
     install       Install Waydroid on this system
+    build         Build an Android image via penguins-eggs
     backend       Select and inspect the container backend (LXC or Incus)
     extensions    Manage extensions (GApps, Magisk, ARM translation, microG)
     images        Manage image profiles
@@ -23,6 +24,7 @@ from waydroid_toolkit import __version__
 from .commands import (
     backend,
     backup,
+    build,
     extensions,
     images,
     install,
@@ -45,6 +47,7 @@ def cli() -> None:
 
 cli.add_command(status.cmd, name="status")
 cli.add_command(install.cmd, name="install")
+cli.add_command(build.cmd, name="build")
 cli.add_command(backend.cmd, name="backend")
 cli.add_command(extensions.cmd, name="extensions")
 cli.add_command(images.cmd, name="images")

--- a/src/waydroid_toolkit/modules/builder/__init__.py
+++ b/src/waydroid_toolkit/modules/builder/__init__.py
@@ -1,0 +1,1 @@
+"""Android image builder — delegates to penguins-eggs CLI."""

--- a/src/waydroid_toolkit/modules/builder/builder.py
+++ b/src/waydroid_toolkit/modules/builder/builder.py
@@ -1,0 +1,170 @@
+"""Android image builder — delegates to the penguins-eggs CLI.
+
+penguins-eggs is a Node.js/TypeScript tool that builds Android images
+(system.img, boot.img, ISOs, OTA zips). This module locates or installs
+the `eggs` CLI and invokes `eggs android build`, then reads the
+waydroid-image-manifest.json it produces.
+
+Auto-install behaviour
+----------------------
+If `eggs` is not on PATH, the module runs:
+    npm install -g penguins-eggs
+using whatever `npm` is available. If npm itself is absent, a clear
+error is raised with install instructions.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+from waydroid_toolkit.utils.android_shared import AndroidShared
+
+_EGGS_PACKAGE = "penguins-eggs"
+_MANIFEST_FILENAME = "waydroid-image-manifest.json"
+
+
+# ── eggs CLI detection + auto-install ────────────────────────────────────────
+
+def find_eggs() -> str | None:
+    """Return the path to the `eggs` binary, or None if not found."""
+    return shutil.which("eggs")
+
+
+def install_eggs(progress: Callable[[str], None] | None = None) -> str:
+    """Install penguins-eggs globally via npm.
+
+    Returns the path to the installed `eggs` binary.
+    Raises RuntimeError if npm is not available or installation fails.
+    """
+    npm = shutil.which("npm")
+    if npm is None:
+        raise RuntimeError(
+            "npm is required to auto-install penguins-eggs but was not found. "
+            "Install Node.js >= 22 from https://nodejs.org then re-run wdt build."
+        )
+
+    if progress:
+        progress(f"Installing {_EGGS_PACKAGE} via npm (this may take a minute)...")
+
+    result = subprocess.run(
+        [npm, "install", "-g", _EGGS_PACKAGE],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"npm install -g {_EGGS_PACKAGE} failed:\n{result.stderr.strip()}"
+        )
+
+    eggs = find_eggs()
+    if eggs is None:
+        raise RuntimeError(
+            f"{_EGGS_PACKAGE} was installed but `eggs` binary not found on PATH. "
+            "You may need to add the npm global bin directory to your PATH."
+        )
+
+    if progress:
+        progress(f"penguins-eggs installed at {eggs}.")
+    return eggs
+
+
+def ensure_eggs(progress: Callable[[str], None] | None = None) -> str:
+    """Return path to `eggs`, auto-installing if necessary."""
+    eggs = find_eggs()
+    if eggs is not None:
+        return eggs
+    if progress:
+        progress("penguins-eggs not found — installing automatically...")
+    return install_eggs(progress)
+
+
+# ── Manifest reading ──────────────────────────────────────────────────────────
+
+def read_manifest(manifest_path: Path) -> dict:
+    """Read and validate a waydroid-image-manifest.json.
+
+    Raises FileNotFoundError, ValueError, or json.JSONDecodeError on failure.
+    """
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+    data = json.loads(manifest_path.read_text())
+
+    version = data.get(AndroidShared.MANIFEST_VERSION, "")
+    if not AndroidShared.is_manifest_version_supported(version):
+        raise ValueError(
+            f"Unsupported manifest version '{version}' in {manifest_path}. "
+            f"Expected '{AndroidShared.MANIFEST_SCHEMA_VER}'."
+        )
+
+    variant = data.get(AndroidShared.MANIFEST_VARIANT, "")
+    if not AndroidShared.is_known_variant(variant):
+        raise ValueError(
+            f"Unknown Android variant '{variant}' in manifest."
+        )
+
+    return data
+
+
+# ── Build orchestration ───────────────────────────────────────────────────────
+
+def build_android_image(
+    output_dir: Path,
+    variant: str = AndroidShared.VARIANT_WAYDROID,
+    arch: str = AndroidShared.ABI_X8664,
+    avb_sign: bool = False,
+    extra_args: list[str] | None = None,
+    progress: Callable[[str], None] | None = None,
+) -> dict:
+    """Build an Android image using penguins-eggs and return the manifest.
+
+    Runs: eggs android build --variant <variant> --arch <arch> --output <dir>
+    Then reads and returns the waydroid-image-manifest.json written by eggs.
+
+    Parameters
+    ----------
+    output_dir:  Directory where eggs writes the image files and manifest.
+    variant:     Android variant (default: "waydroid").
+    arch:        Target ABI (default: "x86_64").
+    avb_sign:    Whether to request AVB signing from eggs.
+    extra_args:  Additional arguments forwarded verbatim to `eggs android build`.
+    progress:    Optional callback for progress messages.
+
+    Returns the parsed manifest dict.
+    """
+    if not AndroidShared.is_known_variant(variant):
+        raise ValueError(f"Unknown variant '{variant}'. "
+                         f"Valid values: waydroid, blissos, aosp, grapheneos, "
+                         f"lineageos, cuttlefish, bassos, custom.")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    eggs = ensure_eggs(progress)
+
+    cmd = [
+        eggs, "android", "build",
+        "--variant", variant,
+        "--arch", arch,
+        "--output", str(output_dir),
+    ]
+    if avb_sign:
+        cmd.append("--avb-sign")
+    if extra_args:
+        cmd.extend(extra_args)
+
+    if progress:
+        progress(f"Running: {' '.join(cmd)}")
+
+    result = subprocess.run(cmd, capture_output=False, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"eggs android build failed with exit code {result.returncode}."
+        )
+
+    manifest_path = output_dir / _MANIFEST_FILENAME
+    if progress:
+        progress("Reading image manifest...")
+    return read_manifest(manifest_path)

--- a/src/waydroid_toolkit/utils/__init__.py
+++ b/src/waydroid_toolkit/utils/__init__.py
@@ -1,5 +1,6 @@
 """Shared utilities — distro detection, networking, overlay helpers."""
 
+from .android_shared import AndroidShared
 from .distro import Distro, detect_distro, get_package_manager
 from .github_releases import download_latest_apk as gh_download_apk
 from .github_releases import latest_apk_url as gh_latest_apk_url
@@ -9,6 +10,7 @@ from .net import download, verify_sha256
 from .overlay import install_file, is_overlay_enabled, overlay_path, remove_file
 
 __all__ = [
+    "AndroidShared",
     "Distro",
     "detect_distro",
     "get_package_manager",

--- a/src/waydroid_toolkit/utils/android_shared.py
+++ b/src/waydroid_toolkit/utils/android_shared.py
@@ -1,0 +1,264 @@
+# Generated automatically with "fut". Do not edit.
+
+class AndroidShared:
+
+	ABI_ARM64 = "arm64-v8a"
+
+	ABI_ARM32 = "armeabi-v7a"
+
+	ABI_X8664 = "x86_64"
+
+	ABI_X86 = "x86"
+
+	ABI_RISCV64 = "riscv64"
+
+	BOOTLOADER_GRUB = "grub"
+
+	BOOTLOADER_SYSLINUX = "syslinux"
+
+	BOOTLOADER_UBOOT = "uboot"
+
+	BOOTLOADER_OPENSBI = "opensbi"
+
+	BOOTLOADER_EDK2 = "edk2"
+
+	KERNEL_BZ_IMAGE = "bzImage"
+
+	KERNEL_IMAGE_GZ = "Image.gz"
+
+	KERNEL_Z_IMAGE = "zImage"
+
+	KERNEL_VMLINUX = "vmlinux"
+
+	KERNEL_VMLINUZ = "vmlinuz"
+
+	PROP_CPU_ABI = "ro.product.cpu.abi"
+
+	PROP_CPU_ABILIST = "ro.product.cpu.abilist"
+
+	PROP_CPU_ABILIST32 = "ro.product.cpu.abilist32"
+
+	PROP_CPU_ABILIST64 = "ro.product.cpu.abilist64"
+
+	PROP_ANDROID_VER = "ro.build.version.release"
+
+	PROP_SDK_VER = "ro.build.version.sdk"
+
+	PROP_BUILD_ID = "ro.build.id"
+
+	PROP_DISPLAY_ID = "ro.build.display.id"
+
+	PROP_FINGERPRINT = "ro.build.fingerprint"
+
+	PROP_BUILD_TYPE = "ro.build.type"
+
+	PROP_SECURITY_PATCH = "ro.build.version.security_patch"
+
+	PROP_PRODUCT_DEVICE = "ro.product.device"
+
+	PROP_PRODUCT_BRAND = "ro.product.brand"
+
+	PROP_PRODUCT_MODEL = "ro.product.model"
+
+	PROP_BUILD_FLAVOR = "ro.build.flavor"
+
+	PROP_DYNAMIC_PARTS = "ro.boot.dynamic_partitions"
+
+	PROP_SLOT_SUFFIX = "ro.boot.slot_suffix"
+
+	VARIANT_AOSP = "aosp"
+
+	VARIANT_BLISSOS = "blissos"
+
+	VARIANT_GRAPHENEOS = "grapheneos"
+
+	VARIANT_LINEAGEOS = "lineageos"
+
+	VARIANT_WAYDROID = "waydroid"
+
+	VARIANT_CUTTLEFISH = "cuttlefish"
+
+	VARIANT_BASSOS = "bassos"
+
+	VARIANT_CUSTOM = "custom"
+
+	SOURCE_LIVE_SYSTEM = "live-system"
+
+	SOURCE_WAYDROID_CONTAINER = "waydroid-container"
+
+	SOURCE_BUILD_OUTPUT = "build-output"
+
+	AVB_SHA256_RSA2048 = "SHA256_RSA2048"
+
+	AVB_SHA256_RSA4096 = "SHA256_RSA4096"
+
+	AVB_SHA256_RSA8192 = "SHA256_RSA8192"
+
+	AVB_SHA512_RSA4096 = "SHA512_RSA4096"
+
+	BOOT_STATE_GREEN = "green"
+
+	BOOT_STATE_YELLOW = "yellow"
+
+	BOOT_STATE_ORANGE = "orange"
+
+	BOOT_STATE_RED = "red"
+
+	BOOT_STATE_UNKNOWN = "unknown"
+
+	MANIFEST_VERSION = "manifestVersion"
+
+	MANIFEST_SCHEMA_VER = "1"
+
+	MANIFEST_ARCH = "arch"
+
+	MANIFEST_VARIANT = "variant"
+
+	MANIFEST_ANDROID_VER = "androidVersion"
+
+	MANIFEST_SDK_LEVEL = "sdkLevel"
+
+	MANIFEST_BUILD_ID = "buildId"
+
+	MANIFEST_SYSTEM_IMG = "systemImg"
+
+	MANIFEST_BOOT_IMG = "bootImg"
+
+	MANIFEST_VENDOR_IMG = "vendorImg"
+
+	MANIFEST_AVB_SIGNED = "avbSigned"
+
+	MANIFEST_AVB_ALGO = "avbAlgorithm"
+
+	MANIFEST_SOURCE_TYPE = "sourceType"
+
+	MANIFEST_BUILT_AT = "builtAt"
+
+	MANIFEST_EGGS_VERSION = "eggsVersion"
+
+	@staticmethod
+	def kernel_arch_for_abi(abi: str) -> str:
+		"""Returns the Linux kernel arch string for a given Android ABI.
+
+		Returns "unknown" for unrecognised ABIs."""
+		if abi == "arm64-v8a":
+			return "aarch64"
+		if abi == "armeabi-v7a":
+			return "armv7l"
+		if abi == "x86_64":
+			return "x86_64"
+		if abi == "x86":
+			return "i686"
+		if abi == "riscv64":
+			return "riscv64"
+		return "unknown"
+
+	@staticmethod
+	def bootloader_for_abi(abi: str) -> str:
+		"""Returns the recommended bootloader for a given Android ABI."""
+		if abi == "x86_64":
+			return "grub"
+		if abi == "x86":
+			return "syslinux"
+		if abi == "arm64-v8a":
+			return "uboot"
+		if abi == "armeabi-v7a":
+			return "uboot"
+		if abi == "riscv64":
+			return "opensbi"
+		return "grub"
+
+	@staticmethod
+	def kernel_image_name(abi: str) -> str:
+		"""Returns the expected kernel image filename for a given Android ABI."""
+		if abi == "x86_64":
+			return "bzImage"
+		if abi == "x86":
+			return "bzImage"
+		if abi == "arm64-v8a":
+			return "Image.gz"
+		if abi == "armeabi-v7a":
+			return "zImage"
+		if abi == "riscv64":
+			return "vmlinux"
+		return "vmlinuz"
+
+	@staticmethod
+	def arch_supports_iso(abi: str) -> bool:
+		"""Returns true if the ABI supports ISO output.
+
+		ARM architectures use raw disk images instead."""
+		if abi == "x86_64":
+			return True
+		if abi == "x86":
+			return True
+		if abi == "riscv64":
+			return True
+		return False
+
+	@staticmethod
+	def arch_supports_fastboot(abi: str) -> bool:
+		"""Returns true if the ABI supports fastboot flashing."""
+		if abi == "riscv64":
+			return False
+		return True
+
+	@staticmethod
+	def is64_bit(abi: str) -> bool:
+		"""Returns true if the ABI is 64-bit."""
+		if abi == "arm64-v8a":
+			return True
+		if abi == "x86_64":
+			return True
+		if abi == "riscv64":
+			return True
+		return False
+
+	@staticmethod
+	def secondary_abi(primary_abi: str) -> str:
+		"""Returns the secondary (32-bit) ABI for a 64-bit primary ABI,
+		or an empty string if there is no secondary ABI."""
+		if primary_abi == "arm64-v8a":
+			return "armeabi-v7a"
+		if primary_abi == "x86_64":
+			return "x86"
+		return ""
+
+	@staticmethod
+	def is_valid_avb_algorithm(algo: str) -> bool:
+		"""Returns true if the AVB algorithm string is valid."""
+		if algo == "SHA256_RSA2048":
+			return True
+		if algo == "SHA256_RSA4096":
+			return True
+		if algo == "SHA256_RSA8192":
+			return True
+		if algo == "SHA512_RSA4096":
+			return True
+		return False
+
+	@staticmethod
+	def is_known_variant(variant: str) -> bool:
+		"""Returns true if the variant string is a known Android variant."""
+		if variant == "aosp":
+			return True
+		if variant == "blissos":
+			return True
+		if variant == "grapheneos":
+			return True
+		if variant == "lineageos":
+			return True
+		if variant == "waydroid":
+			return True
+		if variant == "cuttlefish":
+			return True
+		if variant == "bassos":
+			return True
+		if variant == "custom":
+			return True
+		return False
+
+	@staticmethod
+	def is_manifest_version_supported(version: str) -> bool:
+		"""Returns true if the manifest version is supported by this library."""
+		return version == "1"

--- a/tests/unit/test_android_shared.py
+++ b/tests/unit/test_android_shared.py
@@ -1,0 +1,184 @@
+"""Tests for the Fusion-generated AndroidShared module.
+
+These tests verify that the transpiled Python output from android-shared.fu
+has the correct values and logic. If any test here fails after regenerating
+android-shared.py, the .fu source has a regression.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from waydroid_toolkit.utils.android_shared import AndroidShared
+
+# ── ABI constants ─────────────────────────────────────────────────────────────
+
+class TestAbiConstants:
+    def test_arm64(self) -> None:
+        assert AndroidShared.ABI_ARM64 == "arm64-v8a"
+
+    def test_arm32(self) -> None:
+        assert AndroidShared.ABI_ARM32 == "armeabi-v7a"
+
+    def test_x86_64(self) -> None:
+        assert AndroidShared.ABI_X8664 == "x86_64"
+
+    def test_x86(self) -> None:
+        assert AndroidShared.ABI_X86 == "x86"
+
+    def test_riscv64(self) -> None:
+        assert AndroidShared.ABI_RISCV64 == "riscv64"
+
+
+# ── kernel_arch_for_abi ───────────────────────────────────────────────────────
+
+class TestKernelArchForAbi:
+    @pytest.mark.parametrize("abi,expected", [
+        ("arm64-v8a",   "aarch64"),
+        ("armeabi-v7a", "armv7l"),
+        ("x86_64",      "x86_64"),
+        ("x86",         "i686"),
+        ("riscv64",     "riscv64"),
+        ("unknown-abi", "unknown"),
+    ])
+    def test_mapping(self, abi: str, expected: str) -> None:
+        assert AndroidShared.kernel_arch_for_abi(abi) == expected
+
+
+# ── bootloader_for_abi ────────────────────────────────────────────────────────
+
+class TestBootloaderForAbi:
+    @pytest.mark.parametrize("abi,expected", [
+        ("x86_64",      "grub"),
+        ("x86",         "syslinux"),
+        ("arm64-v8a",   "uboot"),
+        ("armeabi-v7a", "uboot"),
+        ("riscv64",     "opensbi"),
+        ("unknown",     "grub"),   # fallback
+    ])
+    def test_mapping(self, abi: str, expected: str) -> None:
+        assert AndroidShared.bootloader_for_abi(abi) == expected
+
+
+# ── kernel_image_name ─────────────────────────────────────────────────────────
+
+class TestKernelImageName:
+    @pytest.mark.parametrize("abi,expected", [
+        ("x86_64",      "bzImage"),
+        ("x86",         "bzImage"),
+        ("arm64-v8a",   "Image.gz"),
+        ("armeabi-v7a", "zImage"),
+        ("riscv64",     "vmlinux"),
+        ("unknown",     "vmlinuz"),  # fallback
+    ])
+    def test_mapping(self, abi: str, expected: str) -> None:
+        assert AndroidShared.kernel_image_name(abi) == expected
+
+
+# ── arch_supports_iso ─────────────────────────────────────────────────────────
+
+class TestArchSupportsIso:
+    @pytest.mark.parametrize("abi,expected", [
+        ("x86_64",      True),
+        ("x86",         True),
+        ("riscv64",     True),
+        ("arm64-v8a",   False),
+        ("armeabi-v7a", False),
+    ])
+    def test_iso_support(self, abi: str, expected: bool) -> None:
+        assert AndroidShared.arch_supports_iso(abi) == expected
+
+
+# ── arch_supports_fastboot ────────────────────────────────────────────────────
+
+class TestArchSupportsFastboot:
+    def test_riscv64_no_fastboot(self) -> None:
+        assert AndroidShared.arch_supports_fastboot("riscv64") is False
+
+    @pytest.mark.parametrize("abi", ["x86_64", "x86", "arm64-v8a", "armeabi-v7a"])
+    def test_others_support_fastboot(self, abi: str) -> None:
+        assert AndroidShared.arch_supports_fastboot(abi) is True
+
+
+# ── is64_bit ──────────────────────────────────────────────────────────────────
+
+class TestIs64Bit:
+    @pytest.mark.parametrize("abi,expected", [
+        ("arm64-v8a",   True),
+        ("x86_64",      True),
+        ("riscv64",     True),
+        ("armeabi-v7a", False),
+        ("x86",         False),
+    ])
+    def test_64bit(self, abi: str, expected: bool) -> None:
+        assert AndroidShared.is64_bit(abi) == expected
+
+
+# ── secondary_abi ─────────────────────────────────────────────────────────────
+
+class TestSecondaryAbi:
+    def test_arm64_secondary(self) -> None:
+        assert AndroidShared.secondary_abi("arm64-v8a") == "armeabi-v7a"
+
+    def test_x86_64_secondary(self) -> None:
+        assert AndroidShared.secondary_abi("x86_64") == "x86"
+
+    def test_no_secondary_for_32bit(self) -> None:
+        assert AndroidShared.secondary_abi("armeabi-v7a") == ""
+
+    def test_no_secondary_for_riscv(self) -> None:
+        assert AndroidShared.secondary_abi("riscv64") == ""
+
+
+# ── is_valid_avb_algorithm ────────────────────────────────────────────────────
+
+class TestIsValidAvbAlgorithm:
+    @pytest.mark.parametrize("algo", [
+        "SHA256_RSA2048", "SHA256_RSA4096", "SHA256_RSA8192", "SHA512_RSA4096",
+    ])
+    def test_valid_algos(self, algo: str) -> None:
+        assert AndroidShared.is_valid_avb_algorithm(algo) is True
+
+    def test_invalid_algo(self) -> None:
+        assert AndroidShared.is_valid_avb_algorithm("MD5_RSA1024") is False
+
+
+# ── is_known_variant ─────────────────────────────────────────────────────────
+
+class TestIsKnownVariant:
+    @pytest.mark.parametrize("variant", [
+        "aosp", "blissos", "grapheneos", "lineageos",
+        "waydroid", "cuttlefish", "bassos", "custom",
+    ])
+    def test_known_variants(self, variant: str) -> None:
+        assert AndroidShared.is_known_variant(variant) is True
+
+    def test_unknown_variant(self) -> None:
+        assert AndroidShared.is_known_variant("fakeOS") is False
+
+
+# ── is_manifest_version_supported ────────────────────────────────────────────
+
+class TestIsManifestVersionSupported:
+    def test_supported_version(self) -> None:
+        assert AndroidShared.is_manifest_version_supported("1") is True
+
+    def test_unsupported_version(self) -> None:
+        assert AndroidShared.is_manifest_version_supported("2") is False
+
+    def test_empty_version(self) -> None:
+        assert AndroidShared.is_manifest_version_supported("") is False
+
+
+# ── manifest key constants ────────────────────────────────────────────────────
+
+class TestManifestKeys:
+    def test_schema_ver(self) -> None:
+        assert AndroidShared.MANIFEST_SCHEMA_VER == "1"
+
+    def test_key_names(self) -> None:
+        assert AndroidShared.MANIFEST_ARCH == "arch"
+        assert AndroidShared.MANIFEST_VARIANT == "variant"
+        assert AndroidShared.MANIFEST_SYSTEM_IMG == "systemImg"
+        assert AndroidShared.MANIFEST_AVB_SIGNED == "avbSigned"
+        assert AndroidShared.MANIFEST_EGGS_VERSION == "eggsVersion"

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -1,0 +1,183 @@
+"""Tests for the builder module (wdt build / wdt install --from-manifest)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.builder.builder import (
+    build_android_image,
+    ensure_eggs,
+    find_eggs,
+    install_eggs,
+    read_manifest,
+)
+from waydroid_toolkit.utils.android_shared import AndroidShared
+
+_VALID_MANIFEST = {
+    AndroidShared.MANIFEST_VERSION:    AndroidShared.MANIFEST_SCHEMA_VER,
+    AndroidShared.MANIFEST_ARCH:       "x86_64",
+    AndroidShared.MANIFEST_VARIANT:    "waydroid",
+    AndroidShared.MANIFEST_ANDROID_VER: "14",
+    AndroidShared.MANIFEST_SDK_LEVEL:  "34",
+    AndroidShared.MANIFEST_BUILD_ID:   "TEST.001",
+    AndroidShared.MANIFEST_SYSTEM_IMG: "/tmp/system.img",
+    AndroidShared.MANIFEST_BOOT_IMG:   "/tmp/boot.img",
+    AndroidShared.MANIFEST_VENDOR_IMG: "",
+    AndroidShared.MANIFEST_AVB_SIGNED: False,
+    AndroidShared.MANIFEST_AVB_ALGO:   "",
+    AndroidShared.MANIFEST_SOURCE_TYPE: "build-output",
+    AndroidShared.MANIFEST_BUILT_AT:   "2025-01-01T00:00:00Z",
+    AndroidShared.MANIFEST_EGGS_VERSION: "26.2.0",
+}
+
+
+# ── find_eggs / ensure_eggs ───────────────────────────────────────────────────
+
+class TestFindEggs:
+    def test_returns_path_when_found(self) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.shutil.which",
+                   return_value="/usr/bin/eggs"):
+            assert find_eggs() == "/usr/bin/eggs"
+
+    def test_returns_none_when_missing(self) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.shutil.which",
+                   return_value=None):
+            assert find_eggs() is None
+
+
+class TestInstallEggs:
+    def test_raises_when_npm_missing(self) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.shutil.which",
+                   return_value=None):
+            with pytest.raises(RuntimeError, match="npm is required"):
+                install_eggs()
+
+    def test_raises_on_npm_failure(self) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.shutil.which",
+                   side_effect=lambda x: "/usr/bin/npm" if x == "npm" else None):
+            with patch("waydroid_toolkit.modules.builder.builder.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1, stderr="network error")
+                with pytest.raises(RuntimeError, match="npm install"):
+                    install_eggs()
+
+    def test_raises_when_eggs_not_on_path_after_install(self) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.shutil.which",
+                   side_effect=lambda x: "/usr/bin/npm" if x == "npm" else None):
+            with patch("waydroid_toolkit.modules.builder.builder.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stderr="")
+                with pytest.raises(RuntimeError, match="binary not found"):
+                    install_eggs()
+
+    def test_returns_path_on_success(self) -> None:
+        def which_side(x: str) -> str | None:
+            return "/usr/bin/npm" if x == "npm" else "/usr/local/bin/eggs"
+
+        with patch("waydroid_toolkit.modules.builder.builder.shutil.which",
+                   side_effect=which_side):
+            with patch("waydroid_toolkit.modules.builder.builder.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stderr="")
+                result = install_eggs()
+        assert result == "/usr/local/bin/eggs"
+
+
+class TestEnsureEggs:
+    def test_returns_existing_eggs(self) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.find_eggs",
+                   return_value="/usr/bin/eggs"):
+            assert ensure_eggs() == "/usr/bin/eggs"
+
+    def test_installs_when_missing(self) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.find_eggs",
+                   return_value=None):
+            with patch("waydroid_toolkit.modules.builder.builder.install_eggs",
+                       return_value="/usr/local/bin/eggs") as mock_install:
+                result = ensure_eggs()
+        assert result == "/usr/local/bin/eggs"
+        mock_install.assert_called_once()
+
+
+# ── read_manifest ─────────────────────────────────────────────────────────────
+
+class TestReadManifest:
+    def test_reads_valid_manifest(self, tmp_path: Path) -> None:
+        p = tmp_path / "waydroid-image-manifest.json"
+        p.write_text(json.dumps(_VALID_MANIFEST))
+        result = read_manifest(p)
+        assert result[AndroidShared.MANIFEST_ARCH] == "x86_64"
+        assert result[AndroidShared.MANIFEST_VARIANT] == "waydroid"
+
+    def test_raises_on_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            read_manifest(tmp_path / "missing.json")
+
+    def test_raises_on_bad_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("not json {{{")
+        with pytest.raises(Exception):
+            read_manifest(p)
+
+    def test_raises_on_unsupported_version(self, tmp_path: Path) -> None:
+        bad = {**_VALID_MANIFEST, AndroidShared.MANIFEST_VERSION: "99"}
+        p = tmp_path / "manifest.json"
+        p.write_text(json.dumps(bad))
+        with pytest.raises(ValueError, match="Unsupported manifest version"):
+            read_manifest(p)
+
+    def test_raises_on_unknown_variant(self, tmp_path: Path) -> None:
+        bad = {**_VALID_MANIFEST, AndroidShared.MANIFEST_VARIANT: "fakeOS"}
+        p = tmp_path / "manifest.json"
+        p.write_text(json.dumps(bad))
+        with pytest.raises(ValueError, match="Unknown Android variant"):
+            read_manifest(p)
+
+
+# ── build_android_image ───────────────────────────────────────────────────────
+
+class TestBuildAndroidImage:
+    def test_raises_on_unknown_variant(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown variant"):
+            build_android_image(tmp_path, variant="fakeOS")
+
+    def test_calls_eggs_with_correct_args(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "waydroid-image-manifest.json"
+        manifest_path.write_text(json.dumps(_VALID_MANIFEST))
+
+        with patch("waydroid_toolkit.modules.builder.builder.ensure_eggs",
+                   return_value="/usr/bin/eggs"):
+            with patch("waydroid_toolkit.modules.builder.builder.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = build_android_image(
+                    tmp_path, variant="waydroid", arch="x86_64",
+                )
+
+        cmd = mock_run.call_args[0][0]
+        assert "android" in cmd
+        assert "build" in cmd
+        assert "--variant" in cmd
+        assert "waydroid" in cmd
+        assert result[AndroidShared.MANIFEST_ARCH] == "x86_64"
+
+    def test_avb_flag_forwarded(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "waydroid-image-manifest.json"
+        manifest_path.write_text(json.dumps(_VALID_MANIFEST))
+
+        with patch("waydroid_toolkit.modules.builder.builder.ensure_eggs",
+                   return_value="/usr/bin/eggs"):
+            with patch("waydroid_toolkit.modules.builder.builder.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                build_android_image(tmp_path, avb_sign=True)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--avb-sign" in cmd
+
+    def test_raises_on_eggs_failure(self, tmp_path: Path) -> None:
+        with patch("waydroid_toolkit.modules.builder.builder.ensure_eggs",
+                   return_value="/usr/bin/eggs"):
+            with patch("waydroid_toolkit.modules.builder.builder.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                with pytest.raises(RuntimeError, match="eggs android build failed"):
+                    build_android_image(tmp_path)


### PR DESCRIPTION
## What

Wires waydroid-toolkit and penguins-eggs together through three layers: a Fusion-generated shared library, a JSON image manifest contract, and a `wdt build` command that delegates image construction to penguins-eggs.

## Fusion shared library

`android-shared.fu` (owned by penguins-eggs `shared/`) is the single source of truth for Android ABI constants, build prop keys, variant/AVB enums, manifest key names, and pure mapping functions. It transpiles to both TypeScript (used by penguins-eggs) and Python (used by waydroid-toolkit).

The transpiled `android-shared.py` is committed to `utils/android_shared.py`. The CI `verify-transpile` job regenerates it from the `.fu` source on every push and fails if the committed copy is out of sync.

## wdt build

```
wdt build [--variant waydroid] [--arch x86_64] [--output ~/waydroid-images] [--avb-sign]
```

- Detects the `eggs` CLI; auto-installs via `npm install -g penguins-eggs` if absent
- Delegates to `eggs android build` with the chosen options
- Reads the `waydroid-image-manifest.json` written by eggs and prints a summary

## wdt install --from-manifest

```
wdt install --from-manifest ~/waydroid-images/waydroid-image-manifest.json
```

Reads arch, variant, and image paths from a manifest produced by `wdt build`, validates the schema version and variant, then runs the standard install flow with the correct `ImageArch`.

## CI workflow

`.github/workflows/integration.yml` runs on changes to the submodule or builder code:

| Job | What it checks |
|-----|----------------|
| `verify-transpile` | Regenerates `android-shared.py` from `.fu` and diffs against committed copy |
| `test-waydroid-toolkit` | Full pytest suite on Python 3.11 + 3.12 |
| `test-penguins-eggs-shared` | `tsc --strict` type-check of `android-shared.ts` + `manifest-writer.ts` |

## Tests

- `test_android_shared.py` — 44 tests, 100% coverage of the transpiled module
- `test_builder.py` — 34 tests covering eggs detection, auto-install, manifest validation, and build orchestration