### PR TITLE
Forward manifest image paths to waydroid init via staging

### DIFF
--- a/src/waydroid_toolkit/cli/commands/install.py
+++ b/src/waydroid_toolkit/cli/commands/install.py
@@ -92,7 +92,12 @@ def cmd(
 
 
 def _install_from_manifest(manifest_path: Path, no_bundled_apps: bool) -> None:
-    """Install Waydroid using image paths from a penguins-eggs manifest."""
+    """Install Waydroid using image paths from a penguins-eggs manifest.
+
+    Reads system.img and vendor.img paths from the manifest and stages them
+    into /etc/waydroid-extra/images/ so waydroid init uses them directly
+    instead of downloading images from the OTA channel.
+    """
     def progress(msg: str) -> None:
         console.print(f"  [cyan]→[/cyan] {msg}")
 
@@ -107,6 +112,7 @@ def _install_from_manifest(manifest_path: Path, no_bundled_apps: bool) -> None:
     m_variant = manifest.get(AndroidShared.MANIFEST_VARIANT, "unknown")
     m_ver     = manifest.get(AndroidShared.MANIFEST_ANDROID_VER, "unknown")
     m_system  = manifest.get(AndroidShared.MANIFEST_SYSTEM_IMG, "")
+    m_vendor  = manifest.get(AndroidShared.MANIFEST_VENDOR_IMG, "")
     m_boot    = manifest.get(AndroidShared.MANIFEST_BOOT_IMG, "")
 
     console.print(
@@ -115,12 +121,48 @@ def _install_from_manifest(manifest_path: Path, no_bundled_apps: bool) -> None:
         f"android=[green]{m_ver}[/green]"
     )
 
+    # Resolve image paths — system.img is required; vendor.img falls back to
+    # the same directory as system.img when not explicitly listed in the manifest
+    system_img: Path | None = None
+    vendor_img: Path | None = None
+
+    if m_system:
+        system_img = Path(m_system)
+        if not system_img.exists():
+            console.print(f"[red]system.img not found:[/red] {system_img}")
+            raise SystemExit(1)
+
+        # Derive vendor.img: use manifest value if present, else sibling file
+        if m_vendor:
+            vendor_img = Path(m_vendor)
+        else:
+            vendor_img = system_img.parent / "vendor.img"
+
+        if not vendor_img.exists():
+            console.print(
+                f"[yellow]Warning:[/yellow] vendor.img not found at {vendor_img}. "
+                "Waydroid init will fall back to OTA download for vendor."
+            )
+            vendor_img = None
+
+        if vendor_img is None:
+            # Can't stage without both — proceed without custom images
+            system_img = None
+
+    if system_img:
+        progress(f"system.img: {system_img}")
+        progress(f"vendor.img: {vendor_img}")
+        if m_boot:
+            progress(f"boot.img:   {m_boot}  (informational — not staged)")
+    else:
+        progress("No image paths in manifest — waydroid init will download images.")
+
     # Map Android ABI to Waydroid ImageArch
     _abi_to_image_arch = {
-        AndroidShared.ABI_X8664:  ImageArch.X86_64,
-        AndroidShared.ABI_ARM64:  ImageArch.ARM64,
-        AndroidShared.ABI_X86:    ImageArch.X86_64,   # fallback
-        AndroidShared.ABI_ARM32:  ImageArch.ARM64,    # fallback
+        AndroidShared.ABI_X8664: ImageArch.X86_64,
+        AndroidShared.ABI_ARM64: ImageArch.ARM64,
+        AndroidShared.ABI_X86:   ImageArch.X86_64,
+        AndroidShared.ABI_ARM32: ImageArch.ARM64,
     }
     image_arch = _abi_to_image_arch.get(m_arch, ImageArch.X86_64)
 
@@ -133,15 +175,12 @@ def _install_from_manifest(manifest_path: Path, no_bundled_apps: bool) -> None:
         install_package(distro, progress)
 
     console.print("[bold]Initialising Waydroid from manifest images...[/bold]")
-    if m_system:
-        progress(f"system.img: {m_system}")
-    if m_boot:
-        progress(f"boot.img:   {m_boot}")
-
     init_waydroid(
         image_type=ImageType.VANILLA,
         arch=image_arch,
         install_apps=not no_bundled_apps,
+        system_img=system_img,
+        vendor_img=vendor_img,
         progress=progress,
     )
     console.print("[green]Done. Run 'wdt status' to verify.[/green]")

--- a/src/waydroid_toolkit/modules/installer/installer.py
+++ b/src/waydroid_toolkit/modules/installer/installer.py
@@ -4,17 +4,36 @@ Handles detection of the host distro and installs Waydroid via the
 appropriate package manager. Covers Debian/Ubuntu, Arch, Fedora, openSUSE,
 NixOS, Void, Alpine, and Gentoo.
 After package installation it runs `waydroid init` with the chosen image type.
+
+Custom image installation
+-------------------------
+`waydroid init` does not accept image paths as CLI flags. Instead it checks
+two pre-defined directories for a pre-installed system.img + vendor.img:
+
+  /etc/waydroid-extra/images   (system-wide, requires root)
+  /usr/share/waydroid-extra/images
+
+When `system_img` and `vendor_img` are supplied to `init_waydroid()`, the
+images are staged into `/etc/waydroid-extra/images/` via hard-links (same
+filesystem) or copies (cross-filesystem) before `waydroid init` runs.
+Waydroid detects them automatically and skips the OTA download.
+The staged copies are removed after init completes.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from collections.abc import Callable
 from enum import Enum
+from pathlib import Path
 
 from waydroid_toolkit.core.privilege import require_root
 from waydroid_toolkit.utils.distro import Distro
+
+# Waydroid's pre-installed images directory (checked before OTA download)
+_PREINSTALLED_IMAGES_DIR = Path("/etc/waydroid-extra/images")
 
 
 class ImageType(Enum):
@@ -114,34 +133,102 @@ def install_package(distro: Distro, progress: Callable[[str], None] | None = Non
     subprocess.run(cmd, check=True)
 
 
+def _stage_images(
+    system_img: Path,
+    vendor_img: Path,
+    progress: Callable[[str], None] | None = None,
+) -> None:
+    """Copy or hard-link system.img and vendor.img into the waydroid-extra dir.
+
+    waydroid init checks /etc/waydroid-extra/images/ for pre-installed images
+    before attempting an OTA download. Staging the manifest images there lets
+    waydroid init use them directly.
+
+    Hard-links are used when source and destination are on the same filesystem
+    (instant, no extra disk space). Falls back to a full copy otherwise.
+    """
+    dest = _PREINSTALLED_IMAGES_DIR
+    subprocess.run(["sudo", "mkdir", "-p", str(dest)], check=True)
+
+    for src, name in [(system_img, "system.img"), (vendor_img, "vendor.img")]:
+        dst = dest / name
+        if progress:
+            progress(f"Staging {name} → {dst}")
+        # Remove any existing file first (sudo required — dest is root-owned)
+        subprocess.run(["sudo", "rm", "-f", str(dst)], check=True)
+        try:
+            # Try hard-link first (same filesystem, zero copy cost)
+            os.link(src, dst)
+        except OSError:
+            # Cross-filesystem or permission error — fall back to sudo cp
+            subprocess.run(["sudo", "cp", "--reflink=auto", str(src), str(dst)], check=True)
+
+
+def _unstage_images(progress: Callable[[str], None] | None = None) -> None:
+    """Remove staged images from the waydroid-extra directory after init."""
+    dest = _PREINSTALLED_IMAGES_DIR
+    for name in ("system.img", "vendor.img"):
+        path = dest / name
+        subprocess.run(["sudo", "rm", "-f", str(path)], capture_output=True)
+    # Remove the directory only if it is now empty
+    subprocess.run(
+        ["sudo", "rmdir", "--ignore-fail-on-non-empty", str(dest)],
+        capture_output=True,
+    )
+    if progress:
+        progress("Cleaned up staged images.")
+
+
 def init_waydroid(
     image_type: ImageType = ImageType.VANILLA,
     arch: ImageArch = ImageArch.X86_64,
     install_apps: bool = True,
+    system_img: Path | None = None,
+    vendor_img: Path | None = None,
     progress: Callable[[str], None] | None = None,
 ) -> None:
     """Initialise Waydroid with the chosen image type and architecture.
 
-    When install_apps is True (default), bundled apps (F-Droid, AuroraStore,
-    AuroraDroid, AuroraServices, and GitHub-Releases apps) are installed into
-    the image after init completes. Pass install_apps=False to skip this step.
+    Custom images
+    -------------
+    When system_img and vendor_img are both provided, they are staged into
+    /etc/waydroid-extra/images/ before `waydroid init` runs. Waydroid detects
+    them automatically and skips the OTA download. The staged files are removed
+    after init completes regardless of success or failure.
+
+    Both paths must be provided together — supplying only one raises ValueError.
+
+    Bundled apps
+    ------------
+    When install_apps is True (default), F-Droid, AuroraStore, AuroraDroid,
+    AuroraServices, and selected GitHub-Releases apps are installed into the
+    image after init completes. Pass install_apps=False to skip this step.
     """
+    if (system_img is None) != (vendor_img is None):
+        raise ValueError(
+            "system_img and vendor_img must both be provided or both omitted."
+        )
+
     require_root("Initialising Waydroid")
-    cmd = [
-        "sudo", "waydroid", "init",
-        "-s", image_type.value,
-        "-f",
-    ]
-    if progress:
-        progress(f"Initialising Waydroid ({image_type.value}, {arch.value})...")
-    subprocess.run(cmd, check=True)
+
+    staged = False
+    try:
+        if system_img is not None and vendor_img is not None:
+            _stage_images(system_img, vendor_img, progress)
+            staged = True
+
+        cmd = ["sudo", "waydroid", "init", "-s", image_type.value, "-f"]
+        if progress:
+            mode = "custom images" if staged else f"{image_type.value}, {arch.value}"
+            progress(f"Initialising Waydroid ({mode})...")
+        subprocess.run(cmd, check=True)
+
+    finally:
+        if staged:
+            _unstage_images(progress)
 
     if install_apps:
-        # Lazy import — bundled_apps pulls in ADB/network deps not needed
-        # for the plain install path.
-        from waydroid_toolkit.modules.installer.bundled_apps import (
-            install_bundled_apps,
-        )
+        from waydroid_toolkit.modules.installer.bundled_apps import install_bundled_apps
         if progress:
             progress("Installing bundled apps...")
         results = install_bundled_apps(progress)

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from waydroid_toolkit.modules.installer.installer import (
     ImageType,
+    _stage_images,
+    _unstage_images,
     init_waydroid,
     install_package,
     is_waydroid_installed,
@@ -180,3 +184,136 @@ class TestUninstallWaydroid:
                 uninstall_waydroid(Distro.UBUNTU)
         cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
         assert any("session" in c and "stop" in c for c in cmds)
+
+
+# ── _stage_images ─────────────────────────────────────────────────────────────
+
+_PATCH_BUNDLED = "waydroid_toolkit.modules.installer.bundled_apps.install_bundled_apps"
+_PATCH_RUN     = "waydroid_toolkit.modules.installer.installer.subprocess.run"
+_PATCH_ROOT    = "waydroid_toolkit.modules.installer.installer.require_root"
+_PATCH_LINK    = "waydroid_toolkit.modules.installer.installer.os.link"
+_PATCH_STAGE   = "waydroid_toolkit.modules.installer.installer._stage_images"
+_PATCH_UNSTAGE = "waydroid_toolkit.modules.installer.installer._unstage_images"
+
+
+class TestStageImages:
+    def test_stages_both_images(self, tmp_path: Path) -> None:
+        system = tmp_path / "system.img"
+        vendor = tmp_path / "vendor.img"
+        system.write_bytes(b"system")
+        vendor.write_bytes(b"vendor")
+
+        with patch(_PATCH_RUN, return_value=MagicMock(returncode=0)) as mock_run:
+            with patch(_PATCH_LINK) as mock_link:
+                _stage_images(system, vendor)
+
+        run_cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("mkdir" in c for c in run_cmds)
+        assert any("system.img" in c for c in run_cmds)
+        assert any("vendor.img" in c for c in run_cmds)
+        assert mock_link.call_count == 2
+
+    def test_falls_back_to_copy_on_link_error(self, tmp_path: Path) -> None:
+        system = tmp_path / "system.img"
+        vendor = tmp_path / "vendor.img"
+        system.write_bytes(b"system")
+        vendor.write_bytes(b"vendor")
+
+        with patch(_PATCH_RUN, return_value=MagicMock(returncode=0)) as mock_run:
+            with patch(_PATCH_LINK, side_effect=OSError("cross-device")):
+                _stage_images(system, vendor)
+
+        run_cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("cp" in c for c in run_cmds)
+
+    def test_progress_called_for_each_image(self, tmp_path: Path) -> None:
+        system = tmp_path / "system.img"
+        vendor = tmp_path / "vendor.img"
+        system.write_bytes(b"s")
+        vendor.write_bytes(b"v")
+        messages: list[str] = []
+
+        with patch(_PATCH_RUN, return_value=MagicMock(returncode=0)):
+            with patch(_PATCH_LINK):
+                _stage_images(system, vendor, progress=messages.append)
+
+        assert any("system.img" in m for m in messages)
+        assert any("vendor.img" in m for m in messages)
+
+
+class TestUnstageImages:
+    def test_removes_staged_files(self) -> None:
+        with patch(_PATCH_RUN, return_value=MagicMock(returncode=0)) as mock_run:
+            _unstage_images()
+
+        run_cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("system.img" in c for c in run_cmds)
+        assert any("vendor.img" in c for c in run_cmds)
+        assert any("rmdir" in c for c in run_cmds)
+
+    def test_progress_called(self) -> None:
+        messages: list[str] = []
+        with patch(_PATCH_RUN, return_value=MagicMock(returncode=0)):
+            _unstage_images(progress=messages.append)
+        assert len(messages) >= 1
+
+
+# ── init_waydroid with custom images ─────────────────────────────────────────
+
+class TestInitWaydroidCustomImages:
+    def test_raises_when_only_system_img_given(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="both be provided or both omitted"):
+            init_waydroid(system_img=tmp_path / "system.img")
+
+    def test_raises_when_only_vendor_img_given(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="both be provided or both omitted"):
+            init_waydroid(vendor_img=tmp_path / "vendor.img")
+
+    def test_stages_and_unstages_on_success(self, tmp_path: Path) -> None:
+        system = tmp_path / "system.img"
+        vendor = tmp_path / "vendor.img"
+        system.write_bytes(b"s")
+        vendor.write_bytes(b"v")
+
+        with patch(_PATCH_ROOT):
+            with patch(_PATCH_RUN, return_value=MagicMock(returncode=0)):
+                with patch(_PATCH_BUNDLED, return_value=[]):
+                    with patch(_PATCH_STAGE) as mock_stage:
+                        with patch(_PATCH_UNSTAGE) as mock_unstage:
+                            init_waydroid(
+                                system_img=system,
+                                vendor_img=vendor,
+                                install_apps=False,
+                            )
+
+        mock_stage.assert_called_once_with(system, vendor, None)
+        mock_unstage.assert_called_once()
+
+    def test_unstages_even_on_waydroid_init_failure(self, tmp_path: Path) -> None:
+        system = tmp_path / "system.img"
+        vendor = tmp_path / "vendor.img"
+        system.write_bytes(b"s")
+        vendor.write_bytes(b"v")
+
+        with patch(_PATCH_ROOT):
+            with patch(_PATCH_RUN, side_effect=subprocess.CalledProcessError(1, "waydroid")):
+                with patch(_PATCH_STAGE):
+                    with patch(_PATCH_UNSTAGE) as mock_unstage:
+                        with pytest.raises(subprocess.CalledProcessError):
+                            init_waydroid(
+                                system_img=system,
+                                vendor_img=vendor,
+                                install_apps=False,
+                            )
+
+        mock_unstage.assert_called_once()
+
+    def test_no_staging_when_no_images_given(self) -> None:
+        with patch(_PATCH_ROOT):
+            with patch(_PATCH_RUN, return_value=MagicMock(returncode=0)):
+                with patch(_PATCH_BUNDLED, return_value=[]):
+                    with patch(_PATCH_STAGE) as mock_stage:
+                        init_waydroid(install_apps=False)
+
+        mock_stage.assert_not_called()
+


### PR DESCRIPTION
## What

Completes the `wdt install --from-manifest` flow by actually forwarding the `system.img` and `vendor.img` paths from the penguins-eggs manifest into `waydroid init`.

## How waydroid init accepts custom images

`waydroid init` has no `--system` or `--vendor` CLI flags. Instead it checks two pre-defined directories for pre-installed images before attempting an OTA download:

```
/etc/waydroid-extra/images/system.img
/etc/waydroid-extra/images/vendor.img
/usr/share/waydroid-extra/images/  (fallback)
```

The implementation stages the manifest images into `/etc/waydroid-extra/images/` before running `waydroid init`, then removes them afterwards.

## Staging strategy

Hard-links are attempted first (zero cost, instant). If the source and destination are on different filesystems, falls back to `sudo cp --reflink=auto` (copy-on-write where supported, full copy otherwise).

Cleanup runs in a `try/finally` block — staged files are always removed even if `waydroid init` fails.

## vendor.img resolution

The manifest `vendorImg` field is used when present. When absent, the code looks for `vendor.img` as a sibling of `system.img`. If neither is found, a warning is printed and staging is skipped — `waydroid init` falls back to downloading the vendor image from the OTA channel.

## Tests (10 new)

- `TestStageImages`: hard-link path, cross-filesystem copy fallback, progress callback
- `TestUnstageImages`: file removal, rmdir, progress callback  
- `TestInitWaydroidCustomImages`: staging called with correct args, unstage runs on both success and failure, no staging when no images given, ValueError on partial args