### PR TITLE
feat: native adb shell fallback for Terminal tab

### DIFF
--- a/src/waydroid_toolkit/gui/app.py
+++ b/src/waydroid_toolkit/gui/app.py
@@ -67,6 +67,7 @@ def _setup_webengine() -> None:
 def _register_bridges(engine: QtQml.QQmlApplicationEngine) -> None:  # type: ignore[name-defined]
     """Instantiate all bridge objects and expose them as QML context properties."""
     from waydroid_toolkit.gui.bridge import (
+        AdbShellBridge,
         BackendBridge,
         BackupBridge,
         ExtensionsBridge,
@@ -88,6 +89,7 @@ def _register_bridges(engine: QtQml.QQmlApplicationEngine) -> None:  # type: ign
         "backupBridge":      BackupBridge(),
         "imagesBridge":      ImagesBridge(),
         "maintenanceBridge": MaintenanceBridge(),
+        "adbShellBridge":    AdbShellBridge(),
     }
 
     for name, bridge in bridges.items():

--- a/src/waydroid_toolkit/gui/bridge.py
+++ b/src/waydroid_toolkit/gui/bridge.py
@@ -19,6 +19,8 @@ All bridge classes inherit WdtBridgeBase which provides:
 
 from __future__ import annotations
 
+import subprocess
+import threading
 import traceback
 from collections.abc import Callable
 from typing import Any
@@ -451,3 +453,155 @@ class MaintenanceBridge(WdtBridgeBase):
             from waydroid_toolkit.modules.maintenance.tools import get_logcat
             return get_logcat()
         self._run(_do, on_done=lambda out: self.logcatOutput.emit(out))
+
+
+# ── ADB shell bridge ──────────────────────────────────────────────────────────
+
+class AdbShellBridge(QtCore.QObject):
+    """Interactive adb shell terminal bridge for the native fallback UI.
+
+    Maintains a persistent ``adb shell`` subprocess. A background thread
+    reads stdout line-by-line and emits ``lineReceived`` on the Qt thread
+    via a queued signal so QML can append each line to the terminal view.
+
+    Lifecycle
+    ---------
+    QML calls ``connect()`` when the Terminal page becomes visible.
+    The user types a command and QML calls ``sendLine(cmd)``.
+    QML calls ``disconnect()`` when leaving the page (or on window close).
+
+    If the persistent shell process dies unexpectedly ``sessionEnded`` is
+    emitted so QML can show a reconnect prompt.
+    """
+
+    # Emitted for every line of output from the shell (including the prompt)
+    lineReceived = Signal(str)
+    # Emitted when the adb connection state changes
+    connectedChanged = Signal()
+    # Emitted when the shell process exits (code, or -1 on read error)
+    sessionEnded = Signal(int)
+    # Emitted when adb is not on PATH or the device is unreachable
+    errorOccurred = Signal(str)
+
+    _ADB_TARGET = "192.168.250.1:5555"
+
+    def __init__(self, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self._proc: subprocess.Popen | None = None
+        self._reader: threading.Thread | None = None
+        self._connected = False
+
+    # ── Public properties ─────────────────────────────────────────────────
+
+    @Property(bool, notify=connectedChanged)
+    def connected(self) -> bool:
+        return self._connected
+
+    # ── Slots ─────────────────────────────────────────────────────────────
+
+    @Slot()
+    def connectShell(self) -> None:
+        """Open a persistent ``adb shell`` session to Waydroid."""
+        if self._proc is not None:
+            return  # already open
+
+        try:
+            subprocess.run(
+                ["adb", "connect", self._ADB_TARGET],
+                capture_output=True, timeout=8, check=False,
+            )
+            self._proc = subprocess.Popen(
+                ["adb", "-s", self._ADB_TARGET, "shell"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+        except FileNotFoundError:
+            self.errorOccurred.emit(
+                "adb not found. Install android-tools-adb and try again."
+            )
+            return
+        except Exception:  # noqa: BLE001
+            self.errorOccurred.emit(traceback.format_exc())
+            return
+
+        self._set_connected(True)
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    @Slot()
+    def disconnectShell(self) -> None:
+        """Terminate the shell session."""
+        proc = self._proc
+        self._proc = None
+        self._set_connected(False)
+        if proc is not None:
+            try:
+                proc.stdin.close()  # type: ignore[union-attr]
+                proc.terminate()
+                proc.wait(timeout=3)
+            except Exception:  # noqa: BLE001
+                proc.kill()
+
+    @Slot(str)
+    def sendLine(self, line: str) -> None:
+        """Write *line* to the shell's stdin (newline appended automatically)."""
+        if self._proc is None or self._proc.stdin is None:
+            self.errorOccurred.emit("Shell is not connected.")
+            return
+        try:
+            self._proc.stdin.write(line + "\n")
+            self._proc.stdin.flush()
+        except BrokenPipeError:
+            self._handle_proc_exit(-1)
+
+    @Slot(str, result=str)
+    def runCommand(self, command: str) -> str:
+        """Run a single ``adb shell <command>`` and return combined output.
+
+        This is the one-shot fallback used when no persistent session is
+        open (e.g. the user hasn't pressed Connect yet).
+        """
+        try:
+            result = subprocess.run(
+                ["adb", "-s", self._ADB_TARGET, "shell", command],
+                capture_output=True, text=True, timeout=30,
+            )
+            return (result.stdout + result.stderr).rstrip()
+        except FileNotFoundError:
+            return "Error: adb not found. Install android-tools-adb."
+        except subprocess.TimeoutExpired:
+            return "Error: command timed out after 30 s."
+        except Exception:  # noqa: BLE001
+            return traceback.format_exc()
+
+    # ── Internal ──────────────────────────────────────────────────────────
+
+    def _set_connected(self, value: bool) -> None:
+        if self._connected != value:
+            self._connected = value
+            self.connectedChanged.emit()
+
+    def _read_loop(self) -> None:
+        """Background thread: read lines from the shell and emit signals."""
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            for line in proc.stdout:
+                if self._proc is None:
+                    break  # disconnectShell() was called
+                self.lineReceived.emit(line.rstrip("\n"))
+            code = proc.wait()
+        except Exception:  # noqa: BLE001
+            code = -1
+        # Only fire sessionEnded if we didn't initiate the disconnect
+        if self._proc is not None:
+            self._handle_proc_exit(code)
+
+    def _handle_proc_exit(self, code: int) -> None:
+        self._proc = None
+        self._set_connected(False)
+        self.sessionEnded.emit(code)

--- a/src/waydroid_toolkit/gui/qml/pages/TerminalPage.qml
+++ b/src/waydroid_toolkit/gui/qml/pages/TerminalPage.qml
@@ -1,5 +1,6 @@
-// TerminalPage.qml — wadb-powered ADB terminal via WebEngineView
-// Falls back to a plain text ADB shell output view when WebEngine is unavailable.
+// TerminalPage.qml
+// Uses QtWebEngineQuick + wadb when available; falls back to a native
+// adb shell REPL (AdbShellBridge) otherwise.
 import QtQuick
 import QtQuick.Controls.Material
 import QtQuick.Layouts
@@ -9,142 +10,287 @@ Page {
     id: root
     title: "Terminal"
 
-    // wadbHtmlUrl is set by the Python app.py to the local wadb HTML page URL
     property string wadbHtmlUrl: typeof _wadbUrl !== "undefined" ? _wadbUrl : ""
-    property bool webEngineAvailable: typeof WebEngineView !== "undefined"
+    property bool   webEngineAvailable: typeof WebEngineView !== "undefined"
+    property bool   useNative: !webEngineAvailable || wadbHtmlUrl === ""
 
+    // Maximum lines kept in the native terminal buffer
+    readonly property int maxLines: 2000
+
+    // ── Toolbar ───────────────────────────────────────────────────────────
+    header: Pane {
+        padding: 8
+        Material.elevation: 1
+
+        RowLayout {
+            width: parent.width
+            spacing: 8
+
+            Label {
+                text: "ADB Terminal"
+                font.pixelSize: 16
+                font.weight: Font.Medium
+                Layout.fillWidth: true
+            }
+
+            Label {
+                text: root.useNative ? "native adb shell" : "wadb (WebUSB)"
+                font.pixelSize: 12
+                color: Material.hintTextColor
+            }
+
+            // Connect / Disconnect button (native mode only)
+            Button {
+                visible: root.useNative
+                flat: true
+                Material.accent: Material.Teal
+                text: adbShellBridge.connected ? "Disconnect" : "Connect"
+                onClicked: adbShellBridge.connected
+                    ? adbShellBridge.disconnectShell()
+                    : adbShellBridge.connectShell()
+            }
+
+            // Reload button (WebEngine mode only)
+            Button {
+                visible: !root.useNative
+                flat: true
+                text: "Reload"
+                Material.accent: Material.Teal
+                onClicked: {
+                    if (webEngineLoader.item && webEngineLoader.item.reload) {
+                        webEngineLoader.item.reload()
+                    }
+                }
+            }
+        }
+    }
+
+    // ── WebEngine terminal (wadb) ─────────────────────────────────────────
+    Loader {
+        id: webEngineLoader
+        anchors.fill: parent
+        active: !root.useNative
+
+        sourceComponent: Component {
+            Item {
+                anchors.fill: parent
+                Component.onCompleted: {
+                    var comp = Qt.createComponent("WebEngineTerminal.qml")
+                    if (comp.status === Component.Ready) {
+                        comp.createObject(this, {
+                            anchors: { fill: this },
+                            url: root.wadbHtmlUrl
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Native adb shell REPL ─────────────────────────────────────────────
     ColumnLayout {
         anchors.fill: parent
+        anchors.margins: 0
         spacing: 0
+        visible: root.useNative
 
-        // ── Toolbar ───────────────────────────────────────────────────────
+        // Status banner shown when not connected
         Pane {
             Layout.fillWidth: true
             padding: 8
-            Material.elevation: 1
+            visible: !adbShellBridge.connected
+            background: Rectangle {
+                color: Material.color(Material.Orange, Material.Shade100)
+            }
+
+            Label {
+                width: parent.width
+                text: "Not connected — press Connect to open an adb shell session."
+                wrapMode: Text.WordWrap
+                font.pixelSize: 12
+                color: Material.color(Material.Orange, Material.Shade900)
+            }
+        }
+
+        // Output area
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            color: "#1a1a1a"
+
+            ScrollView {
+                id: outputScroll
+                anchors.fill: parent
+                anchors.margins: 8
+                clip: true
+                ScrollBar.horizontal.policy: ScrollBar.AsNeeded
+                ScrollBar.vertical.policy: ScrollBar.AsNeeded
+
+                TextArea {
+                    id: outputArea
+                    readOnly: true
+                    font.family: "monospace"
+                    font.pixelSize: 13
+                    color: "#d4d4d4"
+                    background: null
+                    wrapMode: Text.NoWrap
+                    selectByMouse: true
+                    text: "$ Press Connect to start an adb shell session.\n"
+
+                    onTextChanged: {
+                        Qt.callLater(function() {
+                            outputScroll.ScrollBar.vertical.position =
+                                1.0 - outputScroll.ScrollBar.vertical.size
+                        })
+                    }
+                }
+            }
+        }
+
+        // Input row
+        Pane {
+            Layout.fillWidth: true
+            padding: 8
+            Material.elevation: 2
 
             RowLayout {
                 width: parent.width
                 spacing: 8
 
                 Label {
-                    text: "ADB Terminal"
-                    font.pixelSize: 16
-                    font.weight: Font.Medium
-                    Layout.fillWidth: true
+                    text: "$"
+                    font.family: "monospace"
+                    font.pixelSize: 14
+                    color: adbShellBridge.connected
+                        ? Material.color(Material.Teal)
+                        : Material.hintTextColor
                 }
-
-                Label {
-                    text: webEngineAvailable ? "wadb (WebUSB)" : "native adb"
-                    font.pixelSize: 12
-                    color: Material.hintTextColor
-                }
-
-                Button {
-                    text: "Reconnect"
-                    flat: true
-                    Material.accent: Material.Teal
-                    onClicked: webEngineAvailable ? webView.reload() : nativeShell.refresh()
-                }
-            }
-        }
-
-        // ── WebEngine terminal (wadb) ─────────────────────────────────────
-        Loader {
-            id: webEngineLoader
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            active: root.webEngineAvailable && root.wadbHtmlUrl !== ""
-
-            sourceComponent: Component {
-                // WebEngineView is conditionally imported — use Loader to avoid
-                // import errors when QtWebEngine is not installed
-                Item {
-                    anchors.fill: parent
-
-                    // Dynamically create WebEngineView to avoid hard import
-                    Component.onCompleted: {
-                        var comp = Qt.createComponent("WebEngineTerminal.qml")
-                        if (comp.status === Component.Ready) {
-                            comp.createObject(this, { anchors: { fill: this }, url: root.wadbHtmlUrl })
-                        }
-                    }
-                }
-            }
-        }
-
-        // ── Fallback: native adb shell output ─────────────────────────────
-        ColumnLayout {
-            id: nativeShell
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            spacing: 8
-            padding: 16
-            visible: !root.webEngineAvailable || root.wadbHtmlUrl === ""
-
-            function refresh() {
-                maintenanceBridge.startLogcat()
-            }
-
-            Label {
-                text: "WebEngine not available — showing logcat output.\nInstall PySide6-WebEngine for the full wadb terminal."
-                wrapMode: Text.WordWrap
-                color: Material.hintTextColor
-                font.pixelSize: 12
-                Layout.fillWidth: true
-            }
-
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                color: "#1e1e1e"
-                radius: 6
-
-                ScrollView {
-                    anchors.fill: parent
-                    anchors.margins: 8
-                    clip: true
-
-                    TextArea {
-                        id: logOutput
-                        readOnly: true
-                        font.family: "monospace"
-                        font.pixelSize: 12
-                        color: "#d4d4d4"
-                        background: null
-                        wrapMode: Text.NoWrap
-
-                        Connections {
-                            target: maintenanceBridge
-                            function onLogcatOutput(output) { logOutput.text = output }
-                        }
-                    }
-                }
-            }
-
-            RowLayout {
-                Layout.fillWidth: true
 
                 TextField {
                     id: cmdField
                     Layout.fillWidth: true
-                    placeholderText: "adb shell command…"
+                    placeholderText: adbShellBridge.connected
+                        ? "Enter command…"
+                        : "Connect first…"
+                    enabled: adbShellBridge.connected
                     font.family: "monospace"
-                    onAccepted: runBtn.clicked()
+                    font.pixelSize: 13
+                    background: Rectangle {
+                        color: "#2a2a2a"
+                        radius: 4
+                        border.color: cmdField.activeFocus
+                            ? Material.color(Material.Teal)
+                            : "#444"
+                    }
+                    color: "#d4d4d4"
+
+                    Keys.onReturnPressed: root.sendCmd()
+                    Keys.onEnterPressed:  root.sendCmd()
+
+                    // Simple command history (up/down arrows)
+                    property var history: []
+                    property int historyIdx: -1
+
+                    Keys.onUpPressed: {
+                        if (history.length === 0) return
+                        historyIdx = Math.min(historyIdx + 1, history.length - 1)
+                        text = history[history.length - 1 - historyIdx]
+                    }
+                    Keys.onDownPressed: {
+                        if (historyIdx <= 0) {
+                            historyIdx = -1
+                            text = ""
+                            return
+                        }
+                        historyIdx--
+                        text = history[history.length - 1 - historyIdx]
+                    }
                 }
 
                 Button {
-                    id: runBtn
                     text: "Run"
+                    enabled: adbShellBridge.connected && cmdField.text.trim() !== ""
                     Material.accent: Material.Teal
-                    onClicked: {
-                        if (cmdField.text !== "") {
-                            maintenanceBridge.startLogcat()
-                            cmdField.clear()
-                        }
-                    }
+                    onClicked: root.sendCmd()
+                }
+
+                Button {
+                    text: "Clear"
+                    flat: true
+                    onClicked: outputArea.text = ""
                 }
             }
+        }
+    }
+
+    // ── Bridge signal handlers ────────────────────────────────────────────
+
+    Connections {
+        target: adbShellBridge
+
+        function onLineReceived(line) {
+            // Trim buffer to maxLines to avoid unbounded memory growth
+            var lines = outputArea.text.split("\n")
+            if (lines.length > root.maxLines) {
+                lines = lines.slice(lines.length - root.maxLines)
+                outputArea.text = lines.join("\n")
+            }
+            outputArea.text += line + "\n"
+        }
+
+        function onSessionEnded(code) {
+            var suffix = (code !== 0) ? " (exit " + code + ")" : ""
+            outputArea.text += "\n[Session ended" + suffix
+                + " — press Connect to reconnect]\n"
+        }
+
+        function onErrorOccurred(msg) {
+            outputArea.text += "\n[Error: " + msg + "]\n"
+        }
+
+        function onConnectedChanged() {
+            if (adbShellBridge.connected) {
+                outputArea.text += "[Connected]\n"
+                cmdField.forceActiveFocus()
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    function sendCmd() {
+        var cmd = cmdField.text.trim()
+        if (cmd === "") return
+
+        outputArea.text += "$ " + cmd + "\n"
+
+        // Save to history (avoid consecutive duplicates)
+        if (cmdField.history.length === 0 ||
+                cmdField.history[cmdField.history.length - 1] !== cmd) {
+            cmdField.history.push(cmd)
+        }
+        cmdField.historyIdx = -1
+        cmdField.text = ""
+
+        if (adbShellBridge.connected) {
+            adbShellBridge.sendLine(cmd)
+        } else {
+            // One-shot fallback when persistent session is not open
+            var out = adbShellBridge.runCommand(cmd)
+            outputArea.text += out + "\n"
+        }
+    }
+
+    // Auto-connect when the page is created (if in native mode)
+    Component.onCompleted: {
+        if (root.useNative) {
+            adbShellBridge.connectShell()
+        }
+    }
+
+    Component.onDestruction: {
+        if (root.useNative) {
+            adbShellBridge.disconnectShell()
         }
     }
 }

--- a/tests/unit/test_adb_shell_bridge.py
+++ b/tests/unit/test_adb_shell_bridge.py
@@ -1,0 +1,278 @@
+"""Tests for AdbShellBridge.
+
+Qt is not available in CI. The qt_compat module is stubbed out so that
+bridge.py can be imported and the AdbShellBridge logic tested in isolation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# ── Qt stubs (same pattern as test_gui_toast.py) ──────────────────────────────
+
+class _FakeSignal:
+    def __init__(self, *types_):
+        self._slots: list = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+
+    def emit(self, *args):
+        for slot in self._slots:
+            slot(*args)
+
+    def __call__(self, *types_):
+        return _FakeSignal(*types_)
+
+
+_signal_factory = _FakeSignal()
+
+
+class _FakeQObject:
+    def __init__(self, parent=None):
+        pass
+
+
+class _FakeQRunnable:
+    pass
+
+
+class _FakeQThreadPool:
+    @staticmethod
+    def globalInstance():
+        return _FakeQThreadPool()
+
+    def start(self, r):
+        pass
+
+
+_qtcore = types.SimpleNamespace(
+    QObject=_FakeQObject,
+    QRunnable=_FakeQRunnable,
+    QThreadPool=_FakeQThreadPool,
+    Signal=_signal_factory,
+    Slot=lambda *a, **kw: (lambda f: f),
+    Property=lambda *a, **kw: (lambda f: f),
+)
+_qtwidgets = types.SimpleNamespace(
+    QWidget=MagicMock,
+    QLabel=MagicMock,
+    QVBoxLayout=MagicMock,
+    QAbstractTableModel=MagicMock,
+    QTableView=MagicMock,
+    QHeaderView=MagicMock,
+    QSizePolicy=MagicMock,
+)
+
+_qt_compat_stub = types.ModuleType("waydroid_toolkit.gui.qt_compat")
+_qt_compat_stub.QtCore = _qtcore  # type: ignore[attr-defined]
+_qt_compat_stub.QtWidgets = _qtwidgets  # type: ignore[attr-defined]
+_qt_compat_stub.Signal = _signal_factory  # type: ignore[attr-defined]
+_qt_compat_stub.Slot = lambda *a, **kw: (lambda f: f)  # type: ignore[attr-defined]
+_qt_compat_stub.Property = lambda *a, **kw: (lambda f: f)  # type: ignore[attr-defined]
+_qt_compat_stub.QT_BINDING = "stub"  # type: ignore[attr-defined]
+_qt_compat_stub.HAS_WEBENGINE = False  # type: ignore[attr-defined]
+
+sys.modules["waydroid_toolkit.gui.qt_compat"] = _qt_compat_stub
+
+for _mod in list(sys.modules):
+    if _mod.startswith("waydroid_toolkit.gui.bridge"):
+        del sys.modules[_mod]
+
+from waydroid_toolkit.gui.bridge import AdbShellBridge  # noqa: E402
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_bridge() -> AdbShellBridge:
+    """Return an AdbShellBridge with live FakeSignals attached."""
+    bridge = object.__new__(AdbShellBridge)
+    bridge._proc = None
+    bridge._reader = None
+    bridge._connected = False
+    bridge.lineReceived    = _signal_factory(str)
+    bridge.connectedChanged = _signal_factory()
+    bridge.sessionEnded    = _signal_factory(int)
+    bridge.errorOccurred   = _signal_factory(str)
+    return bridge
+
+
+def _fake_popen(lines: list[str], returncode: int = 0) -> MagicMock:
+    """Return a mock Popen whose stdout yields *lines*."""
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.stdout = iter(lines)
+    proc.stdin = MagicMock()
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+# ── connectShell ──────────────────────────────────────────────────────────────
+
+class TestConnectShell:
+    def test_sets_connected_true(self) -> None:
+        bridge = _make_bridge()
+        # Patch Thread so the reader never runs and races the assertion
+        with patch("subprocess.run"), \
+             patch("subprocess.Popen", return_value=_fake_popen([])), \
+             patch("threading.Thread"):
+            bridge.connectShell()
+        assert bridge._connected is True
+
+    def test_emits_connectedChanged(self) -> None:
+        bridge = _make_bridge()
+        fired: list = []
+        bridge.connectedChanged.connect(lambda: fired.append(True))
+        with patch("subprocess.run"), \
+             patch("subprocess.Popen", return_value=_fake_popen([])), \
+             patch("threading.Thread"):
+            bridge.connectShell()
+        assert fired
+
+    def test_noop_when_already_connected(self) -> None:
+        bridge = _make_bridge()
+        bridge._proc = MagicMock()  # simulate existing session
+        bridge._connected = True
+        with patch("subprocess.Popen") as mock_popen:
+            bridge.connectShell()
+        mock_popen.assert_not_called()
+
+    def test_emits_error_when_adb_missing(self) -> None:
+        bridge = _make_bridge()
+        errors: list[str] = []
+        bridge.errorOccurred.connect(errors.append)
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            bridge.connectShell()
+        assert any("adb not found" in e for e in errors)
+        assert bridge._connected is False
+
+
+# ── disconnectShell ───────────────────────────────────────────────────────────
+
+class TestDisconnectShell:
+    def test_sets_connected_false(self) -> None:
+        bridge = _make_bridge()
+        proc = _fake_popen([])
+        bridge._proc = proc
+        bridge._connected = True
+        bridge.disconnectShell()
+        assert bridge._connected is False
+
+    def test_terminates_process(self) -> None:
+        bridge = _make_bridge()
+        proc = _fake_popen([])
+        bridge._proc = proc
+        bridge._connected = True
+        bridge.disconnectShell()
+        proc.terminate.assert_called_once()
+
+    def test_noop_when_not_connected(self) -> None:
+        bridge = _make_bridge()
+        bridge.disconnectShell()  # must not raise
+
+
+# ── sendLine ──────────────────────────────────────────────────────────────────
+
+class TestSendLine:
+    def test_writes_to_stdin(self) -> None:
+        bridge = _make_bridge()
+        proc = _fake_popen([])
+        bridge._proc = proc
+        bridge._connected = True
+        bridge.sendLine("ls /")
+        proc.stdin.write.assert_called_once_with("ls /\n")
+        proc.stdin.flush.assert_called_once()
+
+    def test_emits_error_when_not_connected(self) -> None:
+        bridge = _make_bridge()
+        errors: list[str] = []
+        bridge.errorOccurred.connect(errors.append)
+        bridge.sendLine("ls /")
+        assert errors
+
+    def test_handles_broken_pipe(self) -> None:
+        bridge = _make_bridge()
+        proc = _fake_popen([])
+        proc.stdin.write.side_effect = BrokenPipeError
+        bridge._proc = proc
+        bridge._connected = True
+        # Should not raise; should mark disconnected
+        bridge.sendLine("ls /")
+        assert bridge._connected is False
+
+
+# ── runCommand ────────────────────────────────────────────────────────────────
+
+class TestRunCommand:
+    def test_returns_stdout(self) -> None:
+        bridge = _make_bridge()
+        mock_result = MagicMock()
+        mock_result.stdout = "hello\n"
+        mock_result.stderr = ""
+        with patch("subprocess.run", return_value=mock_result):
+            out = bridge.runCommand("echo hello")
+        assert out == "hello"
+
+    def test_returns_error_when_adb_missing(self) -> None:
+        bridge = _make_bridge()
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            out = bridge.runCommand("ls")
+        assert "adb not found" in out
+
+    def test_returns_error_on_timeout(self) -> None:
+        bridge = _make_bridge()
+        with patch("subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd="adb", timeout=30)):
+            out = bridge.runCommand("sleep 999")
+        assert "timed out" in out
+
+
+# ── _read_loop ────────────────────────────────────────────────────────────────
+
+class TestReadLoop:
+    def test_emits_lines(self) -> None:
+        bridge = _make_bridge()
+        received: list[str] = []
+        bridge.lineReceived.connect(received.append)
+
+        proc = _fake_popen(["line1\n", "line2\n"])
+        bridge._proc = proc
+        bridge._connected = True
+
+        # Run the read loop synchronously (it's normally in a thread)
+        bridge._read_loop()
+
+        assert received == ["line1", "line2"]
+
+    def test_emits_sessionEnded_on_exit(self) -> None:
+        bridge = _make_bridge()
+        ended: list[int] = []
+        bridge.sessionEnded.connect(ended.append)
+
+        proc = _fake_popen([], returncode=1)
+        bridge._proc = proc
+        bridge._connected = True
+
+        bridge._read_loop()
+
+        assert ended == [1]
+
+    def test_no_sessionEnded_after_explicit_disconnect(self) -> None:
+        """If disconnectShell() clears _proc before the loop exits, no signal."""
+        bridge = _make_bridge()
+        ended: list[int] = []
+        bridge.sessionEnded.connect(ended.append)
+
+        proc = _fake_popen([])
+        bridge._proc = proc
+        bridge._connected = True
+
+        # Simulate disconnectShell() having cleared _proc before loop exits
+        bridge._proc = None
+        bridge._connected = False
+
+        bridge._read_loop()
+
+        assert ended == []


### PR DESCRIPTION
Resolves the known limitation where the Terminal tab showed a static logcat stub when `QtWebEngineQuick` was not installed.

## Changes

### `gui/bridge.py` — new `AdbShellBridge`
- Persistent `adb shell` subprocess managed via `subprocess.Popen`
- Background reader thread emits `lineReceived(str)` per line to QML
- `sendLine(cmd)` writes to stdin for the interactive session
- `runCommand(cmd)` one-shot fallback (no persistent session required)
- `connectShell()` / `disconnectShell()` lifecycle slots
- `sessionEnded(int)` emitted on unexpected process exit
- `FileNotFoundError` → `errorOccurred` signal (adb not on PATH)
- `BrokenPipeError` in `sendLine` handled without crash

### `gui/qml/pages/TerminalPage.qml` — rewritten native fallback
- Dark output buffer: monospace `TextArea`, auto-scroll, mouse-selectable
- Input field with up/down arrow command history
- Connect/Disconnect button in toolbar; orange banner when disconnected
- Buffer trimmed to 2 000 lines to bound memory use
- Auto-connects on page creation; disconnects on destruction

### `gui/app.py`
- Registers `adbShellBridge` as a QML context property

### `tests/unit/test_adb_shell_bridge.py`
- 16 tests: connect, disconnect, sendLine, runCommand, \_read\_loop
- Threading race in connect test avoided by patching `threading.Thread`

## Testing
- `pytest tests/ -q`: 463 passed, 0 failed
- `ruff check src/ tests/`: clean