### PR TITLE
feat: four v0.2 items — get_logcat fix, GApps extraction, OTA, logcat viewer

### DIFF
--- a/src/waydroid_toolkit/cli/commands/images.py
+++ b/src/waydroid_toolkit/cli/commands/images.py
@@ -4,7 +4,13 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from waydroid_toolkit.modules.images import get_active_profile, scan_profiles, switch_profile
+from waydroid_toolkit.modules.images import (
+    check_updates,
+    download_updates,
+    get_active_profile,
+    scan_profiles,
+    switch_profile,
+)
 
 console = Console()
 
@@ -59,3 +65,73 @@ def switch_image(profile_name: str, base: str | None) -> None:
 
     switch_profile(match, progress=lambda msg: console.print(f"  [cyan]→[/cyan] {msg}"))
     console.print(f"[green]Switched to profile '{profile_name}'.[/green]")
+
+
+@cmd.command("check-update")
+def check_update() -> None:
+    """Check OTA channels for available image updates."""
+    import urllib.error
+    try:
+        system_info, vendor_info = check_updates()
+    except urllib.error.URLError as exc:
+        console.print(f"[red]Network error: {exc}[/red]")
+        raise SystemExit(1)
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Channel")
+    table.add_column("Current build")
+    table.add_column("Latest build")
+    table.add_column("Status")
+
+    for info in (system_info, vendor_info):
+        current = str(info.current_datetime) if info.current_datetime else "none"
+        latest  = str(info.latest.datetime) if info.latest else "unavailable"
+        if info.update_available:
+            status = "[green]update available[/green]"
+        elif info.latest is None:
+            status = "[yellow]channel unavailable[/yellow]"
+        else:
+            status = "[dim]up to date[/dim]"
+        table.add_row(info.channel, current, latest, status)
+
+    console.print(table)
+
+
+@cmd.command("download")
+@click.option(
+    "--dest",
+    default=None,
+    help="Directory to save images (default: ~/waydroid-images/ota).",
+)
+@click.option(
+    "--no-update-cfg",
+    is_flag=True,
+    default=False,
+    help="Do not update system_datetime/vendor_datetime in waydroid.cfg.",
+)
+def download_image_cmd(dest: str | None, no_update_cfg: bool) -> None:
+    """Download the latest system and vendor images from the OTA channel."""
+    import urllib.error
+    from pathlib import Path
+
+    dest_dir = Path(dest) if dest else Path.home() / "waydroid-images" / "ota"
+
+    try:
+        system_path, vendor_path = download_updates(
+            dest_dir=dest_dir,
+            progress=lambda msg: console.print(f"  [cyan]→[/cyan] {msg}"),
+            update_cfg=not no_update_cfg,
+        )
+    except urllib.error.URLError as exc:
+        console.print(f"[red]Network error: {exc}[/red]")
+        raise SystemExit(1)
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1)
+
+    if system_path:
+        console.print(f"[green]System image: {system_path}[/green]")
+    if vendor_path:
+        console.print(f"[green]Vendor image: {vendor_path}[/green]")
+    if not system_path and not vendor_path:
+        console.print("[dim]No updates downloaded — images are already up to date.[/dim]")

--- a/src/waydroid_toolkit/core/waydroid.py
+++ b/src/waydroid_toolkit/core/waydroid.py
@@ -29,6 +29,10 @@ class WaydroidConfig:
     images_path: str = ""
     mount_overlays: bool = True
     suspend_action: str = "freeze"
+    system_ota: str = "https://ota.waydro.id/system"
+    vendor_ota: str = "https://ota.waydro.id/vendor"
+    system_datetime: int = 0
+    vendor_datetime: int = 0
     extra: dict[str, str] = field(default_factory=dict)
 
     @classmethod
@@ -42,6 +46,10 @@ class WaydroidConfig:
             images_path=waydroid_section.get("images_path", ""),
             mount_overlays=waydroid_section.get("mount_overlays", "true").lower() == "true",
             suspend_action=waydroid_section.get("suspend_action", "freeze"),
+            system_ota=waydroid_section.get("system_ota", "https://ota.waydro.id/system"),
+            vendor_ota=waydroid_section.get("vendor_ota", "https://ota.waydro.id/vendor"),
+            system_datetime=int(waydroid_section.get("system_datetime", "0")),
+            vendor_datetime=int(waydroid_section.get("vendor_datetime", "0")),
         )
 
 

--- a/src/waydroid_toolkit/gui/app.py
+++ b/src/waydroid_toolkit/gui/app.py
@@ -72,6 +72,7 @@ def _register_bridges(engine: QtQml.QQmlApplicationEngine) -> None:  # type: ign
         BackupBridge,
         ExtensionsBridge,
         ImagesBridge,
+        LogcatBridge,
         MaintenanceBridge,
         PackagesBridge,
         PerformanceBridge,
@@ -89,6 +90,7 @@ def _register_bridges(engine: QtQml.QQmlApplicationEngine) -> None:  # type: ign
         "backupBridge":      BackupBridge(),
         "imagesBridge":      ImagesBridge(),
         "maintenanceBridge": MaintenanceBridge(),
+        "logcatBridge":      LogcatBridge(),
         "adbShellBridge":    AdbShellBridge(),
     }
 

--- a/src/waydroid_toolkit/gui/bridge.py
+++ b/src/waydroid_toolkit/gui/bridge.py
@@ -455,6 +455,134 @@ class MaintenanceBridge(WdtBridgeBase):
         self._run(_do, on_done=lambda out: self.logcatOutput.emit(out))
 
 
+# ── Logcat bridge ─────────────────────────────────────────────────────────────
+
+class LogcatBridge(QtCore.QObject):
+    """Live logcat streaming bridge.
+
+    Wraps ``stream_logcat`` in a background thread and emits each line
+    to QML via ``lineReceived``. Supports tag and level filters that can
+    be changed while streaming is active (restarts the stream).
+
+    Lifecycle
+    ---------
+    QML calls ``start()`` to begin streaming.
+    QML calls ``stop()`` to terminate the stream.
+    ``streamingChanged`` is emitted whenever the running state changes.
+    """
+
+    lineReceived    = Signal(str)
+    streamingChanged = Signal()
+    errorOccurred   = Signal(str)
+
+    _LEVELS = ("V", "D", "I", "W", "E", "F")
+
+    def __init__(self, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self._streaming = False
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._tag: str = ""
+        self._level: str = ""   # empty = all levels
+
+    # ── Properties ────────────────────────────────────────────────────────
+
+    @Property(bool, notify=streamingChanged)
+    def streaming(self) -> bool:
+        return self._streaming
+
+    @Property(str)
+    def tag(self) -> str:
+        return self._tag
+
+    @Property(str)
+    def level(self) -> str:
+        return self._level
+
+    # ── Slots ──────────────────────────────────────────────────────────────
+
+    @Slot()
+    def start(self) -> None:
+        """Start (or restart) the logcat stream."""
+        self.stop()
+        self._stop_event.clear()
+        self._set_streaming(True)
+        self._thread = threading.Thread(target=self._stream_loop, daemon=True)
+        self._thread.start()
+
+    @Slot()
+    def stop(self) -> None:
+        """Stop the logcat stream."""
+        self._stop_event.set()
+        self._set_streaming(False)
+
+    @Slot(str)
+    def setTag(self, tag: str) -> None:
+        """Filter by tag. Empty string = no tag filter. Restarts stream."""
+        self._tag = tag.strip()
+        if self._streaming:
+            self.start()
+
+    @Slot(str)
+    def setLevel(self, level: str) -> None:
+        """Filter by minimum level (V/D/I/W/E/F). Empty = all. Restarts stream."""
+        lvl = level.strip().upper()
+        if lvl and lvl not in self._LEVELS:
+            self.errorOccurred.emit(
+                f"Unknown log level '{level}'. Valid: {', '.join(self._LEVELS)}"
+            )
+            return
+        self._level = lvl
+        if self._streaming:
+            self.start()
+
+    # ── Internal ──────────────────────────────────────────────────────────
+
+    def _set_streaming(self, value: bool) -> None:
+        if self._streaming != value:
+            self._streaming = value
+            self.streamingChanged.emit()
+
+    def _stream_loop(self) -> None:
+        """Background thread: read logcat lines and emit signals."""
+        try:
+            from waydroid_toolkit.modules.maintenance.tools import stream_logcat
+            errors_only = self._level == "E"
+            tag = self._tag or None
+            for line in stream_logcat(tag=tag, errors_only=errors_only):
+                if self._stop_event.is_set():
+                    break
+                # Client-side level filter when not using errors_only shortcut
+                if self._level and self._level not in ("E",):
+                    if not self._line_matches_level(line, self._level):
+                        continue
+                self.lineReceived.emit(line)
+        except Exception:  # noqa: BLE001
+            if not self._stop_event.is_set():
+                self.errorOccurred.emit(traceback.format_exc())
+        finally:
+            self._set_streaming(False)
+
+    @staticmethod
+    def _line_matches_level(line: str, min_level: str) -> bool:
+        """Return True if the logcat line is at or above *min_level*.
+
+        Standard logcat format: ``MM-DD HH:MM:SS.mmm PID TID LEVEL tag: msg``
+        The level character is at index 4 of the space-split tokens.
+        """
+        levels = LogcatBridge._LEVELS
+        try:
+            parts = line.split()
+            if len(parts) < 5:
+                return True  # can't parse — let it through
+            line_level = parts[4].upper()
+            if line_level not in levels:
+                return True
+            return levels.index(line_level) >= levels.index(min_level)
+        except (IndexError, ValueError):
+            return True
+
+
 # ── ADB shell bridge ──────────────────────────────────────────────────────────
 
 class AdbShellBridge(QtCore.QObject):

--- a/src/waydroid_toolkit/gui/qml/Main.qml
+++ b/src/waydroid_toolkit/gui/qml/Main.qml
@@ -30,6 +30,7 @@ ApplicationWindow {
         { id: "performance", label: "Performance", icon: "qrc:/icons/performance.svg", page: "pages/PerformancePage.qml" },
         { id: "backup",      label: "Backup",      icon: "qrc:/icons/backup.svg",      page: "pages/BackupPage.qml"      },
         { id: "maintenance", label: "Maintenance", icon: "qrc:/icons/maintenance.svg", page: "pages/MaintenancePage.qml" },
+        { id: "logcat",      label: "Logcat",      icon: "qrc:/icons/logcat.svg",      page: "pages/LogcatPage.qml"      },
         { id: "terminal",    label: "Terminal",    icon: "qrc:/icons/terminal.svg",    page: "pages/TerminalPage.qml"    },
     ]
 

--- a/src/waydroid_toolkit/gui/qml/pages/LogcatPage.qml
+++ b/src/waydroid_toolkit/gui/qml/pages/LogcatPage.qml
@@ -1,0 +1,179 @@
+// LogcatPage.qml — live logcat viewer with tag and level filters
+import QtQuick
+import QtQuick.Controls.Material
+import QtQuick.Layouts
+import "../components"
+
+Page {
+    id: root
+    title: "Logcat"
+
+    readonly property int maxLines: 3000
+    readonly property var levels: ["", "V", "D", "I", "W", "E", "F"]
+    readonly property var levelLabels: ["All", "Verbose", "Debug", "Info", "Warn", "Error", "Fatal"]
+
+    // ── Toolbar ───────────────────────────────────────────────────────────
+    header: Pane {
+        padding: 8
+        Material.elevation: 1
+
+        RowLayout {
+            width: parent.width
+            spacing: 8
+
+            Label {
+                text: "Logcat"
+                font.pixelSize: 16
+                font.weight: Font.Medium
+            }
+
+            // Tag filter
+            TextField {
+                id: tagField
+                placeholderText: "Tag filter…"
+                font.pixelSize: 12
+                implicitWidth: 140
+                onEditingFinished: logcatBridge.setTag(text)
+                Keys.onReturnPressed: logcatBridge.setTag(text)
+            }
+
+            // Level filter
+            ComboBox {
+                id: levelCombo
+                model: root.levelLabels
+                implicitWidth: 110
+                font.pixelSize: 12
+                onActivated: logcatBridge.setLevel(root.levels[currentIndex])
+            }
+
+            Item { Layout.fillWidth: true }
+
+            // Line count badge
+            Label {
+                text: lineCount + " lines"
+                font.pixelSize: 11
+                color: Material.hintTextColor
+                property int lineCount: outputArea.text.split("\n").length - 1
+            }
+
+            Button {
+                text: "Clear"
+                flat: true
+                onClicked: outputArea.text = ""
+            }
+
+            Button {
+                text: logcatBridge.streaming ? "Stop" : "Start"
+                flat: true
+                Material.accent: logcatBridge.streaming
+                    ? Material.Red : Material.Teal
+                highlighted: logcatBridge.streaming
+                onClicked: logcatBridge.streaming
+                    ? logcatBridge.stop()
+                    : logcatBridge.start()
+            }
+        }
+    }
+
+    // ── Output area ───────────────────────────────────────────────────────
+    Rectangle {
+        anchors.fill: parent
+        color: "#111"
+
+        ScrollView {
+            id: scroll
+            anchors.fill: parent
+            anchors.margins: 6
+            clip: true
+            ScrollBar.horizontal.policy: ScrollBar.AsNeeded
+            ScrollBar.vertical.policy: ScrollBar.AsNeeded
+
+            TextArea {
+                id: outputArea
+                readOnly: true
+                font.family: "monospace"
+                font.pixelSize: 12
+                color: "#d4d4d4"
+                background: null
+                wrapMode: Text.NoWrap
+                selectByMouse: true
+                text: ""
+
+                onTextChanged: {
+                    if (autoScrollCheck.checked) {
+                        Qt.callLater(function() {
+                            scroll.ScrollBar.vertical.position =
+                                1.0 - scroll.ScrollBar.vertical.size
+                        })
+                    }
+                }
+            }
+        }
+
+        // Auto-scroll toggle (bottom-right corner)
+        CheckBox {
+            id: autoScrollCheck
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            anchors.margins: 6
+            text: "Auto-scroll"
+            checked: true
+            font.pixelSize: 11
+            opacity: 0.7
+        }
+    }
+
+    // ── Bridge connections ────────────────────────────────────────────────
+
+    Connections {
+        target: logcatBridge
+
+        function onLineReceived(line) {
+            // Colour-code by level character (standard logcat format)
+            var coloured = root.colouriseLine(line)
+
+            // Trim buffer
+            var lines = outputArea.text.split("\n")
+            if (lines.length > root.maxLines) {
+                lines = lines.slice(lines.length - root.maxLines)
+                outputArea.text = lines.join("\n")
+            }
+            outputArea.text += coloured + "\n"
+        }
+
+        function onErrorOccurred(msg) {
+            outputArea.text += "\n[Error: " + msg + "]\n"
+        }
+
+        function onStreamingChanged() {
+            if (!logcatBridge.streaming && outputArea.text !== "") {
+                outputArea.text += "[Stream stopped]\n"
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    // Wrap a logcat line in a colour span based on the level token.
+    // Standard format: "MM-DD HH:MM:SS.mmm  PID  TID LEVEL tag: msg"
+    // The level is the 5th whitespace-delimited token (index 4).
+    function colouriseLine(line) {
+        var parts = line.split(/\s+/)
+        if (parts.length < 5) return line
+        var lvl = parts[4].toUpperCase()
+        // Return plain text — QML TextArea doesn't support rich text in
+        // readOnly mode without a TextEdit + textFormat:RichText, which
+        // has poor performance for large buffers. Prefix with a marker
+        // character so users can visually scan levels.
+        var prefix = ""
+        if      (lvl === "E" || lvl === "F") prefix = "✖ "
+        else if (lvl === "W")                prefix = "⚠ "
+        else if (lvl === "I")                prefix = "  "
+        else                                 prefix = "  "
+        return prefix + line
+    }
+
+    // Auto-start when the page becomes visible
+    Component.onCompleted: logcatBridge.start()
+    Component.onDestruction: logcatBridge.stop()
+}

--- a/src/waydroid_toolkit/modules/extensions/gapps.py
+++ b/src/waydroid_toolkit/modules/extensions/gapps.py
@@ -1,8 +1,41 @@
-"""Google Apps (OpenGApps) extension."""
+"""Google Apps extension.
+
+Supports two GApps sources depending on the target Android version:
+  - Android 11: OpenGApps pico (x86_64) from SourceForge
+  - Android 13: MindTheGapps (x86_64) from GitHub
+
+OpenGApps pico zip layout (Android 11)
+---------------------------------------
+The outer zip contains a ``Core/`` directory of per-app ``.tar.lz`` archives.
+Each archive unpacks to one of two shapes:
+
+  APK packages:
+    <AppName>/<dpi>/nodpi/<AppDir>/<AppName>.apk [+ lib/]
+    installed to overlay/system/priv-app/<AppDir>/
+
+  Non-APK (config/framework) packages:
+    <AppName>/common/<etc|framework|...>/...
+    installed to overlay/system/<etc|framework|...>/
+
+MindTheGapps zip layout (Android 13)
+--------------------------------------
+The zip contains a ``system/`` tree that maps 1:1 to the overlay:
+  system/priv-app/...  -> overlay/system/priv-app/...
+  system/product/...   -> overlay/system/product/...
+
+Host requirements
+-----------------
+OpenGApps extraction requires ``lzip`` and ``tar`` on PATH.
+MindTheGapps uses only Python's ``zipfile`` module.
+"""
 
 from __future__ import annotations
 
+import hashlib
+import shutil
 import subprocess
+import tempfile
+import zipfile
 from collections.abc import Callable
 from pathlib import Path
 
@@ -12,21 +45,262 @@ from waydroid_toolkit.utils.overlay import is_overlay_enabled
 
 from .base import Extension, ExtensionMeta
 
-# OpenGApps pico package for x86_64 Android 11
-_GAPPS_URL = (
-    "https://sourceforge.net/projects/opengapps/files/x86_64/20220503/"
-    "open_gapps-x86_64-11.0-pico-20220503.zip/download"
-)
-_MARKER = Path("/var/lib/waydroid/overlay/system/priv-app/PrebuiltGmsCore")
+# ── Download catalogue ────────────────────────────────────────────────────────
 
+_SOURCES: dict[str, dict[str, tuple[str, str]]] = {
+    "11": {
+        "x86_64": (
+            "https://sourceforge.net/projects/opengapps/files/x86_64/20220503/"
+            "open_gapps-x86_64-11.0-pico-20220503.zip/download",
+            "5a6d242be34ad1acf92899c7732afa1b",
+        ),
+        "x86": (
+            "https://sourceforge.net/projects/opengapps/files/x86/20220503/"
+            "open_gapps-x86-11.0-pico-20220503.zip/download",
+            "efda4943076016d00b40e0874b12ddd3",
+        ),
+        "arm64-v8a": (
+            "https://sourceforge.net/projects/opengapps/files/arm64/20220503/"
+            "open_gapps-arm64-11.0-pico-20220503.zip/download",
+            "7790055d34bbfc6fe610b0cd263a7add",
+        ),
+        "armeabi-v7a": (
+            "https://sourceforge.net/projects/opengapps/files/arm/20220215/"
+            "open_gapps-arm-11.0-pico-20220215.zip/download",
+            "8719519fa32ae83a62621c6056d32814",
+        ),
+    },
+    "13": {
+        "x86_64": (
+            "https://github.com/s1204IT/MindTheGappsBuilder/releases/download/"
+            "20231028/MindTheGapps-13.0.0-x86_64-20231028.zip",
+            "63ccebbf93d45c384f58d7c40049d398",
+        ),
+        "x86": (
+            "https://github.com/s1204IT/MindTheGappsBuilder/releases/download/"
+            "20231028/MindTheGapps-13.0.0-x86-20231028.zip",
+            "f12b6a8ed14eedbb4b5b3c932a865956",
+        ),
+        "arm64-v8a": (
+            "https://github.com/s1204IT/MindTheGappsBuilder/releases/download/"
+            "20231028/MindTheGapps-13.0.0-arm64-20231028.zip",
+            "11180da0a5d9f2ed2863882c30a8d556",
+        ),
+        "armeabi-v7a": (
+            "https://github.com/s1204IT/MindTheGappsBuilder/releases/download/"
+            "20231028/MindTheGapps-13.0.0-arm-20231028.zip",
+            "d525c980bac427844aa4cb01628f8a8f",
+        ),
+    },
+}
+
+# OpenGApps .tar.lz archives that contain config/framework files (not APKs)
+_NON_APK_ARCHIVES = frozenset({
+    "defaultetc-common.tar.lz",
+    "defaultframework-common.tar.lz",
+    "googlepixelconfig-common.tar.lz",
+    "vending-common.tar.lz",
+})
+
+# OpenGApps archives to skip entirely (setup wizard variants)
+_SKIP_ARCHIVES = frozenset({
+    "setupwizarddefault-x86_64.tar.lz",
+    "setupwizardtablet-x86_64.tar.lz",
+})
+
+_OVERLAY_ROOT = Path("/var/lib/waydroid/overlay")
+_CACHE_DIR = Path("/tmp/waydroid-toolkit")
+_MARKER = _OVERLAY_ROOT / "system" / "priv-app" / "PrebuiltGmsCore"
+
+# Overlay paths removed by uninstall (covers both Android 11 and 13 layouts)
+_UNINSTALL_TARGETS = [
+    "system/priv-app/PrebuiltGmsCore",
+    "system/priv-app/GoogleServicesFramework",
+    "system/priv-app/Phonesky",
+    "system/priv-app/ConfigUpdater",
+    "system/priv-app/GoogleExtServices",
+    "system/priv-app/GoogleExtShared",
+    "system/priv-app/GoogleFeedback",
+    "system/priv-app/GoogleBackupTransport",
+    "system/priv-app/GoogleOneTimeInitializer",
+    "system/priv-app/GoogleContactsSyncAdapter",
+    "system/priv-app/GooglePartnerSetup",
+    "system/priv-app/GoogleRestore",
+    "system/priv-app/CarrierSetup",
+    "system/priv-app/AndroidMigratePrebuilt",
+    "system/product/priv-app/GmsCore",
+    "system/product/priv-app/Phonesky",
+    "system/product/priv-app/Velvet",
+]
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _md5(path: Path) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def detect_arch() -> str:
+    """Return the Waydroid ABI string for the host CPU."""
+    import platform
+    machine = platform.machine().lower()
+    if machine == "x86_64":
+        return "x86_64"
+    if machine in ("i386", "i686", "x86"):
+        return "x86"
+    if machine == "aarch64":
+        return "arm64-v8a"
+    if machine.startswith("arm"):
+        return "armeabi-v7a"
+    return "x86_64"  # safe default for most Waydroid hosts
+
+
+def _check_lzip() -> None:
+    """Raise RuntimeError if lzip is not on PATH (needed for OpenGApps)."""
+    if shutil.which("lzip") is None:
+        raise RuntimeError(
+            "lzip is required to extract OpenGApps pico.\n"
+            "Install it with your package manager, e.g.:\n"
+            "  sudo apt install lzip        # Debian/Ubuntu\n"
+            "  sudo dnf install lzip        # Fedora\n"
+            "  sudo pacman -S lzip          # Arch"
+        )
+
+
+def _sudo_copytree(src: Path, dst: Path) -> None:
+    """Recursively copy src into dst using sudo (dst is root-owned overlay)."""
+    subprocess.run(["sudo", "mkdir", "-p", str(dst)], check=True)
+    for item in src.iterdir():
+        target = dst / item.name
+        if item.is_dir():
+            _sudo_copytree(item, target)
+        else:
+            subprocess.run(["sudo", "cp", "-f", str(item), str(target)], check=True)
+
+
+def install_opengapps_11(
+    zip_path: Path,
+    overlay_system: Path,
+    progress: Callable[[str], None] | None = None,
+) -> None:
+    """Extract and install an OpenGApps pico Android-11 zip into the overlay."""
+    _check_lzip()
+
+    with tempfile.TemporaryDirectory(prefix="wdt-gapps-") as tmp:
+        tmp_path = Path(tmp)
+        extract_dir = tmp_path / "extract"
+        appunpack = tmp_path / "appunpack"
+        extract_dir.mkdir()
+        appunpack.mkdir()
+
+        if progress:
+            progress("Unpacking outer GApps zip…")
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(extract_dir)
+
+        core_dir = extract_dir / "Core"
+        if not core_dir.is_dir():
+            raise RuntimeError(
+                f"Expected 'Core/' directory inside GApps zip, not found in {zip_path}"
+            )
+
+        for lz_file in sorted(core_dir.iterdir()):
+            name = lz_file.name
+            if name in _SKIP_ARCHIVES:
+                continue
+
+            # Clear appunpack between archives
+            for child in list(appunpack.iterdir()):
+                shutil.rmtree(child) if child.is_dir() else child.unlink()
+
+            if progress:
+                progress(f"Installing {name}…")
+
+            subprocess.run(
+                ["tar", "--lzip", "-xf", str(lz_file), "-C", str(appunpack)],
+                check=True,
+            )
+
+            app_name_dirs = list(appunpack.iterdir())
+            if not app_name_dirs:
+                continue
+            app_root = app_name_dirs[0]
+
+            if name in _NON_APK_ARCHIVES:
+                # Config/framework: <AppName>/common/<etc|framework|...>/
+                common_dir = app_root / "common"
+                if common_dir.is_dir():
+                    for content_dir in common_dir.iterdir():
+                        _sudo_copytree(content_dir, overlay_system / content_dir.name)
+            else:
+                # APK: <AppName>/<dpi>/nodpi/<AppDir>/
+                dpi_dirs = list(app_root.iterdir())
+                if not dpi_dirs:
+                    continue
+                dpi_dir = dpi_dirs[0]
+                nodpi = dpi_dir / "nodpi"
+                src_dir = nodpi if nodpi.is_dir() else dpi_dir
+                for app_dir in src_dir.iterdir():
+                    _sudo_copytree(app_dir, overlay_system / "priv-app" / app_dir.name)
+
+
+def install_mindthegapps_13(
+    zip_path: Path,
+    overlay_system: Path,
+    progress: Callable[[str], None] | None = None,
+) -> None:
+    """Extract and install a MindTheGapps Android-13 zip into the overlay."""
+    with tempfile.TemporaryDirectory(prefix="wdt-gapps-") as tmp:
+        tmp_path = Path(tmp)
+
+        if progress:
+            progress("Unpacking MindTheGapps zip…")
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(tmp_path)
+
+        src_system = tmp_path / "system"
+        if not src_system.is_dir():
+            raise RuntimeError(
+                f"Expected 'system/' directory inside MindTheGapps zip, "
+                f"not found in {zip_path}"
+            )
+
+        if progress:
+            progress("Copying files into overlay…")
+        _sudo_copytree(src_system, overlay_system)
+
+
+# ── Extension class ───────────────────────────────────────────────────────────
 
 class GAppsExtension(Extension):
+    """Installs Google Apps into the Waydroid overlay.
+
+    Defaults to Android 11 / OpenGApps pico. Pass ``android_version="13"``
+    to use MindTheGapps instead.
+    """
+
+    def __init__(self, android_version: str = "11") -> None:
+        if android_version not in _SOURCES:
+            raise ValueError(
+                f"Unsupported Android version '{android_version}'. "
+                f"Supported: {', '.join(sorted(_SOURCES))}"
+            )
+        self._android_version = android_version
+
     @property
     def meta(self) -> ExtensionMeta:
+        source = "OpenGApps pico" if self._android_version == "11" else "MindTheGapps"
         return ExtensionMeta(
             id="gapps",
-            name="Google Apps (OpenGApps pico)",
-            description="Installs OpenGApps pico into the Waydroid overlay.",
+            name=f"Google Apps ({source}, Android {self._android_version})",
+            description=(
+                f"Installs {source} into the Waydroid overlay "
+                f"(Android {self._android_version})."
+            ),
             requires_root=True,
             conflicts=["microg"],
         )
@@ -40,27 +314,60 @@ class GAppsExtension(Extension):
             raise RuntimeError(
                 "mount_overlays must be enabled in waydroid.cfg to install GApps."
             )
-        cache = Path("/tmp/waydroid-toolkit/gapps.zip")
-        if progress:
-            progress("Downloading OpenGApps pico...")
-        download(
-            _GAPPS_URL,
-            cache,
-            progress=lambda d, t: progress(f"Downloading... {d}/{t}") if progress else None,
-        )
-        if progress:
-            progress("Extracting GApps into overlay...")
-        extract_cmd = (
-            f"import zipfile; z=zipfile.ZipFile('{cache}'); z.extractall('/tmp/gapps_extract')"
-        )
-        subprocess.run(["sudo", "python3", "-c", extract_cmd], check=True)
-        # Actual extraction logic mirrors casualsnek/waydroid_script behaviour
+
+        arch = detect_arch()
+        version_sources = _SOURCES.get(self._android_version, {})
+        if arch not in version_sources:
+            raise RuntimeError(
+                f"No GApps package available for arch '{arch}' / "
+                f"Android {self._android_version}."
+            )
+
+        url, expected_md5 = version_sources[arch]
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        cache = _CACHE_DIR / f"gapps-{self._android_version}-{arch}.zip"
+
+        # Re-use cached download if MD5 matches
+        if cache.exists() and _md5(cache) == expected_md5:
+            if progress:
+                progress("Using cached GApps zip.")
+        else:
+            if progress:
+                progress(f"Downloading GApps ({self._android_version}/{arch})…")
+            download(
+                url,
+                cache,
+                progress=(
+                    (lambda d, t: progress(f"Downloading… {d}/{t} bytes"))
+                    if progress else None
+                ),
+            )
+            actual = _md5(cache)
+            if actual != expected_md5:
+                cache.unlink(missing_ok=True)
+                raise RuntimeError(
+                    f"GApps zip MD5 mismatch: expected {expected_md5}, got {actual}. "
+                    "The download may be corrupt. Try again."
+                )
+
+        overlay_system = _OVERLAY_ROOT / "system"
+        subprocess.run(["sudo", "mkdir", "-p", str(overlay_system)], check=True)
+
+        if self._android_version == "11":
+            install_opengapps_11(cache, overlay_system, progress)
+        else:
+            install_mindthegapps_13(cache, overlay_system, progress)
+
         if progress:
             progress("GApps installed. Restart Waydroid to apply.")
 
     def uninstall(self, progress: Callable[[str], None] | None = None) -> None:
         require_root("Uninstalling GApps")
-        if _MARKER.exists():
-            subprocess.run(["sudo", "rm", "-rf", str(_MARKER)], check=True)
+        for rel in _UNINSTALL_TARGETS:
+            target = _OVERLAY_ROOT / rel
+            if target.exists():
+                subprocess.run(["sudo", "rm", "-rf", str(target)], check=True)
+                if progress:
+                    progress(f"Removed {target.name}")
         if progress:
             progress("GApps removed from overlay.")

--- a/src/waydroid_toolkit/modules/images/__init__.py
+++ b/src/waydroid_toolkit/modules/images/__init__.py
@@ -1,5 +1,16 @@
 """Image profile management module."""
 
 from .manager import ImageProfile, get_active_profile, scan_profiles, switch_profile
+from .ota import OtaEntry, UpdateInfo, check_updates, download_image, download_updates
 
-__all__ = ["ImageProfile", "get_active_profile", "scan_profiles", "switch_profile"]
+__all__ = [
+    "ImageProfile",
+    "OtaEntry",
+    "UpdateInfo",
+    "check_updates",
+    "download_image",
+    "download_updates",
+    "get_active_profile",
+    "scan_profiles",
+    "switch_profile",
+]

--- a/src/waydroid_toolkit/modules/images/ota.py
+++ b/src/waydroid_toolkit/modules/images/ota.py
@@ -1,0 +1,245 @@
+"""Waydroid OTA image update checker and downloader.
+
+The Waydroid OTA server returns a JSON manifest at the channel URL:
+
+    GET https://ota.waydro.id/system
+    {"response": [
+        {
+            "datetime":  1680000000,
+            "filename":  "system.img.zip",
+            "url":       "https://...",
+            "id":        "<sha256hex>"
+        },
+        ...
+    ]}
+
+The ``datetime`` field is a Unix timestamp. An update is available when
+the server's latest ``datetime`` is greater than the value stored in
+``waydroid.cfg`` (``system_datetime`` / ``vendor_datetime``).
+
+The downloaded zip contains a single ``system.img`` or ``vendor.img``
+file that is extracted directly into the target images directory.
+"""
+
+from __future__ import annotations
+
+import configparser
+import hashlib
+import json
+import subprocess
+import tempfile
+import urllib.request
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from waydroid_toolkit.core.waydroid import WaydroidConfig
+
+_CFG_PATH = Path("/var/lib/waydroid/waydroid.cfg")
+_DOWNLOAD_TIMEOUT = 30  # seconds for the manifest fetch
+
+
+@dataclass
+class OtaEntry:
+    """A single entry from an OTA channel manifest."""
+
+    datetime: int
+    filename: str
+    url: str
+    sha256: str  # ``id`` field in the manifest
+
+
+@dataclass
+class UpdateInfo:
+    """Result of an update check for one image (system or vendor)."""
+
+    channel: str          # "system" or "vendor"
+    current_datetime: int
+    latest: OtaEntry | None  # None when the channel returned no entries
+    update_available: bool
+
+
+# ── Manifest fetching ─────────────────────────────────────────────────────────
+
+def fetch_manifest(url: str, timeout: int = _DOWNLOAD_TIMEOUT) -> list[OtaEntry]:
+    """Fetch and parse an OTA channel manifest. Returns entries newest-first."""
+    req = urllib.request.Request(url, headers={"User-Agent": "waydroid-toolkit/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = json.loads(resp.read().decode())
+
+    entries = []
+    for item in data.get("response", []):
+        entries.append(OtaEntry(
+            datetime=int(item["datetime"]),
+            filename=item["filename"],
+            url=item["url"],
+            sha256=item["id"],
+        ))
+    # Sort newest first so entries[0] is always the latest build
+    entries.sort(key=lambda e: e.datetime, reverse=True)
+    return entries
+
+
+# ── Update check ──────────────────────────────────────────────────────────────
+
+def check_updates(cfg: WaydroidConfig | None = None) -> tuple[UpdateInfo, UpdateInfo]:
+    """Check both OTA channels for available updates.
+
+    Returns ``(system_info, vendor_info)``. Does not download anything.
+    Raises ``urllib.error.URLError`` / ``OSError`` on network failure.
+    """
+    if cfg is None:
+        cfg = WaydroidConfig.load()
+
+    def _check(channel: str, url: str, current_dt: int) -> UpdateInfo:
+        entries = fetch_manifest(url)
+        latest = entries[0] if entries else None
+        available = latest is not None and latest.datetime > current_dt
+        return UpdateInfo(
+            channel=channel,
+            current_datetime=current_dt,
+            latest=latest,
+            update_available=available,
+        )
+
+    system_info = _check("system", cfg.system_ota, cfg.system_datetime)
+    vendor_info  = _check("vendor", cfg.vendor_ota,  cfg.vendor_datetime)
+    return system_info, vendor_info
+
+
+# ── Download helpers ──────────────────────────────────────────────────────────
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _download_with_progress(
+    url: str,
+    dest: Path,
+    progress: Callable[[str], None] | None,
+) -> None:
+    """Stream *url* to *dest*, calling *progress* with human-readable status."""
+    req = urllib.request.Request(url, headers={"User-Agent": "waydroid-toolkit/1.0"})
+    with urllib.request.urlopen(req) as resp:
+        total = int(resp.headers.get("Content-Length", 0))
+        downloaded = 0
+        with dest.open("wb") as fh:
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                fh.write(chunk)
+                downloaded += len(chunk)
+                if progress and total:
+                    pct = downloaded * 100 // total
+                    mb = downloaded / 1_048_576
+                    total_mb = total / 1_048_576
+                    progress(f"  {mb:.1f} / {total_mb:.1f} MB ({pct}%)")
+
+
+def _save_datetime(channel: str, dt: int) -> None:
+    """Persist the updated datetime back to waydroid.cfg (requires root)."""
+    key = f"{channel}_datetime"
+    parser = configparser.ConfigParser()
+    if _CFG_PATH.exists():
+        parser.read(_CFG_PATH)
+    if "waydroid" not in parser:
+        parser["waydroid"] = {}
+    parser["waydroid"][key] = str(dt)
+    tmp = _CFG_PATH.with_suffix(".tmp")
+    with tmp.open("w") as fh:
+        parser.write(fh)
+    subprocess.run(["sudo", "mv", str(tmp), str(_CFG_PATH)], check=True)
+
+
+# ── Download + install ────────────────────────────────────────────────────────
+
+def download_image(
+    entry: OtaEntry,
+    dest_dir: Path,
+    progress: Callable[[str], None] | None = None,
+) -> Path:
+    """Download *entry* into *dest_dir*, verify SHA-256, extract the image.
+
+    Returns the path to the extracted ``.img`` file.
+    Raises ``RuntimeError`` on hash mismatch (partial download deleted).
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="wdt-ota-") as tmp:
+        tmp_path = Path(tmp)
+        zip_path = tmp_path / entry.filename
+
+        if progress:
+            progress(f"Downloading {entry.filename}…")
+        _download_with_progress(entry.url, zip_path, progress)
+
+        if progress:
+            progress("Verifying SHA-256…")
+        actual = _sha256(zip_path)
+        if actual != entry.sha256:
+            raise RuntimeError(
+                f"SHA-256 mismatch for {entry.filename}:\n"
+                f"  expected: {entry.sha256}\n"
+                f"  got:      {actual}\n"
+                "The download may be corrupt. Try again."
+            )
+
+        if progress:
+            progress(f"Extracting to {dest_dir}…")
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(dest_dir)
+
+        # Return the path to the extracted image (system.img or vendor.img)
+        img_name = entry.filename.replace(".zip", "")
+        return dest_dir / img_name
+
+
+def download_updates(
+    dest_dir: Path,
+    cfg: WaydroidConfig | None = None,
+    progress: Callable[[str], None] | None = None,
+    update_cfg: bool = True,
+) -> tuple[Path | None, Path | None]:
+    """Download any available system and vendor image updates.
+
+    Returns ``(system_img_path, vendor_img_path)``. Either may be ``None``
+    if that channel had no update available.
+
+    When *update_cfg* is True (default), persists the new ``datetime``
+    values to ``waydroid.cfg`` after each successful download.
+    """
+    if cfg is None:
+        cfg = WaydroidConfig.load()
+
+    system_path: Path | None = None
+    vendor_path: Path | None = None
+
+    system_info, vendor_info = check_updates(cfg)
+
+    if system_info.update_available and system_info.latest:
+        if progress:
+            progress("System image update available.")
+        system_path = download_image(system_info.latest, dest_dir, progress)
+        if update_cfg:
+            _save_datetime("system", system_info.latest.datetime)
+    else:
+        if progress:
+            progress("System image is up to date.")
+
+    if vendor_info.update_available and vendor_info.latest:
+        if progress:
+            progress("Vendor image update available.")
+        vendor_path = download_image(vendor_info.latest, dest_dir, progress)
+        if update_cfg:
+            _save_datetime("vendor", vendor_info.latest.datetime)
+    else:
+        if progress:
+            progress("Vendor image is up to date.")
+
+    return system_path, vendor_path

--- a/src/waydroid_toolkit/modules/maintenance/tools.py
+++ b/src/waydroid_toolkit/modules/maintenance/tools.py
@@ -100,6 +100,24 @@ def stream_logcat(
         proc.terminate()
 
 
+def get_logcat(
+    lines: int = 500,
+    tag: str | None = None,
+    errors_only: bool = False,
+) -> str:
+    """Return up to *lines* of logcat output as a single string.
+
+    Collects a bounded snapshot suitable for display in a text widget.
+    Use ``stream_logcat`` for live streaming.
+    """
+    collected: list[str] = []
+    for line in stream_logcat(tag=tag, errors_only=errors_only):
+        collected.append(line)
+        if len(collected) >= lines:
+            break
+    return "\n".join(collected)
+
+
 # ── App management ────────────────────────────────────────────────────────────
 
 def freeze_app(package: str) -> None:

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -104,20 +105,154 @@ class TestGAppsInstall:
     def test_raises_when_overlay_disabled(self) -> None:
         ext = get("gapps")
         with patch("waydroid_toolkit.modules.extensions.gapps.require_root"):
-            with patch("waydroid_toolkit.modules.extensions.gapps.is_overlay_enabled", return_value=False):
+            with patch("waydroid_toolkit.modules.extensions.gapps.is_overlay_enabled",
+                       return_value=False):
                 with pytest.raises(RuntimeError, match="mount_overlays"):
                     ext.install()
 
-    def test_uninstall_removes_marker(self) -> None:
+    def test_raises_on_unsupported_android_version(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import GAppsExtension
+        with pytest.raises(ValueError, match="Unsupported"):
+            GAppsExtension(android_version="99")
+
+    def test_android_13_meta_mentions_mindthegapps(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import GAppsExtension
+        ext = GAppsExtension(android_version="13")
+        assert "MindTheGapps" in ext.meta.name
+
+    def test_android_11_meta_mentions_opengapps(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import GAppsExtension
+        ext = GAppsExtension(android_version="11")
+        assert "OpenGApps" in ext.meta.name
+
+    def test_md5_mismatch_raises_and_deletes_cache(self, tmp_path: Path) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import GAppsExtension
+        ext = GAppsExtension(android_version="11")
+        bad_zip = tmp_path / "gapps-11-x86_64.zip"
+        bad_zip.write_bytes(b"corrupt")
+
+        with patch("waydroid_toolkit.modules.extensions.gapps.require_root"), \
+             patch("waydroid_toolkit.modules.extensions.gapps.is_overlay_enabled",
+                   return_value=True), \
+             patch("waydroid_toolkit.modules.extensions.gapps.detect_arch",
+                   return_value="x86_64"), \
+             patch("waydroid_toolkit.modules.extensions.gapps._CACHE_DIR", tmp_path), \
+             patch("waydroid_toolkit.modules.extensions.gapps.download"):
+            with pytest.raises(RuntimeError, match="MD5 mismatch"):
+                ext.install()
+        assert not bad_zip.exists()
+
+    def test_uses_cached_zip_when_md5_matches(self, tmp_path: Path) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import _SOURCES, GAppsExtension
+        ext = GAppsExtension(android_version="11")
+        _, expected_md5 = _SOURCES["11"]["x86_64"]
+
+        # Write a file whose MD5 matches the catalogue entry
+        cache = tmp_path / "gapps-11-x86_64.zip"
+        # We can't reproduce the real MD5 without the real file, so patch _md5
+        with patch("waydroid_toolkit.modules.extensions.gapps.require_root"), \
+             patch("waydroid_toolkit.modules.extensions.gapps.is_overlay_enabled",
+                   return_value=True), \
+             patch("waydroid_toolkit.modules.extensions.gapps.detect_arch",
+                   return_value="x86_64"), \
+             patch("waydroid_toolkit.modules.extensions.gapps._CACHE_DIR", tmp_path), \
+             patch("waydroid_toolkit.modules.extensions.gapps._md5",
+                   return_value=expected_md5), \
+             patch("waydroid_toolkit.modules.extensions.gapps.download") as mock_dl, \
+             patch("waydroid_toolkit.modules.extensions.gapps.subprocess.run",
+                   return_value=MagicMock(returncode=0)), \
+             patch("waydroid_toolkit.modules.extensions.gapps.install_opengapps_11"):
+            cache.write_bytes(b"fake")
+            messages: list[str] = []
+            ext.install(progress=messages.append)
+
+        mock_dl.assert_not_called()
+        assert any("cached" in m for m in messages)
+
+    def test_uninstall_removes_overlay_targets(self) -> None:
         ext = get("gapps")
-        with patch("waydroid_toolkit.modules.extensions.gapps.require_root"):
-            with patch("waydroid_toolkit.modules.extensions.gapps._MARKER") as mock_marker:
-                mock_marker.exists.return_value = True
-                with patch("waydroid_toolkit.modules.extensions.gapps.subprocess.run") as mock_run:
-                    mock_run.return_value = MagicMock(returncode=0)
-                    ext.uninstall()
+        with patch("waydroid_toolkit.modules.extensions.gapps.require_root"), \
+             patch("waydroid_toolkit.modules.extensions.gapps.subprocess.run",
+                   return_value=MagicMock(returncode=0)) as mock_run, \
+             patch("pathlib.Path.exists", return_value=True):
+            ext.uninstall()
         cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
         assert any("rm" in c for c in cmds)
+
+    def test_uninstall_skips_absent_targets(self) -> None:
+        ext = get("gapps")
+        with patch("waydroid_toolkit.modules.extensions.gapps.require_root"), \
+             patch("waydroid_toolkit.modules.extensions.gapps.subprocess.run",
+                   return_value=MagicMock(returncode=0)) as mock_run, \
+             patch("pathlib.Path.exists", return_value=False):
+            ext.uninstall()
+        # No rm calls when nothing exists
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert not any("rm" in c for c in cmds)
+
+
+class TestGAppsHelpers:
+    def test_detect_arch_x86_64(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import detect_arch
+        with patch("platform.machine", return_value="x86_64"):
+            assert detect_arch() == "x86_64"
+
+    def test_detect_arch_aarch64(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import detect_arch
+        with patch("platform.machine", return_value="aarch64"):
+            assert detect_arch() == "arm64-v8a"
+
+    def test_detect_arch_arm(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import detect_arch
+        with patch("platform.machine", return_value="armv7l"):
+            assert detect_arch() == "armeabi-v7a"
+
+    def test_check_lzip_raises_when_missing(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import _check_lzip
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="lzip"):
+                _check_lzip()
+
+    def test_check_lzip_passes_when_present(self) -> None:
+        from waydroid_toolkit.modules.extensions.gapps import _check_lzip
+        with patch("shutil.which", return_value="/usr/bin/lzip"):
+            _check_lzip()  # must not raise
+
+    def test_install_mindthegapps_13_copies_system_tree(self, tmp_path: Path) -> None:
+        import zipfile as zf
+
+        from waydroid_toolkit.modules.extensions.gapps import install_mindthegapps_13
+
+        # Build a minimal MindTheGapps zip: system/priv-app/GmsCore/GmsCore.apk
+        zip_path = tmp_path / "mtg.zip"
+        with zf.ZipFile(zip_path, "w") as z:
+            z.writestr("system/priv-app/GmsCore/GmsCore.apk", b"fake-apk")
+
+        overlay_system = tmp_path / "overlay" / "system"
+        overlay_system.mkdir(parents=True)
+
+        with patch("waydroid_toolkit.modules.extensions.gapps.subprocess.run",
+                   return_value=MagicMock(returncode=0)) as mock_run:
+            install_mindthegapps_13(zip_path, overlay_system)
+
+        # sudo mkdir -p and sudo cp should have been called
+        cmds = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert any("mkdir" in c for c in cmds)
+        assert any("cp" in c for c in cmds)
+
+    def test_install_mindthegapps_13_raises_on_missing_system_dir(
+        self, tmp_path: Path
+    ) -> None:
+        import zipfile as zf
+
+        from waydroid_toolkit.modules.extensions.gapps import install_mindthegapps_13
+
+        zip_path = tmp_path / "bad.zip"
+        with zf.ZipFile(zip_path, "w") as z:
+            z.writestr("README.txt", "no system dir here")
+
+        with pytest.raises(RuntimeError, match="system/"):
+            install_mindthegapps_13(zip_path, tmp_path / "overlay")
 
 
 class TestMicroGInstall:

--- a/tests/unit/test_logcat_bridge.py
+++ b/tests/unit/test_logcat_bridge.py
@@ -1,0 +1,282 @@
+"""Tests for LogcatBridge.
+
+Qt is not available in CI. The qt_compat module is stubbed so that
+bridge.py can be imported and LogcatBridge logic tested in isolation.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# ── Qt stubs (same pattern as test_adb_shell_bridge.py) ──────────────────────
+
+class _FakeSignal:
+    def __init__(self, *types_):
+        self._slots: list = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+
+    def emit(self, *args):
+        for slot in self._slots:
+            slot(*args)
+
+    def __call__(self, *types_):
+        return _FakeSignal(*types_)
+
+
+_signal_factory = _FakeSignal()
+
+
+class _FakeQObject:
+    def __init__(self, parent=None):
+        pass
+
+
+_qtcore = types.SimpleNamespace(
+    QObject=_FakeQObject,
+    QRunnable=MagicMock,
+    QThreadPool=MagicMock,
+    Signal=_signal_factory,
+    Slot=lambda *a, **kw: (lambda f: f),
+    Property=lambda *a, **kw: (lambda f: f),
+)
+_qtwidgets = types.SimpleNamespace(
+    QWidget=MagicMock,
+    QLabel=MagicMock,
+    QVBoxLayout=MagicMock,
+    QAbstractTableModel=MagicMock,
+    QTableView=MagicMock,
+    QHeaderView=MagicMock,
+    QSizePolicy=MagicMock,
+)
+
+_qt_compat_stub = types.ModuleType("waydroid_toolkit.gui.qt_compat")
+_qt_compat_stub.QtCore = _qtcore  # type: ignore[attr-defined]
+_qt_compat_stub.QtWidgets = _qtwidgets  # type: ignore[attr-defined]
+_qt_compat_stub.Signal = _signal_factory  # type: ignore[attr-defined]
+_qt_compat_stub.Slot = lambda *a, **kw: (lambda f: f)  # type: ignore[attr-defined]
+_qt_compat_stub.Property = lambda *a, **kw: (lambda f: f)  # type: ignore[attr-defined]
+_qt_compat_stub.QT_BINDING = "stub"  # type: ignore[attr-defined]
+_qt_compat_stub.HAS_WEBENGINE = False  # type: ignore[attr-defined]
+
+sys.modules["waydroid_toolkit.gui.qt_compat"] = _qt_compat_stub
+
+for _mod in list(sys.modules):
+    if _mod.startswith("waydroid_toolkit.gui.bridge"):
+        del sys.modules[_mod]
+
+from waydroid_toolkit.gui.bridge import LogcatBridge  # noqa: E402
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_bridge() -> LogcatBridge:
+    bridge = object.__new__(LogcatBridge)
+    import threading
+    bridge._streaming = False
+    bridge._thread = None
+    bridge._stop_event = threading.Event()
+    bridge._tag = ""
+    bridge._level = ""
+    bridge.lineReceived     = _signal_factory(str)
+    bridge.streamingChanged = _signal_factory()
+    bridge.errorOccurred    = _signal_factory(str)
+    return bridge
+
+
+# ── start / stop ──────────────────────────────────────────────────────────────
+
+class TestStartStop:
+    def test_start_sets_streaming_true(self) -> None:
+        bridge = _make_bridge()
+        with patch("threading.Thread"):
+            bridge.start()
+        assert bridge._streaming is True
+
+    def test_stop_sets_streaming_false(self) -> None:
+        bridge = _make_bridge()
+        with patch("threading.Thread"):
+            bridge.start()
+        bridge.stop()
+        assert bridge._streaming is False
+
+    def test_stop_sets_stop_event(self) -> None:
+        bridge = _make_bridge()
+        bridge.stop()
+        assert bridge._stop_event.is_set()
+
+    def test_start_emits_streamingChanged(self) -> None:
+        bridge = _make_bridge()
+        fired: list = []
+        bridge.streamingChanged.connect(lambda: fired.append(True))
+        with patch("threading.Thread"):
+            bridge.start()
+        assert fired
+
+    def test_start_restarts_if_already_streaming(self) -> None:
+        bridge = _make_bridge()
+        with patch("threading.Thread") as mock_thread:
+            bridge.start()
+            bridge.start()
+        # Thread constructor called twice
+        assert mock_thread.call_count == 2
+
+
+# ── setTag / setLevel ─────────────────────────────────────────────────────────
+
+class TestFilters:
+    def test_setTag_updates_tag(self) -> None:
+        bridge = _make_bridge()
+        bridge.setTag("MyApp")
+        assert bridge._tag == "MyApp"
+
+    def test_setTag_strips_whitespace(self) -> None:
+        bridge = _make_bridge()
+        bridge.setTag("  MyApp  ")
+        assert bridge._tag == "MyApp"
+
+    def test_setLevel_updates_level(self) -> None:
+        bridge = _make_bridge()
+        bridge.setLevel("W")
+        assert bridge._level == "W"
+
+    def test_setLevel_normalises_to_uppercase(self) -> None:
+        bridge = _make_bridge()
+        bridge.setLevel("e")
+        assert bridge._level == "E"
+
+    def test_setLevel_invalid_emits_error(self) -> None:
+        bridge = _make_bridge()
+        errors: list[str] = []
+        bridge.errorOccurred.connect(errors.append)
+        bridge.setLevel("X")
+        assert errors
+        assert bridge._level == ""  # unchanged
+
+    def test_setTag_restarts_stream_when_streaming(self) -> None:
+        bridge = _make_bridge()
+        with patch("threading.Thread"):
+            bridge.start()
+        with patch.object(bridge, "start") as mock_start:
+            bridge.setTag("foo")
+        mock_start.assert_called_once()
+
+    def test_setLevel_restarts_stream_when_streaming(self) -> None:
+        bridge = _make_bridge()
+        with patch("threading.Thread"):
+            bridge.start()
+        with patch.object(bridge, "start") as mock_start:
+            bridge.setLevel("W")
+        mock_start.assert_called_once()
+
+    def test_setTag_does_not_restart_when_stopped(self) -> None:
+        bridge = _make_bridge()
+        with patch.object(bridge, "start") as mock_start:
+            bridge.setTag("foo")
+        mock_start.assert_not_called()
+
+
+# ── _line_matches_level ───────────────────────────────────────────────────────
+
+class TestLineMatchesLevel:
+    # Standard logcat line: "01-01 00:00:00.000  123  456 W MyTag: message"
+    def _line(self, level: str) -> str:
+        return f"01-01 00:00:00.000  123  456 {level} MyTag: hello"
+
+    def test_exact_level_matches(self) -> None:
+        assert LogcatBridge._line_matches_level(self._line("W"), "W") is True
+
+    def test_higher_level_matches(self) -> None:
+        assert LogcatBridge._line_matches_level(self._line("E"), "W") is True
+
+    def test_lower_level_does_not_match(self) -> None:
+        assert LogcatBridge._line_matches_level(self._line("D"), "W") is False
+
+    def test_unparseable_line_passes_through(self) -> None:
+        assert LogcatBridge._line_matches_level("short", "E") is True
+
+    def test_unknown_level_in_line_passes_through(self) -> None:
+        assert LogcatBridge._line_matches_level(self._line("?"), "W") is True
+
+
+# ── _stream_loop ──────────────────────────────────────────────────────────────
+
+class TestStreamLoop:
+    def test_emits_lines(self) -> None:
+        bridge = _make_bridge()
+        received: list[str] = []
+        bridge.lineReceived.connect(received.append)
+
+        with patch(
+            "waydroid_toolkit.modules.maintenance.tools.stream_logcat",
+            return_value=iter(["line one", "line two"]),
+        ):
+            bridge._stream_loop()
+
+        assert received == ["line one", "line two"]
+
+    def test_stops_on_stop_event(self) -> None:
+        bridge = _make_bridge()
+        received: list[str] = []
+        bridge.lineReceived.connect(received.append)
+        bridge._stop_event.set()
+
+        with patch(
+            "waydroid_toolkit.modules.maintenance.tools.stream_logcat",
+            return_value=iter(["line one", "line two"]),
+        ):
+            bridge._stream_loop()
+
+        assert received == []
+
+    def test_emits_error_on_exception(self) -> None:
+        bridge = _make_bridge()
+        errors: list[str] = []
+        bridge.errorOccurred.connect(errors.append)
+
+        def _bad_stream(**kw):
+            raise RuntimeError("adb died")
+            yield  # make it a generator
+
+        with patch(
+            "waydroid_toolkit.modules.maintenance.tools.stream_logcat",
+            side_effect=_bad_stream,
+        ):
+            bridge._stream_loop()
+
+        assert errors
+
+    def test_sets_streaming_false_on_completion(self) -> None:
+        bridge = _make_bridge()
+        bridge._streaming = True
+
+        with patch(
+            "waydroid_toolkit.modules.maintenance.tools.stream_logcat",
+            return_value=iter([]),
+        ):
+            bridge._stream_loop()
+
+        assert bridge._streaming is False
+
+    def test_level_filter_applied(self) -> None:
+        bridge = _make_bridge()
+        bridge._level = "W"
+        received: list[str] = []
+        bridge.lineReceived.connect(received.append)
+
+        lines = [
+            "01-01 00:00:00.000  1  1 D tag: debug msg",
+            "01-01 00:00:00.000  1  1 W tag: warn msg",
+            "01-01 00:00:00.000  1  1 E tag: error msg",
+        ]
+        with patch(
+            "waydroid_toolkit.modules.maintenance.tools.stream_logcat",
+            return_value=iter(lines),
+        ):
+            bridge._stream_loop()
+
+        assert all("debug" not in line for line in received)
+        assert any("warn" in line for line in received)
+        assert any("error" in line for line in received)

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -13,6 +13,7 @@ from waydroid_toolkit.modules.maintenance.tools import (
     debloat,
     freeze_app,
     get_device_info,
+    get_logcat,
     launch_app,
     pull_file,
     push_file,
@@ -182,6 +183,43 @@ class TestStreamLogcat:
                    return_value=mock_proc) as mock_logcat:
             list(stream_logcat(tag="MyTag", errors_only=True))
         mock_logcat.assert_called_once_with(tag="MyTag", errors_only=True)
+
+
+class TestGetLogcat:
+    def _mock_logcat(self, lines: list[str]) -> MagicMock:
+        proc = MagicMock()
+        proc.stdout = iter(line + "\n" for line in lines)
+        return proc
+
+    def test_returns_joined_string(self) -> None:
+        proc = self._mock_logcat(["alpha", "beta", "gamma"])
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.logcat",
+                   return_value=proc):
+            result = get_logcat()
+        assert result == "alpha\nbeta\ngamma"
+
+    def test_respects_lines_limit(self) -> None:
+        proc = self._mock_logcat([f"line{i}" for i in range(100)])
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.logcat",
+                   return_value=proc):
+            result = get_logcat(lines=10)
+        assert result.count("\n") == 9  # 10 lines → 9 newlines
+        assert result.startswith("line0")
+        assert result.endswith("line9")
+
+    def test_empty_output_returns_empty_string(self) -> None:
+        proc = self._mock_logcat([])
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.logcat",
+                   return_value=proc):
+            result = get_logcat()
+        assert result == ""
+
+    def test_passes_tag_and_errors_only(self) -> None:
+        proc = self._mock_logcat([])
+        with patch("waydroid_toolkit.modules.maintenance.tools.adb.logcat",
+                   return_value=proc) as mock_logcat:
+            get_logcat(tag="WDT", errors_only=True)
+        mock_logcat.assert_called_once_with(tag="WDT", errors_only=True)
 
 
 # ── App management ────────────────────────────────────────────────────────────

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -1,0 +1,252 @@
+"""Tests for the OTA update checker and downloader."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.images.ota import (
+    OtaEntry,
+    _sha256,
+    check_updates,
+    download_image,
+    download_updates,
+    fetch_manifest,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _manifest_response(entries: list[dict]) -> MagicMock:
+    """Return a mock urllib response yielding a JSON manifest."""
+    body = json.dumps({"response": entries}).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.headers = {}
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _make_entry(dt: int = 1000, filename: str = "system.img.zip") -> dict:
+    return {"datetime": dt, "filename": filename, "url": "https://example.com/img.zip", "id": "abc123"}
+
+
+def _make_zip(tmp_path: Path, name: str, content: bytes = b"img") -> tuple[Path, str]:
+    """Create a zip containing *name* with *content*. Returns (zip_path, sha256)."""
+    zip_path = tmp_path / f"{name}.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr(name, content)
+    sha = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+    return zip_path, sha
+
+
+# ── fetch_manifest ────────────────────────────────────────────────────────────
+
+class TestFetchManifest:
+    def test_returns_entries_sorted_newest_first(self) -> None:
+        entries = [_make_entry(dt=100), _make_entry(dt=300), _make_entry(dt=200)]
+        with patch("urllib.request.urlopen", return_value=_manifest_response(entries)):
+            result = fetch_manifest("https://example.com/ota")
+        assert [e.datetime for e in result] == [300, 200, 100]
+
+    def test_returns_empty_list_on_empty_response(self) -> None:
+        with patch("urllib.request.urlopen",
+                   return_value=_manifest_response([])):
+            result = fetch_manifest("https://example.com/ota")
+        assert result == []
+
+    def test_maps_id_field_to_sha256(self) -> None:
+        with patch("urllib.request.urlopen",
+                   return_value=_manifest_response([_make_entry()])):
+            result = fetch_manifest("https://example.com/ota")
+        assert result[0].sha256 == "abc123"
+
+    def test_maps_all_fields(self) -> None:
+        entry = {"datetime": 9999, "filename": "vendor.img.zip",
+                 "url": "https://x.com/v.zip", "id": "deadbeef"}
+        with patch("urllib.request.urlopen",
+                   return_value=_manifest_response([entry])):
+            result = fetch_manifest("https://example.com/ota")
+        e = result[0]
+        assert e.datetime == 9999
+        assert e.filename == "vendor.img.zip"
+        assert e.url == "https://x.com/v.zip"
+        assert e.sha256 == "deadbeef"
+
+
+# ── check_updates ─────────────────────────────────────────────────────────────
+
+class TestCheckUpdates:
+    def _cfg(self, system_dt: int = 0, vendor_dt: int = 0) -> MagicMock:
+        cfg = MagicMock()
+        cfg.system_ota = "https://ota.waydro.id/system"
+        cfg.vendor_ota = "https://ota.waydro.id/vendor"
+        cfg.system_datetime = system_dt
+        cfg.vendor_datetime = vendor_dt
+        return cfg
+
+    def test_update_available_when_server_newer(self) -> None:
+        cfg = self._cfg(system_dt=100, vendor_dt=100)
+        with patch("waydroid_toolkit.modules.images.ota.fetch_manifest") as mock_fetch:
+            mock_fetch.return_value = [OtaEntry(datetime=200, filename="s.zip",
+                                                url="u", sha256="h")]
+            sys_info, _ = check_updates(cfg)
+        assert sys_info.update_available is True
+
+    def test_no_update_when_server_same_datetime(self) -> None:
+        cfg = self._cfg(system_dt=200, vendor_dt=200)
+        with patch("waydroid_toolkit.modules.images.ota.fetch_manifest") as mock_fetch:
+            mock_fetch.return_value = [OtaEntry(datetime=200, filename="s.zip",
+                                                url="u", sha256="h")]
+            sys_info, _ = check_updates(cfg)
+        assert sys_info.update_available is False
+
+    def test_no_update_when_channel_empty(self) -> None:
+        cfg = self._cfg()
+        with patch("waydroid_toolkit.modules.images.ota.fetch_manifest",
+                   return_value=[]):
+            sys_info, vendor_info = check_updates(cfg)
+        assert sys_info.update_available is False
+        assert sys_info.latest is None
+
+    def test_returns_both_channels(self) -> None:
+        cfg = self._cfg()
+        with patch("waydroid_toolkit.modules.images.ota.fetch_manifest") as mock_fetch:
+            mock_fetch.return_value = [OtaEntry(datetime=500, filename="x.zip",
+                                                url="u", sha256="h")]
+            sys_info, vendor_info = check_updates(cfg)
+        assert sys_info.channel == "system"
+        assert vendor_info.channel == "vendor"
+
+
+# ── _sha256 ───────────────────────────────────────────────────────────────────
+
+class TestSha256:
+    def test_matches_known_hash(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"hello")
+        expected = hashlib.sha256(b"hello").hexdigest()
+        assert _sha256(f) == expected
+
+
+# ── download_image ────────────────────────────────────────────────────────────
+
+class TestDownloadImage:
+    def test_extracts_img_and_returns_path(self, tmp_path: Path) -> None:
+        zip_path, sha = _make_zip(tmp_path, "system.img", b"fake-system")
+        entry = OtaEntry(datetime=1, filename="system.img.zip",
+                         url="https://x.com/s.zip", sha256=sha)
+
+        dest = tmp_path / "dest"
+
+        def _fake_download(url, dest_file, progress):
+            import shutil
+            shutil.copy(zip_path, dest_file)
+
+        with patch("waydroid_toolkit.modules.images.ota._download_with_progress",
+                   side_effect=_fake_download):
+            result = download_image(entry, dest)
+
+        assert result == dest / "system.img"
+
+    def test_raises_on_sha256_mismatch(self, tmp_path: Path) -> None:
+        zip_path, _ = _make_zip(tmp_path, "system.img")
+        entry = OtaEntry(datetime=1, filename="system.img.zip",
+                         url="https://x.com/s.zip", sha256="wronghash")
+
+        dest = tmp_path / "dest"
+
+        def _fake_download(url, dest_file, progress):
+            import shutil
+            shutil.copy(zip_path, dest_file)
+
+        with patch("waydroid_toolkit.modules.images.ota._download_with_progress",
+                   side_effect=_fake_download):
+            with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+                download_image(entry, dest)
+
+    def test_calls_progress(self, tmp_path: Path) -> None:
+        zip_path, sha = _make_zip(tmp_path, "vendor.img")
+        entry = OtaEntry(datetime=1, filename="vendor.img.zip",
+                         url="https://x.com/v.zip", sha256=sha)
+        dest = tmp_path / "dest"
+        messages: list[str] = []
+
+        def _fake_download(url, dest_file, progress):
+            import shutil
+            shutil.copy(zip_path, dest_file)
+
+        with patch("waydroid_toolkit.modules.images.ota._download_with_progress",
+                   side_effect=_fake_download):
+            download_image(entry, dest, progress=messages.append)
+
+        assert any("vendor.img.zip" in m for m in messages)
+
+
+# ── download_updates ──────────────────────────────────────────────────────────
+
+class TestDownloadUpdates:
+    def _cfg(self, system_dt: int = 0, vendor_dt: int = 0) -> MagicMock:
+        cfg = MagicMock()
+        cfg.system_ota = "https://ota.waydro.id/system"
+        cfg.vendor_ota = "https://ota.waydro.id/vendor"
+        cfg.system_datetime = system_dt
+        cfg.vendor_datetime = vendor_dt
+        return cfg
+
+    def test_returns_none_when_up_to_date(self, tmp_path: Path) -> None:
+        cfg = self._cfg(system_dt=999, vendor_dt=999)
+        with patch("waydroid_toolkit.modules.images.ota.fetch_manifest") as mock_fetch:
+            mock_fetch.return_value = [OtaEntry(datetime=999, filename="x.zip",
+                                                url="u", sha256="h")]
+            sys_path, vendor_path = download_updates(tmp_path, cfg=cfg, update_cfg=False)
+        assert sys_path is None
+        assert vendor_path is None
+
+    def test_downloads_when_update_available(self, tmp_path: Path) -> None:
+        cfg = self._cfg(system_dt=0, vendor_dt=0)
+        zip_path, sha = _make_zip(tmp_path, "system.img")
+        entry = OtaEntry(datetime=500, filename="system.img.zip", url="u", sha256=sha)
+
+        def _fake_download(url, dest_file, progress):
+            import shutil
+            shutil.copy(zip_path, dest_file)
+
+        with patch("waydroid_toolkit.modules.images.ota.fetch_manifest",
+                   return_value=[entry]), \
+             patch("waydroid_toolkit.modules.images.ota._download_with_progress",
+                   side_effect=_fake_download), \
+             patch("waydroid_toolkit.modules.images.ota._save_datetime"):
+            sys_path, vendor_path = download_updates(
+                tmp_path / "dest", cfg=cfg, update_cfg=True
+            )
+
+        assert sys_path is not None
+        assert sys_path.name == "system.img"
+
+    def test_saves_datetime_after_download(self, tmp_path: Path) -> None:
+        cfg = self._cfg(system_dt=0, vendor_dt=999)
+        zip_path, sha = _make_zip(tmp_path, "system.img")
+        entry = OtaEntry(datetime=500, filename="system.img.zip", url="u", sha256=sha)
+
+        def _fake_download(url, dest_file, progress):
+            import shutil
+            shutil.copy(zip_path, dest_file)
+
+        with patch("waydroid_toolkit.modules.images.ota.fetch_manifest") as mock_fetch, \
+             patch("waydroid_toolkit.modules.images.ota._download_with_progress",
+                   side_effect=_fake_download), \
+             patch("waydroid_toolkit.modules.images.ota._save_datetime") as mock_save:
+            # system has update (dt=0 < 500), vendor is up to date (dt=999 >= 999)
+            mock_fetch.side_effect = [
+                [entry],                                                    # system
+                [OtaEntry(datetime=999, filename="v.zip", url="u", sha256="h")],  # vendor
+            ]
+            download_updates(tmp_path / "dest", cfg=cfg, update_cfg=True)
+
+        mock_save.assert_called_once_with("system", 500)


### PR DESCRIPTION
## Summary

Four v0.2 roadmap items in one branch.

### 1 — Fix `get_logcat` (bug)
`MaintenanceBridge.startLogcat()` called `get_logcat()` which didn't exist — only `stream_logcat()` was defined. Added `get_logcat(lines, tag, errors_only)` as a bounded snapshot wrapper. 4 new tests.

### 2 — Complete GApps extraction
Replaced the stub `subprocess.run(["sudo", "python3", "-c", "zipfile..."])` with real extraction logic mirroring `casualsnek/waydroid_script`:
- **Android 11 / OpenGApps pico**: outer zip → `Core/*.tar.lz` → `priv-app/` (APK packages) or `system/<etc|framework>/` (non-APK packages) via `tar --lzip`
- **Android 13 / MindTheGapps**: `system/` tree copied directly into overlay
- MD5 verification with cache reuse; `lzip` presence check with install hint
- `detect_arch()` maps host CPU to Waydroid ABI string
- Uninstall removes all known GApps overlay paths (both layouts)
- 15 new tests

### 3 — OTA update checker + `wdt images download`
- `modules/images/ota.py`: `fetch_manifest()`, `check_updates()`, `download_image()`, `download_updates()`
- OTA manifest format: `{"response": [{"datetime", "url", "filename", "id"}]}` (waydro.id format)
- SHA-256 verification on every download
- `WaydroidConfig` gains `system_ota`, `vendor_ota`, `system_datetime`, `vendor_datetime`
- `wdt images check-update`: table of current vs latest datetime per channel
- `wdt images download`: download available updates, persist datetimes to `waydroid.cfg`
- 15 new tests

### 4 — LogcatBridge + live logcat viewer
- `LogcatBridge`: background thread wrapping `stream_logcat`; `setTag`/`setLevel` restart the stream; client-side level filter (V/D/I/W/E/F)
- `LogcatPage.qml`: dark output buffer, tag + level ComboBox, Start/Stop button, auto-scroll toggle, 3000-line buffer cap, ✖/⚠ level prefixes
- Registered as `logcatBridge` context property; added to nav rail
- 23 new tests

## Testing
- `pytest tests/ -q`: **518 passed**, 0 failed
- `ruff check src/ tests/`: clean