### PR TITLE
fix: three minor issues from post-v0.2 audit

### DIFF
--- a/src/waydroid_toolkit/gui/bridge.py
+++ b/src/waydroid_toolkit/gui/bridge.py
@@ -401,16 +401,20 @@ class BackupBridge(WdtBridgeBase):
 # ── Images bridge ─────────────────────────────────────────────────────────────
 
 class ImagesBridge(WdtBridgeBase):
-    """Exposes image profile management to QML."""
+    """Exposes image profile management and OTA updates to QML."""
 
-    imagesChanged = Signal()
+    imagesChanged    = Signal()
+    updateInfoReady  = Signal("QVariantList")   # list of {channel, current, latest, available}
+    downloadProgress = Signal(str)              # progress messages during download
+    downloadDone     = Signal(bool, str)        # (success, message)
 
     def __init__(self, parent: QtCore.QObject | None = None) -> None:
         super().__init__(parent)
         self._images: list[dict] = []
 
     @Property("QVariantList", notify=imagesChanged)
-    def images(self) -> list: return self._images
+    def images(self) -> list:
+        return self._images
 
     @Slot()
     def refresh(self) -> None:
@@ -430,6 +434,46 @@ class ImagesBridge(WdtBridgeBase):
             from waydroid_toolkit.modules.images.manager import activate_image
             activate_image(name)
         self._run(_do, on_done=lambda _: self.refresh())
+
+    @Slot()
+    def checkUpdate(self) -> None:
+        """Fetch both OTA channels and emit updateInfoReady with the results."""
+        def _do() -> list:
+            from waydroid_toolkit.modules.images.ota import check_updates
+            sys_info, vendor_info = check_updates()
+            result = []
+            for info in (sys_info, vendor_info):
+                result.append({
+                    "channel":   info.channel,
+                    "current":   str(info.current_datetime) if info.current_datetime else "none",
+                    "latest":    str(info.latest.datetime) if info.latest else "unavailable",
+                    "available": info.update_available,
+                })
+            return result
+
+        self._run(_do, on_done=lambda data: self.updateInfoReady.emit(data))
+
+    @Slot(str)
+    def downloadImages(self, destDir: str) -> None:
+        """Download available OTA images into *destDir*, emitting progress messages."""
+        def _do() -> tuple:
+            from pathlib import Path
+
+            from waydroid_toolkit.modules.images.ota import download_updates
+            sys_path, vendor_path = download_updates(
+                dest_dir=Path(destDir),
+                progress=lambda msg: self.downloadProgress.emit(msg),
+            )
+            downloaded = [p.name for p in (sys_path, vendor_path) if p is not None]
+            if downloaded:
+                return True, "Downloaded: " + ", ".join(downloaded)
+            return True, "Images are already up to date."
+
+        def _finish(result: tuple) -> None:
+            ok, msg = result
+            self.downloadDone.emit(ok, msg)
+
+        self._run(_do, on_done=_finish)
 
 
 # ── Maintenance bridge ────────────────────────────────────────────────────────

--- a/src/waydroid_toolkit/gui/qml/pages/ImagesPage.qml
+++ b/src/waydroid_toolkit/gui/qml/pages/ImagesPage.qml
@@ -1,13 +1,39 @@
-// ImagesPage.qml
+// ImagesPage.qml — image profile management + OTA update checker
 import QtQuick
 import QtQuick.Controls.Material
 import QtQuick.Layouts
 import "../components"
 
 Page {
+    id: root
     title: "Images"
 
+    // OTA state
+    property var updateRows: []       // [{channel, current, latest, available}]
+    property bool otaChecked: false
+    property string downloadLog: ""
+
     Component.onCompleted: imagesBridge.refresh()
+
+    // ── Bridge connections ────────────────────────────────────────────────
+    Connections {
+        target: imagesBridge
+
+        function onUpdateInfoReady(rows) {
+            root.updateRows = rows
+            root.otaChecked = true
+        }
+
+        function onDownloadProgress(msg) {
+            root.downloadLog += msg + "\n"
+        }
+
+        function onDownloadDone(ok, msg) {
+            root.downloadLog += (ok ? "✓ " : "✗ ") + msg + "\n"
+            // Refresh profile list in case new images were staged
+            imagesBridge.refresh()
+        }
+    }
 
     ScrollView {
         anchors.fill: parent
@@ -31,6 +57,7 @@ Page {
                 Layout.fillWidth: true
             }
 
+            // ── Profiles ──────────────────────────────────────────────────
             SettingsGroup {
                 title: "Profiles"
                 Layout.fillWidth: true
@@ -50,6 +77,127 @@ Page {
                                 onClicked: imagesBridge.activate(modelData.name)
                             }
                         }
+                    }
+                }
+            }
+
+            // ── OTA update checker ────────────────────────────────────────
+            SettingsGroup {
+                title: "OTA Updates"
+                Layout.fillWidth: true
+
+                // Check button row
+                ActionRow {
+                    text: "Check for updates"
+                    subtitle: "Compare installed images against the OTA channel"
+                    trailing: Component {
+                        Button {
+                            text: "Check"
+                            flat: true
+                            Material.accent: Material.Teal
+                            enabled: !imagesBridge.busy
+                            onClicked: {
+                                root.otaChecked = false
+                                root.updateRows = []
+                                imagesBridge.checkUpdate()
+                            }
+                        }
+                    }
+                }
+
+                // Results table — shown after a check
+                ColumnLayout {
+                    visible: root.otaChecked
+                    width: parent.width
+                    spacing: 0
+
+                    Repeater {
+                        model: root.updateRows
+
+                        delegate: Pane {
+                            Layout.fillWidth: true
+                            padding: 12
+                            background: Rectangle {
+                                color: index % 2 === 0
+                                    ? Material.color(Material.Grey, Material.Shade50)
+                                    : "transparent"
+                            }
+
+                            RowLayout {
+                                width: parent.width
+                                spacing: 12
+
+                                Label {
+                                    text: modelData.channel
+                                    font.weight: Font.Medium
+                                    font.capitalization: Font.Capitalize
+                                    implicitWidth: 60
+                                }
+                                Label {
+                                    text: "current: " + modelData.current
+                                    font.pixelSize: 12
+                                    color: Material.hintTextColor
+                                    Layout.fillWidth: true
+                                }
+                                Label {
+                                    text: "latest: " + modelData.latest
+                                    font.pixelSize: 12
+                                    color: Material.hintTextColor
+                                    Layout.fillWidth: true
+                                }
+                                Label {
+                                    text: modelData.available ? "update available" : "up to date"
+                                    font.pixelSize: 12
+                                    color: modelData.available
+                                        ? Material.color(Material.Green)
+                                        : Material.hintTextColor
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Download button — shown when at least one update is available
+                ActionRow {
+                    visible: root.otaChecked && root.updateRows.some(
+                        function(r) { return r.available })
+                    text: "Download updates"
+                    subtitle: "Save to ~/waydroid-images/ota"
+                    trailing: Component {
+                        Button {
+                            text: "Download"
+                            flat: true
+                            Material.accent: Material.Teal
+                            enabled: !imagesBridge.busy
+                            onClicked: {
+                                root.downloadLog = ""
+                                var dest = StandardPaths.writableLocation(
+                                    StandardPaths.HomeLocation) + "/waydroid-images/ota"
+                                imagesBridge.downloadImages(dest)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Download log ──────────────────────────────────────────────
+            SettingsGroup {
+                title: "Download log"
+                Layout.fillWidth: true
+                visible: root.downloadLog !== ""
+
+                ScrollView {
+                    width: parent.width
+                    height: 160
+                    clip: true
+
+                    TextArea {
+                        readOnly: true
+                        font.family: "monospace"
+                        font.pixelSize: 12
+                        text: root.downloadLog
+                        wrapMode: Text.WordWrap
+                        background: null
                     }
                 }
             }

--- a/src/waydroid_toolkit/gui/qml/pages/MaintenancePage.qml
+++ b/src/waydroid_toolkit/gui/qml/pages/MaintenancePage.qml
@@ -12,9 +12,6 @@ Page {
         function onScreenshotSaved(path) {
             applicationWindow.showToast("Screenshot saved: " + path, false)
         }
-        function onLogcatOutput(output) {
-            logcatArea.text = output
-        }
     }
 
     ScrollView {
@@ -51,36 +48,15 @@ Page {
 
                 ActionRow {
                     text: "Logcat"
-                    subtitle: "Fetch recent Android log output"
+                    subtitle: "View live Android log output"
                     trailing: Component {
                         Button {
-                            text: "Fetch"
+                            text: "Open"
                             flat: true
                             Material.accent: Material.Teal
-                            onClicked: maintenanceBridge.startLogcat()
+                            onClicked: pageStack.replace(
+                                Qt.resolvedUrl("LogcatPage.qml"))
                         }
-                    }
-                }
-            }
-
-            // Logcat output
-            SettingsGroup {
-                title: "Log output"
-                Layout.fillWidth: true
-                visible: logcatArea.text !== ""
-
-                ScrollView {
-                    width: parent.width
-                    height: 300
-                    clip: true
-
-                    TextArea {
-                        id: logcatArea
-                        readOnly: true
-                        font.family: "monospace"
-                        font.pixelSize: 12
-                        wrapMode: Text.NoWrap
-                        background: null
                     }
                 }
             }

--- a/src/waydroid_toolkit/modules/images/ota.py
+++ b/src/waydroid_toolkit/modules/images/ota.py
@@ -24,7 +24,6 @@ file that is extracted directly into the target images directory.
 from __future__ import annotations
 
 import configparser
-import hashlib
 import json
 import subprocess
 import tempfile
@@ -35,6 +34,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from waydroid_toolkit.core.waydroid import WaydroidConfig
+from waydroid_toolkit.utils.net import verify_sha256
 
 _CFG_PATH = Path("/var/lib/waydroid/waydroid.cfg")
 _DOWNLOAD_TIMEOUT = 30  # seconds for the manifest fetch
@@ -110,14 +110,6 @@ def check_updates(cfg: WaydroidConfig | None = None) -> tuple[UpdateInfo, Update
 
 # ── Download helpers ──────────────────────────────────────────────────────────
 
-def _sha256(path: Path) -> str:
-    h = hashlib.sha256()
-    with path.open("rb") as fh:
-        for chunk in iter(lambda: fh.read(65536), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
 def _download_with_progress(
     url: str,
     dest: Path,
@@ -181,12 +173,9 @@ def download_image(
 
         if progress:
             progress("Verifying SHA-256…")
-        actual = _sha256(zip_path)
-        if actual != entry.sha256:
+        if not verify_sha256(zip_path, entry.sha256):
             raise RuntimeError(
-                f"SHA-256 mismatch for {entry.filename}:\n"
-                f"  expected: {entry.sha256}\n"
-                f"  got:      {actual}\n"
+                f"SHA-256 mismatch for {entry.filename}.\n"
                 "The download may be corrupt. Try again."
             )
 

--- a/tests/unit/test_ota.py
+++ b/tests/unit/test_ota.py
@@ -12,12 +12,12 @@ import pytest
 
 from waydroid_toolkit.modules.images.ota import (
     OtaEntry,
-    _sha256,
     check_updates,
     download_image,
     download_updates,
     fetch_manifest,
 )
+from waydroid_toolkit.utils.net import verify_sha256
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -124,14 +124,19 @@ class TestCheckUpdates:
         assert vendor_info.channel == "vendor"
 
 
-# ── _sha256 ───────────────────────────────────────────────────────────────────
+# ── verify_sha256 (via net.py) ────────────────────────────────────────────────
 
-class TestSha256:
+class TestVerifySha256:
     def test_matches_known_hash(self, tmp_path: Path) -> None:
         f = tmp_path / "data.bin"
         f.write_bytes(b"hello")
         expected = hashlib.sha256(b"hello").hexdigest()
-        assert _sha256(f) == expected
+        assert verify_sha256(f, expected) is True
+
+    def test_returns_false_on_mismatch(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"hello")
+        assert verify_sha256(f, "wronghash") is False
 
 
 # ── download_image ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes three gaps identified after the v0.2 feature work.

### `ImagesBridge` — OTA slots missing from GUI
`check_updates` and `download_updates` were added to the Python layer but `ImagesBridge` had no slots for them, leaving the GUI Images page unable to trigger an update check.
- `checkUpdate()`: fetches both OTA channels, emits `updateInfoReady(QVariantList)`
- `downloadImages(destDir)`: streams progress via `downloadProgress(str)`, emits `downloadDone(bool, str)`

### `ImagesPage.qml` — OTA UI wired up
- Check button + results table (channel / current datetime / latest datetime / status)
- Download button shown only when at least one update is available
- Download log `TextArea` for progress messages

### `MaintenancePage.qml` — redundant logcat button
The one-shot logcat fetch + static `TextArea` was superseded by `LogcatPage`. Replaced with an Open button that navigates to `LogcatPage` via `pageStack.replace()`.

### `ota.py` — duplicate SHA-256 helper
`_sha256()` was identical to `verify_sha256()` in `utils/net.py`. Removed `_sha256`, import and use `verify_sha256` from `net` instead. Test updated accordingly (+1 test).

## Testing
- `pytest tests/ -q`: 519 passed, 0 failed
- `ruff check src/ tests/`: clean