### PR TITLE
fix: four runtime crashes in GUI layer

### DIFF
--- a/src/waydroid_toolkit/gui/bridge.py
+++ b/src/waydroid_toolkit/gui/bridge.py
@@ -419,8 +419,15 @@ class ImagesBridge(WdtBridgeBase):
     @Slot()
     def refresh(self) -> None:
         def _do() -> list:
-            from waydroid_toolkit.modules.images.manager import list_images
-            return [{"name": i.name, "active": i.active} for i in list_images()]
+            from waydroid_toolkit.modules.images.manager import (
+                get_active_profile,
+                scan_profiles,
+            )
+            active = get_active_profile()
+            return [
+                {"name": p.name, "active": active is not None and p.name == active}
+                for p in scan_profiles()
+            ]
 
         def _apply(data: list) -> None:
             self._images = data
@@ -431,8 +438,15 @@ class ImagesBridge(WdtBridgeBase):
     @Slot(str)
     def activate(self, name: str) -> None:
         def _do() -> None:
-            from waydroid_toolkit.modules.images.manager import activate_image
-            activate_image(name)
+            from waydroid_toolkit.modules.images.manager import (
+                scan_profiles,
+                switch_profile,
+            )
+            profiles = scan_profiles()
+            match = next((p for p in profiles if p.name == name), None)
+            if match is None:
+                raise ValueError(f"Profile '{name}' not found.")
+            switch_profile(match)
         self._run(_do, on_done=lambda _: self.refresh())
 
     @Slot()

--- a/src/waydroid_toolkit/gui/qml/Main.qml
+++ b/src/waydroid_toolkit/gui/qml/Main.qml
@@ -8,6 +8,11 @@ import "components"
 
 ApplicationWindow {
     id: root
+    // Aliases used by child pages loaded into the StackView.
+    // applicationWindow.showToast(msg, isError) — global toast
+    // applicationWindow.pageStack.replace(url) — navigate to a page
+    property alias applicationWindow: root
+    readonly property alias pageStack: pageStack
 
     title: "WayDroid Toolkit"
     width: 960

--- a/src/waydroid_toolkit/gui/qml/pages/ImagesPage.qml
+++ b/src/waydroid_toolkit/gui/qml/pages/ImagesPage.qml
@@ -2,6 +2,7 @@
 import QtQuick
 import QtQuick.Controls.Material
 import QtQuick.Layouts
+import QtCore
 import "../components"
 
 Page {

--- a/src/waydroid_toolkit/gui/qml/pages/MaintenancePage.qml
+++ b/src/waydroid_toolkit/gui/qml/pages/MaintenancePage.qml
@@ -54,7 +54,7 @@ Page {
                             text: "Open"
                             flat: true
                             Material.accent: Material.Teal
-                            onClicked: pageStack.replace(
+                            onClicked: applicationWindow.pageStack.replace(
                                 Qt.resolvedUrl("LogcatPage.qml"))
                         }
                     }


### PR DESCRIPTION
Fixes four bugs that would cause crashes at runtime (none caught by unit tests since they're in QML or bridge wiring).

### `ImagesBridge` — wrong function names
`list_images()` and `activate_image()` were imported from `manager.py` but don't exist there. The Images page would crash on load with `ImportError`.
- `refresh()` now uses `scan_profiles()` + `get_active_profile()`, marking active by name comparison
- `activate()` now uses `scan_profiles()` + `switch_profile()`, raising `ValueError` if the profile isn't found

### `ImagesPage.qml` — missing `QtCore` import
`StandardPaths.writableLocation()` requires `import QtCore` in Qt 6. Without it the Download button threw a QML reference error at runtime.

### `Main.qml` — `applicationWindow` and `pageStack` undefined in child pages
Three pages (`BackupPage`, `PackagesPage`, `MaintenancePage`) call `applicationWindow.showToast()` and `MaintenancePage` calls `pageStack.replace()`, but neither name was defined — child pages loaded into a `StackView` cannot reference parent `id`s directly.
- `property alias applicationWindow: root` — exposes the `ApplicationWindow` to all child pages
- `readonly property alias pageStack: pageStack` — exposes the `StackView` via `applicationWindow.pageStack`

### `MaintenancePage.qml` — bare `pageStack` reference
Updated the Logcat Open button to use `applicationWindow.pageStack.replace()` now that the alias is defined.

## Testing
- `pytest tests/ -q`: 519 passed, 0 failed
- `ruff check src/ tests/`: clean