### PR TITLE
fix: resolve all audit issues

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@
 - [x] Performance tuning (ZRAM, CPU governor, GameMode)
 - [x] Maintenance tools (display, screenshot, logcat, file transfer, debloat)
 - [x] Full CLI (`wdt`) with all subcommands
-- [x] Unit test suite (519 tests)
+- [x] Unit test suite (pytest, pytest-cov)
 
 ## v0.2 — Feature complete ✅
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,11 @@ dependencies = [
 # Qt GUI — PySide6 is tried first; PyQt6 is the fallback (see gui/qt_compat.py)
 gui = [
     "PySide6>=6.6",
-    "qtpy>=2.4",
 ]
 # PyQt6 alternative binding (install instead of PySide6 if preferred)
 gui-pyqt = [
     "PyQt6>=6.6",
     "PyQt6-WebEngine>=6.6",
-    "qtpy>=2.4",
 ]
 # GTK legacy GUI (kept for reference; not actively maintained)
 gui-gtk = [

--- a/src/waydroid_toolkit/gui/app.py
+++ b/src/waydroid_toolkit/gui/app.py
@@ -148,3 +148,5 @@ def run(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     sys.exit(run())
+
+main = run  # entry point alias for pyproject.toml gui_scripts

--- a/src/waydroid_toolkit/gui/pages/base.py
+++ b/src/waydroid_toolkit/gui/pages/base.py
@@ -1,4 +1,4 @@
-"""Base Qt Widget page — replaces GTK BasePage(Gtk.Box).
+"""Base Qt Widget page.
 
 All data-heavy pages that use QTableView/QListView inherit from WdtPage.
 Provides:

--- a/src/waydroid_toolkit/gui/presenters.py
+++ b/src/waydroid_toolkit/gui/presenters.py
@@ -1,11 +1,11 @@
 """GUI presenter functions — pure data-gathering logic extracted from page classes.
 
 Each function collects the data a page needs to display and returns it as a
-plain dataclass or dict. This keeps the GTK widget code thin and makes the
+plain dataclass or dict. This keeps the QML bridge code thin and makes the
 business logic testable without a display server.
 
-Pages call these functions from their background threads, then apply the
-returned data to widgets via GLib.idle_add.
+Pages call these functions from their background threads via the bridge's
+``_run()`` helper, then emit the result as a Qt signal.
 """
 
 from __future__ import annotations

--- a/src/waydroid_toolkit/modules/installer/bundled_apps.py
+++ b/src/waydroid_toolkit/modules/installer/bundled_apps.py
@@ -32,7 +32,6 @@ _CACHE_DIR = Path("/tmp/waydroid-toolkit/bundled")
 
 
 @dataclass
-@dataclass
 class _DirectApp:
     """App with a fixed, stable download URL."""
     name: str

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -188,7 +188,6 @@ class TestUninstallWaydroid:
 
 # ── _stage_images ─────────────────────────────────────────────────────────────
 
-_PATCH_BUNDLED = "waydroid_toolkit.modules.installer.bundled_apps.install_bundled_apps"
 _PATCH_RUN     = "waydroid_toolkit.modules.installer.installer.subprocess.run"
 _PATCH_ROOT    = "waydroid_toolkit.modules.installer.installer.require_root"
 _PATCH_LINK    = "waydroid_toolkit.modules.installer.installer.os.link"


### PR DESCRIPTION
Post-audit cleanup. All issues found by a full end-to-end codebase review.

**Bugs**
- `gui/app.py`: `waydroid-toolkit` GUI entry point referenced `app:main` which didn't exist — added `main = run` alias. Would have caused `AttributeError` on every GUI launch.
- `modules/installer/bundled_apps.py`: `_DirectApp` had a duplicate `@dataclass` decorator (copy-paste error).

**Cleanup**
- `pyproject.toml`: removed `qtpy>=2.4` from `[gui]` and `[gui-pyqt]` optional deps — `qtpy` is never imported anywhere; the project uses its own `gui/qt_compat.py` shim.
- `docs/ROADMAP.md`: removed stale test count (519) from v0.1 entry.
- `gui/presenters.py`: updated module docstring (GTK/GLib references → Qt/QML).
- `gui/pages/base.py`: removed stale `replaces GTK BasePage(Gtk.Box)` from docstring.
- `tests/unit/test_installer.py`: removed duplicate `_PATCH_BUNDLED` constant.