### PR TITLE
feat: prefer Incus backend; add wdt backend set; add wdt doctor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
           names = zipfile.ZipFile(whl).namelist()
           required = [
               "waydroid_toolkit/py.typed",
+              "waydroid_toolkit/cli/commands/doctor.py",
               "waydroid_toolkit/modules/extensions/resolver.py",
               "waydroid_toolkit/modules/images/androidtv.py",
               "waydroid_toolkit/modules/snapshot/zfs.py",
@@ -175,6 +176,21 @@ jobs:
 
       - name: wdt backup --help
         run: wdt backup --help
+
+      - name: wdt doctor --help
+        run: wdt doctor --help
+
+      - name: wdt doctor --json (no Waydroid — must not crash)
+        run: wdt doctor --json || true
+
+      - name: wdt backend --help
+        run: wdt backend --help
+
+      - name: wdt backend set --help
+        run: wdt backend set --help
+
+      - name: wdt install --help shows --backend option
+        run: wdt install --help | grep -q "\-\-backend"
 
   # ── Docs build ─────────────────────────────────────────────────────────────
   docs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,18 @@ alternative. Both implement `ContainerBackend` (ABC in `base.py`).
 - `incus_backend.py` — wraps `incus` CLI
 - `selector.py` — reads/writes `~/.config/waydroid-toolkit/config.toml`
 
-**Switching backends:** `selector.set_active(BackendType.INCUS)` writes the
+**Default backend:** `selector.detect()` prefers Incus over LXC. When Incus
+is not installed it falls back to LXC and prints a warning to stderr
+directing the user to `wdt backend switch incus`.
+
+**Switching backends at runtime:**
+- `wdt backend switch incus` / `wdt backend set incus` — both call
+  `selector.set_active(BackendType.INCUS)` and persist to config.
+  `set` is an alias for `switch` added for discoverability.
+- `wdt install --backend incus` (default) — activates the chosen backend
+  immediately after `waydroid init` completes.
+
+**Programmatic switch:** `selector.set_active(BackendType.INCUS)` writes the
 config; `selector.get_active()` returns the active backend instance.
 
 **Adding a new backend:** subclass `ContainerBackend`, implement all abstract
@@ -72,6 +83,43 @@ explicit configuration for:
 
 6. **Exec privileges** — `execute()` accepts `uid`, `gid`,
    `disable_apparmor`, `extra_env` → `--user` / `--disable-apparmor`.
+
+---
+
+## wdt doctor
+
+`src/waydroid_toolkit/cli/commands/doctor.py`
+
+Checks prerequisites and runtime environment. Exits 0 when all required
+checks pass (warnings are non-fatal). Exits 1 when any required check fails.
+
+**Checks performed:**
+
+| Check | Required | Notes |
+|---|---|---|
+| `waydroid` binary | ✅ | |
+| waydroid initialized | ✅ | only if binary found |
+| container backend | ✅ | reads active backend from config |
+| `incus` binary | ✅ | only when Incus backend is active |
+| `incus waydroid` container | ✅ | only when Incus backend is active |
+| LXC active but Incus available | ⚠ warning | suggests `wdt backend set incus` |
+| `binder_linux` kernel module | ✅ | |
+| `ashmem_linux` kernel module | ⚠ warning | optional on modern kernels |
+| `/dev/binder`, `/dev/ashmem` | ✅ | |
+| GPU/DMA device nodes | ⚠ warning | optional, needed for GPU accel |
+| `adb` binary | ✅ | |
+| ADB connected | ⚠ warning | only if adb found |
+| audio socket (PipeWire/PA) | ⚠ warning | |
+
+**Adding a new check:** append a `_check()` or `_warn()` call to the `rows`
+list in `cmd()`. Both return a 4-tuple `(label, status, detail, fix)`.
+`_check()` increments `fail_count` on failure; `_warn()` increments
+`warn_count`. Do not raise exceptions from check functions — catch and
+convert to `_check(..., ok=False)`.
+
+**JSON output:** `wdt doctor --json` emits a JSON array of
+`{check, status, detail, fix}` objects. Rich markup is stripped from
+`status` in JSON mode.
 
 ---
 

--- a/src/waydroid_toolkit/cli/commands/backend.py
+++ b/src/waydroid_toolkit/cli/commands/backend.py
@@ -6,17 +6,11 @@ from rich.table import Table
 
 from waydroid_toolkit.core.container import (
     BackendType,
-)
-from waydroid_toolkit.core.container import (
+    IncusBackend,
+    LxcBackend,
     detect as detect_backend,
-)
-from waydroid_toolkit.core.container import (
     get_active as get_active_backend,
-)
-from waydroid_toolkit.core.container import (
     list_available as list_available_backends,
-)
-from waydroid_toolkit.core.container import (
     set_active as set_active_backend,
 )
 
@@ -72,8 +66,6 @@ def backend_detect() -> None:
 def _do_switch(backend_name: str) -> None:
     """Shared implementation for 'switch' and 'set'."""
     backend_type = BackendType(backend_name)
-
-    from waydroid_toolkit.core.container import IncusBackend, LxcBackend
     backend_map = {BackendType.LXC: LxcBackend, BackendType.INCUS: IncusBackend}
     backend = backend_map[backend_type]()
 
@@ -135,8 +127,6 @@ def backend_incus_setup() -> None:
 
     Run this once after switching to the Incus backend.
     """
-    from waydroid_toolkit.core.container import IncusBackend
-
     backend = IncusBackend()
     if not backend.is_available():
         console.print("[red]Incus is not installed (binary not found).[/red]")
@@ -157,8 +147,6 @@ def backend_incus_setup() -> None:
 @cmd.command("list")
 def backend_list() -> None:
     """List all backends and their availability on this system."""
-    from waydroid_toolkit.core.container import IncusBackend, LxcBackend
-
     try:
         active = get_active_backend()
         active_type = active.backend_type

--- a/src/waydroid_toolkit/cli/commands/backend.py
+++ b/src/waydroid_toolkit/cli/commands/backend.py
@@ -6,16 +6,14 @@ from rich.table import Table
 
 from waydroid_toolkit.core.container import (
     BackendType,
+    IncusBackend,
+    LxcBackend,
 )
 from waydroid_toolkit.core.container import (
     detect as detect_backend,
 )
 from waydroid_toolkit.core.container import (
     get_active as get_active_backend,
-)
-from waydroid_toolkit.core.container import (
-    IncusBackend,
-    LxcBackend,
 )
 from waydroid_toolkit.core.container import (
     list_available as list_available_backends,

--- a/src/waydroid_toolkit/cli/commands/backend.py
+++ b/src/waydroid_toolkit/cli/commands/backend.py
@@ -69,17 +69,8 @@ def backend_detect() -> None:
     )
 
 
-@cmd.command("switch")
-@click.argument("backend_name", metavar="BACKEND", type=click.Choice(["lxc", "incus"]))
-def backend_switch(backend_name: str) -> None:
-    """Switch the active backend to LXC or Incus.
-
-    BACKEND must be one of: lxc, incus
-
-    The chosen backend binary must be present on PATH.
-    For Incus, run 'wdt backend incus setup' after switching to import
-    the Waydroid container configuration into Incus.
-    """
+def _do_switch(backend_name: str) -> None:
+    """Shared implementation for 'switch' and 'set'."""
     backend_type = BackendType(backend_name)
 
     from waydroid_toolkit.core.container import IncusBackend, LxcBackend
@@ -104,6 +95,34 @@ def backend_switch(backend_name: str) -> None:
             "[dim]Run 'wdt backend incus-setup' to import the Waydroid "
             "container config into Incus.[/dim]"
         )
+
+
+@cmd.command("switch")
+@click.argument("backend_name", metavar="BACKEND", type=click.Choice(["lxc", "incus"]))
+def backend_switch(backend_name: str) -> None:
+    """Switch the active backend to LXC or Incus.
+
+    BACKEND must be one of: lxc, incus
+
+    The chosen backend binary must be present on PATH.
+    For Incus, run 'wdt backend incus-setup' after switching to import
+    the Waydroid container configuration into Incus.
+    """
+    _do_switch(backend_name)
+
+
+@cmd.command("set")
+@click.argument("backend_name", metavar="BACKEND", type=click.Choice(["lxc", "incus"]))
+def backend_set(backend_name: str) -> None:
+    """Set the active backend to LXC or Incus (alias for 'switch').
+
+    BACKEND must be one of: lxc, incus
+
+    The chosen backend binary must be present on PATH.
+    For Incus, run 'wdt backend incus-setup' after switching to import
+    the Waydroid container configuration into Incus.
+    """
+    _do_switch(backend_name)
 
 
 @cmd.command("incus-setup")

--- a/src/waydroid_toolkit/cli/commands/backend.py
+++ b/src/waydroid_toolkit/cli/commands/backend.py
@@ -6,11 +6,21 @@ from rich.table import Table
 
 from waydroid_toolkit.core.container import (
     BackendType,
+)
+from waydroid_toolkit.core.container import (
     IncusBackend,
     LxcBackend,
+)
+from waydroid_toolkit.core.container import (
     detect as detect_backend,
+)
+from waydroid_toolkit.core.container import (
     get_active as get_active_backend,
+)
+from waydroid_toolkit.core.container import (
     list_available as list_available_backends,
+)
+from waydroid_toolkit.core.container import (
     set_active as set_active_backend,
 )
 

--- a/src/waydroid_toolkit/cli/commands/backend.py
+++ b/src/waydroid_toolkit/cli/commands/backend.py
@@ -8,14 +8,14 @@ from waydroid_toolkit.core.container import (
     BackendType,
 )
 from waydroid_toolkit.core.container import (
-    IncusBackend,
-    LxcBackend,
-)
-from waydroid_toolkit.core.container import (
     detect as detect_backend,
 )
 from waydroid_toolkit.core.container import (
     get_active as get_active_backend,
+)
+from waydroid_toolkit.core.container import (
+    IncusBackend,
+    LxcBackend,
 )
 from waydroid_toolkit.core.container import (
     list_available as list_available_backends,

--- a/src/waydroid_toolkit/cli/commands/doctor.py
+++ b/src/waydroid_toolkit/cli/commands/doctor.py
@@ -1,0 +1,272 @@
+"""wdt doctor — check prerequisites and runtime environment."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+# Kernel modules required for Waydroid
+_REQUIRED_MODULES = ["binder_linux"]
+_OPTIONAL_MODULES = ["ashmem_linux"]
+
+# Character device nodes the Android container needs
+_REQUIRED_DEVICES = ["/dev/binder", "/dev/ashmem"]
+_OPTIONAL_DEVICES = [
+    "/dev/dri/renderD128",
+    "/dev/dma_heap/system",
+    "/dev/dma_heap/system-uncached",
+]
+
+
+def _check(label: str, ok: bool, detail: str = "", fix: str = "") -> tuple[str, str, str, str]:
+    """Return a table row tuple: (label, status, detail, fix hint)."""
+    status = "[green]✅ ok[/green]" if ok else "[red]❌ fail[/red]"
+    return label, status, detail, fix
+
+
+def _warn(label: str, detail: str = "", fix: str = "") -> tuple[str, str, str, str]:
+    return label, "[yellow]⚠  warn[/yellow]", detail, fix
+
+
+def _module_loaded(name: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["lsmod"], capture_output=True, text=True, timeout=5
+        )
+        return name in result.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _device_exists(path: str) -> bool:
+    return Path(path).exists()
+
+
+def _audio_socket() -> tuple[str, str]:
+    """Return (backend_name, socket_path) for the detected audio backend."""
+    xdg = Path.home() / ".local" / "share"  # fallback
+    runtime = Path(
+        subprocess.run(
+            ["bash", "-c", "echo $XDG_RUNTIME_DIR"],
+            capture_output=True, text=True,
+        ).stdout.strip() or f"/run/user/{subprocess.os.getuid()}"
+    )
+    pw_sock = runtime / "pipewire-0"
+    pa_sock = runtime / "pulse" / "native"
+    if pw_sock.exists():
+        return "pipewire", str(pw_sock)
+    if pa_sock.exists():
+        return "pulseaudio", str(pa_sock)
+    return "none", ""
+
+
+@click.command("doctor")
+@click.option("--json", "as_json", is_flag=True, help="Output results as JSON.")
+def cmd(as_json: bool) -> None:
+    """Check prerequisites and runtime environment for Waydroid.
+
+    Verifies: Waydroid binary, container backend, kernel modules,
+    device nodes, ADB, audio socket, and Incus-specific requirements
+    when the Incus backend is active.
+    """
+    rows: list[tuple[str, str, str, str]] = []
+    fail_count = 0
+    warn_count = 0
+
+    def add(row: tuple[str, str, str, str]) -> None:
+        nonlocal fail_count, warn_count
+        rows.append(row)
+        if "fail" in row[1]:
+            fail_count += 1
+        elif "warn" in row[1]:
+            warn_count += 1
+
+    # ── Waydroid binary ───────────────────────────────────────────────────────
+    waydroid_ok = shutil.which("waydroid") is not None
+    add(_check(
+        "waydroid binary",
+        waydroid_ok,
+        shutil.which("waydroid") or "",
+        "" if waydroid_ok else "Install Waydroid: wdt install",
+    ))
+
+    # ── Waydroid initialised ──────────────────────────────────────────────────
+    if waydroid_ok:
+        from waydroid_toolkit.core.waydroid import is_initialized
+        init_ok = is_initialized()
+        add(_check(
+            "waydroid initialized",
+            init_ok,
+            fix="" if init_ok else "Run: wdt install --init-only",
+        ))
+
+    # ── Container backend ─────────────────────────────────────────────────────
+    try:
+        from waydroid_toolkit.core.container import get_active
+        backend = get_active()
+        info = backend.get_info()
+        add(_check(
+            "container backend",
+            True,
+            f"{info.backend_type.value} {info.version}",
+        ))
+        active_backend_type = info.backend_type
+    except RuntimeError as exc:
+        add(_check("container backend", False, fix=str(exc)))
+        active_backend_type = None
+
+    # ── Incus-specific checks ─────────────────────────────────────────────────
+    from waydroid_toolkit.core.container import BackendType
+
+    if active_backend_type == BackendType.INCUS:
+        # incus binary
+        incus_bin = shutil.which("incus")
+        add(_check(
+            "incus binary",
+            incus_bin is not None,
+            incus_bin or "",
+            fix="" if incus_bin else "Install Incus: https://linuxcontainers.org/incus/",
+        ))
+
+        # waydroid container exists in Incus
+        if incus_bin:
+            try:
+                result = subprocess.run(
+                    ["incus", "info", "waydroid"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                container_ok = result.returncode == 0
+                add(_check(
+                    "incus 'waydroid' container",
+                    container_ok,
+                    fix="" if container_ok else "Run: wdt backend incus-setup",
+                ))
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                add(_check("incus 'waydroid' container", False,
+                           fix="Run: wdt backend incus-setup"))
+
+    elif active_backend_type == BackendType.LXC:
+        # Suggest upgrading to Incus
+        incus_available = shutil.which("incus") is not None
+        if incus_available:
+            add(_warn(
+                "container backend",
+                "Incus is available but LXC is active",
+                fix="Run: wdt backend set incus",
+            ))
+
+    # ── Kernel modules ────────────────────────────────────────────────────────
+    for mod in _REQUIRED_MODULES:
+        loaded = _module_loaded(mod)
+        add(_check(
+            f"kernel module: {mod}",
+            loaded,
+            fix="" if loaded else f"sudo modprobe {mod}",
+        ))
+
+    for mod in _OPTIONAL_MODULES:
+        loaded = _module_loaded(mod)
+        if not loaded:
+            add(_warn(
+                f"kernel module: {mod}",
+                "optional — needed on older kernels",
+                fix=f"sudo modprobe {mod}",
+            ))
+
+    # ── Device nodes ──────────────────────────────────────────────────────────
+    for dev in _REQUIRED_DEVICES:
+        exists = _device_exists(dev)
+        add(_check(
+            f"device: {dev}",
+            exists,
+            fix="" if exists else f"sudo modprobe binder_linux && ls {dev}",
+        ))
+
+    for dev in _OPTIONAL_DEVICES:
+        exists = _device_exists(dev)
+        if not exists:
+            add(_warn(f"device: {dev}", "optional — GPU acceleration"))
+
+    # ── ADB ───────────────────────────────────────────────────────────────────
+    adb_bin = shutil.which("adb")
+    add(_check(
+        "adb binary",
+        adb_bin is not None,
+        adb_bin or "",
+        fix="" if adb_bin else "Install: sudo apt install adb  # or platform-tools",
+    ))
+
+    if adb_bin:
+        try:
+            from waydroid_toolkit.core.adb import is_connected as adb_connected
+            connected = adb_connected()
+            if connected:
+                add(_check("adb connected", True))
+            else:
+                add(_warn("adb connected", "Waydroid may not be running"))
+        except Exception:  # noqa: BLE001
+            add(_warn("adb connected", "could not determine state"))
+
+    # ── Audio ─────────────────────────────────────────────────────────────────
+    audio_backend, audio_sock = _audio_socket()
+    if audio_backend != "none":
+        add(_check("audio socket", True, f"{audio_backend}: {audio_sock}"))
+    else:
+        add(_warn(
+            "audio socket",
+            "no PipeWire or PulseAudio socket found",
+            fix="Start PipeWire or PulseAudio before launching Waydroid",
+        ))
+
+    # ── Output ────────────────────────────────────────────────────────────────
+    if as_json:
+        import json
+        import re
+
+        def strip_markup(s: str) -> str:
+            return re.sub(r"\[/?[^\]]+\]", "", s)
+
+        data = [
+            {
+                "check": r[0],
+                "status": strip_markup(r[1]),
+                "detail": r[2],
+                "fix": r[3],
+            }
+            for r in rows
+        ]
+        console.print_json(json.dumps(data, indent=2))
+    else:
+        table = Table(show_header=True, header_style="bold cyan", box=None, padding=(0, 1))
+        table.add_column("Check")
+        table.add_column("Status")
+        table.add_column("Detail")
+        table.add_column("Fix")
+
+        for row in rows:
+            table.add_row(*row)
+
+        console.print()
+        console.print(table)
+        console.print()
+
+        if fail_count == 0 and warn_count == 0:
+            console.print("[green]All checks passed.[/green]")
+        elif fail_count == 0:
+            console.print(
+                f"[yellow]{warn_count} warning(s). "
+                "Waydroid should work but some features may be limited.[/yellow]"
+            )
+        else:
+            console.print(
+                f"[red]{fail_count} check(s) failed[/red], "
+                f"[yellow]{warn_count} warning(s)[/yellow]."
+            )
+            raise SystemExit(1)

--- a/src/waydroid_toolkit/cli/commands/doctor.py
+++ b/src/waydroid_toolkit/cli/commands/doctor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -51,12 +52,11 @@ def _device_exists(path: str) -> bool:
 
 def _audio_socket() -> tuple[str, str]:
     """Return (backend_name, socket_path) for the detected audio backend."""
-    xdg = Path.home() / ".local" / "share"  # fallback
     runtime = Path(
         subprocess.run(
             ["bash", "-c", "echo $XDG_RUNTIME_DIR"],
             capture_output=True, text=True,
-        ).stdout.strip() or f"/run/user/{subprocess.os.getuid()}"
+        ).stdout.strip() or f"/run/user/{os.getuid()}"
     )
     pw_sock = runtime / "pipewire-0"
     pa_sock = runtime / "pulse" / "native"
@@ -211,7 +211,7 @@ def cmd(as_json: bool) -> None:
                 add(_check("adb connected", True))
             else:
                 add(_warn("adb connected", "Waydroid may not be running"))
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001  # broad catch intentional — adb state is best-effort
             add(_warn("adb connected", "could not determine state"))
 
     # ── Audio ─────────────────────────────────────────────────────────────────

--- a/src/waydroid_toolkit/cli/commands/install.py
+++ b/src/waydroid_toolkit/cli/commands/install.py
@@ -17,7 +17,7 @@ from waydroid_toolkit.modules.installer.installer import (
     setup_repo,
 )
 from waydroid_toolkit.utils.android_shared import AndroidShared
-from waydroid_toolkit.core.container import BackendType
+from waydroid_toolkit.core.container import BackendType, IncusBackend, LxcBackend
 from waydroid_toolkit.core.container import set_active as set_active_backend
 from waydroid_toolkit.utils.distro import Distro, detect_distro
 
@@ -108,8 +108,6 @@ def cmd(
 
 def _activate_backend(backend_name: str) -> None:
     """Persist the chosen backend to the toolkit config."""
-    from waydroid_toolkit.core.container import IncusBackend, LxcBackend
-
     backend_type = BackendType(backend_name)
     backend_map = {BackendType.LXC: LxcBackend, BackendType.INCUS: IncusBackend}
     backend_obj = backend_map[backend_type]()

--- a/src/waydroid_toolkit/cli/commands/install.py
+++ b/src/waydroid_toolkit/cli/commands/install.py
@@ -17,6 +17,8 @@ from waydroid_toolkit.modules.installer.installer import (
     setup_repo,
 )
 from waydroid_toolkit.utils.android_shared import AndroidShared
+from waydroid_toolkit.core.container import BackendType
+from waydroid_toolkit.core.container import set_active as set_active_backend
 from waydroid_toolkit.utils.distro import Distro, detect_distro
 
 console = Console()
@@ -31,6 +33,16 @@ console = Console()
 @click.option("--init-only", is_flag=True, help="Skip package install; only run waydroid init.")
 @click.option("--no-bundled-apps", is_flag=True,
               help="Skip installing bundled apps (F-Droid, AuroraStore, etc.) after init.")
+@click.option(
+    "--backend",
+    type=click.Choice(["incus", "lxc"]),
+    default="incus",
+    show_default=True,
+    help=(
+        "Container backend to activate after installation. "
+        "'incus' is recommended; use 'lxc' only if Incus is not available."
+    ),
+)
 @click.option(
     "--from-manifest",
     type=click.Path(exists=True, path_type=Path),
@@ -47,6 +59,7 @@ def cmd(
     skip_repo: bool,
     init_only: bool,
     no_bundled_apps: bool,
+    backend: str,
     from_manifest: Path | None,
 ) -> None:
     """Install Waydroid and initialise with the chosen image type.
@@ -61,6 +74,7 @@ def cmd(
     # ── Manifest mode ─────────────────────────────────────────────────────────
     if from_manifest is not None:
         _install_from_manifest(from_manifest, no_bundled_apps)
+        _activate_backend(backend)
         return
 
     # ── Standard mode ─────────────────────────────────────────────────────────
@@ -88,7 +102,35 @@ def cmd(
         install_apps=not no_bundled_apps,
         progress=progress,
     )
+    _activate_backend(backend)
     console.print("[green]Done. Run 'wdt status' to verify.[/green]")
+
+
+def _activate_backend(backend_name: str) -> None:
+    """Persist the chosen backend to the toolkit config."""
+    from waydroid_toolkit.core.container import IncusBackend, LxcBackend
+
+    backend_type = BackendType(backend_name)
+    backend_map = {BackendType.LXC: LxcBackend, BackendType.INCUS: IncusBackend}
+    backend_obj = backend_map[backend_type]()
+
+    if not backend_obj.is_available():
+        console.print(
+            f"[yellow]Warning: backend '{backend_name}' is not available "
+            f"(binary not found). Skipping backend activation.[/yellow]\n"
+            "  Install the backend and run: wdt backend switch "
+            f"{backend_name}"
+        )
+        return
+
+    set_active_backend(backend_type)
+    console.print(f"[dim]Container backend set to: {backend_name}[/dim]")
+
+    if backend_type == BackendType.INCUS:
+        console.print(
+            "[dim]Run 'wdt backend incus-setup' to import the Waydroid "
+            "container config into Incus.[/dim]"
+        )
 
 
 def _install_from_manifest(manifest_path: Path, no_bundled_apps: bool) -> None:

--- a/src/waydroid_toolkit/cli/commands/install.py
+++ b/src/waydroid_toolkit/cli/commands/install.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from waydroid_toolkit.core.container import BackendType, IncusBackend, LxcBackend
+from waydroid_toolkit.core.container import set_active as set_active_backend
 from waydroid_toolkit.modules.builder.builder import read_manifest
 from waydroid_toolkit.modules.installer.installer import (
     ImageArch,
@@ -17,8 +19,6 @@ from waydroid_toolkit.modules.installer.installer import (
     setup_repo,
 )
 from waydroid_toolkit.utils.android_shared import AndroidShared
-from waydroid_toolkit.core.container import BackendType, IncusBackend, LxcBackend
-from waydroid_toolkit.core.container import set_active as set_active_backend
 from waydroid_toolkit.utils.distro import Distro, detect_distro
 
 console = Console()

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -27,6 +27,7 @@ from .commands import (
     backup,
     build,
     dbus,
+    doctor,
     extensions,
     images,
     install,
@@ -66,6 +67,7 @@ def cli() -> None:
 
 
 cli.add_command(status.cmd, name="status")
+cli.add_command(doctor.cmd, name="doctor")
 cli.add_command(install.cmd, name="install")
 cli.add_command(build.cmd, name="build")
 cli.add_command(_gui_cmd(), name="gui")

--- a/src/waydroid_toolkit/core/container/selector.py
+++ b/src/waydroid_toolkit/core/container/selector.py
@@ -76,13 +76,34 @@ def _write_config(data: dict) -> None:
 
 
 def detect() -> ContainerBackend:
-    """Return the first available backend (LXC preferred, then Incus)."""
-    for backend_cls in (LxcBackend, IncusBackend):
-        backend = backend_cls()
-        if backend.is_available():
-            return backend
+    """Return the best available backend (Incus preferred, then LXC).
+
+    Incus is preferred because it provides richer introspection, native
+    device-node management, and per-session mount isolation compared to
+    the bare lxc-* CLI tools.  LXC is used as a fallback when Incus is
+    not installed.
+
+    A warning is printed to stderr when LXC is chosen so users know they
+    can upgrade to the Incus backend with 'wdt backend switch incus'.
+    """
+    import sys
+
+    incus = IncusBackend()
+    if incus.is_available():
+        return incus
+
+    lxc = LxcBackend()
+    if lxc.is_available():
+        print(
+            "Warning: Incus not found; falling back to LXC backend.\n"
+            "  For the full feature set, install Incus and run:\n"
+            "    wdt backend switch incus",
+            file=sys.stderr,
+        )
+        return lxc
+
     raise RuntimeError(
-        "No container backend found. Install lxc or incus."
+        "No container backend found. Install incus (recommended) or lxc."
     )
 
 

--- a/tests/unit/test_backend_set_alias.py
+++ b/tests/unit/test_backend_set_alias.py
@@ -1,0 +1,86 @@
+"""Tests for wdt backend set (alias for wdt backend switch) — change B."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.backend import cmd as backend_cmd
+from waydroid_toolkit.core.container import BackendType
+
+
+def _mock_backend(available: bool, version: str = "1.0.0", btype: BackendType = BackendType.INCUS) -> MagicMock:
+    b = MagicMock()
+    b.is_available.return_value = available
+    info = MagicMock()
+    info.backend_type = btype
+    info.version = version
+    b.get_info.return_value = info
+    return b
+
+
+class TestBackendSet:
+    def test_set_incus_success(self) -> None:
+        runner = CliRunner()
+        mock_incus = _mock_backend(True, "6.0.0", BackendType.INCUS)
+
+        with patch("waydroid_toolkit.cli.commands.backend.IncusBackend", return_value=mock_incus):
+            with patch("waydroid_toolkit.cli.commands.backend.set_active_backend") as mock_set:
+                result = runner.invoke(backend_cmd, ["set", "incus"])
+
+        assert result.exit_code == 0
+        mock_set.assert_called_once_with(BackendType.INCUS)
+        assert "incus" in result.output.lower()
+
+    def test_set_lxc_success(self) -> None:
+        runner = CliRunner()
+        mock_lxc = _mock_backend(True, "5.0.0", BackendType.LXC)
+
+        with patch("waydroid_toolkit.cli.commands.backend.LxcBackend", return_value=mock_lxc):
+            with patch("waydroid_toolkit.cli.commands.backend.set_active_backend") as mock_set:
+                result = runner.invoke(backend_cmd, ["set", "lxc"])
+
+        assert result.exit_code == 0
+        mock_set.assert_called_once_with(BackendType.LXC)
+
+    def test_set_unavailable_backend_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        mock_incus = _mock_backend(False)
+
+        with patch("waydroid_toolkit.cli.commands.backend.IncusBackend", return_value=mock_incus):
+            with patch("waydroid_toolkit.cli.commands.backend.set_active_backend") as mock_set:
+                result = runner.invoke(backend_cmd, ["set", "incus"])
+
+        assert result.exit_code != 0
+        mock_set.assert_not_called()
+
+    def test_set_and_switch_are_equivalent(self) -> None:
+        """Both 'set' and 'switch' call _do_switch with the same argument."""
+        runner = CliRunner()
+        mock_incus = _mock_backend(True, "6.0.0", BackendType.INCUS)
+
+        with patch("waydroid_toolkit.cli.commands.backend.IncusBackend", return_value=mock_incus):
+            with patch("waydroid_toolkit.cli.commands.backend.set_active_backend") as mock_set:
+                r_switch = runner.invoke(backend_cmd, ["switch", "incus"])
+                r_set = runner.invoke(backend_cmd, ["set", "incus"])
+
+        assert r_switch.exit_code == r_set.exit_code == 0
+        assert mock_set.call_count == 2
+        assert mock_set.call_args_list[0] == mock_set.call_args_list[1]
+
+    def test_set_invalid_backend_rejected(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(backend_cmd, ["set", "docker"])
+        assert result.exit_code != 0
+
+    def test_set_incus_shows_incus_setup_hint(self) -> None:
+        runner = CliRunner()
+        mock_incus = _mock_backend(True, "6.0.0", BackendType.INCUS)
+
+        with patch("waydroid_toolkit.cli.commands.backend.IncusBackend", return_value=mock_incus):
+            with patch("waydroid_toolkit.cli.commands.backend.set_active_backend"):
+                result = runner.invoke(backend_cmd, ["set", "incus"])
+
+        assert "incus-setup" in result.output

--- a/tests/unit/test_backend_set_alias.py
+++ b/tests/unit/test_backend_set_alias.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from waydroid_toolkit.cli.commands.backend import cmd as backend_cmd

--- a/tests/unit/test_container_backend.py
+++ b/tests/unit/test_container_backend.py
@@ -393,17 +393,18 @@ class TestIncusBackend:
 # ── Selector ──────────────────────────────────────────────────────────────────
 
 class TestSelector:
-    def test_detect_prefers_lxc(self) -> None:
-        with patch("waydroid_toolkit.core.container.lxc_backend.shutil.which", return_value="/usr/bin/lxc-start"):
+    def test_detect_prefers_incus(self) -> None:
+        """detect() returns Incus when both backends are available."""
+        with patch("waydroid_toolkit.core.container.incus_backend.shutil.which", return_value="/usr/bin/incus"):
             backend = detect()
-        assert backend.backend_type == BackendType.LXC
-
-    def test_detect_falls_back_to_incus(self) -> None:
-        # Patch is_available on the backend instances that selector.detect() creates
-        with patch.object(LxcBackend, "is_available", return_value=False):
-            with patch.object(IncusBackend, "is_available", return_value=True):
-                backend = detect()
         assert backend.backend_type == BackendType.INCUS
+
+    def test_detect_falls_back_to_lxc(self) -> None:
+        """detect() returns LXC when Incus is not available."""
+        with patch.object(IncusBackend, "is_available", return_value=False):
+            with patch.object(LxcBackend, "is_available", return_value=True):
+                backend = detect()
+        assert backend.backend_type == BackendType.LXC
 
     def test_detect_raises_when_none_available(self) -> None:
         with patch("waydroid_toolkit.core.container.lxc_backend.shutil.which", return_value=None):
@@ -421,11 +422,12 @@ class TestSelector:
         assert backend.backend_type == BackendType.LXC
 
     def test_get_active_falls_back_to_detect_on_empty_config(self, tmp_path: Path) -> None:
+        """With no config, get_active() calls detect() which prefers Incus."""
         config_file = tmp_path / "config.toml"
         with patch("waydroid_toolkit.core.container.selector._CONFIG_PATH", config_file):
-            with patch("waydroid_toolkit.core.container.lxc_backend.shutil.which", return_value="/usr/bin/lxc-start"):
+            with patch("waydroid_toolkit.core.container.incus_backend.shutil.which", return_value="/usr/bin/incus"):
                 backend = get_active()
-        assert backend.backend_type == BackendType.LXC
+        assert backend.backend_type == BackendType.INCUS
 
     def test_get_active_raises_if_configured_backend_unavailable(self, tmp_path: Path) -> None:
         config_file = tmp_path / "config.toml"

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -163,70 +163,82 @@ class TestDoctorCommand:
 class TestInstallBackendOption:
     """Tests for --backend flag on wdt install (change A)."""
 
+    def _base_patches(self) -> list:
+        """Patches that stub out the full install flow so only _activate_backend runs."""
+        return [
+            patch("waydroid_toolkit.cli.commands.install.detect_distro"),
+            patch("waydroid_toolkit.cli.commands.install.install_package"),
+            patch("waydroid_toolkit.cli.commands.install.setup_repo"),
+            patch("waydroid_toolkit.cli.commands.install.is_waydroid_installed", return_value=False),
+            patch("waydroid_toolkit.cli.commands.install.init_waydroid"),
+            patch("waydroid_toolkit.cli.commands.install.AndroidShared"),
+        ]
+
     def test_install_defaults_to_incus(self) -> None:
         from waydroid_toolkit.cli.commands.install import cmd as install_cmd
+        from waydroid_toolkit.utils.distro import Distro
 
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.install.detect_distro") as mock_distro, \
-             patch("waydroid_toolkit.cli.commands.install.Installer") as mock_installer_cls, \
-             patch("waydroid_toolkit.cli.commands.install.IncusBackend") as mock_incus_cls, \
+        base = self._base_patches()
+        with patch("waydroid_toolkit.cli.commands.install.IncusBackend") as mock_incus_cls, \
              patch("waydroid_toolkit.cli.commands.install.set_active_backend") as mock_set, \
              patch("waydroid_toolkit.cli.commands.install.LxcBackend"):
-            from waydroid_toolkit.utils.distro import Distro
-            mock_distro.return_value = Distro.UBUNTU
-            mock_installer = MagicMock()
-            mock_installer_cls.return_value = mock_installer
+            mocks = [p.start() for p in base]
+            mocks[0].return_value = Distro.UBUNTU
             mock_incus = MagicMock()
             mock_incus.is_available.return_value = True
             mock_incus_cls.return_value = mock_incus
-            mock_incus.get_info.return_value = _make_backend_info()
-
-            result = runner.invoke(install_cmd, [])
+            try:
+                result = runner.invoke(install_cmd, [])
+            finally:
+                for p in base:
+                    p.stop()
 
         mock_set.assert_called_once_with(BackendType.INCUS)
         assert result.exit_code == 0
 
     def test_install_lxc_backend_flag(self) -> None:
         from waydroid_toolkit.cli.commands.install import cmd as install_cmd
+        from waydroid_toolkit.utils.distro import Distro
 
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.install.detect_distro") as mock_distro, \
-             patch("waydroid_toolkit.cli.commands.install.Installer") as mock_installer_cls, \
-             patch("waydroid_toolkit.cli.commands.install.LxcBackend") as mock_lxc_cls, \
+        base = self._base_patches()
+        with patch("waydroid_toolkit.cli.commands.install.LxcBackend") as mock_lxc_cls, \
              patch("waydroid_toolkit.cli.commands.install.set_active_backend") as mock_set, \
              patch("waydroid_toolkit.cli.commands.install.IncusBackend"):
-            from waydroid_toolkit.utils.distro import Distro
-            mock_distro.return_value = Distro.UBUNTU
-            mock_installer = MagicMock()
-            mock_installer_cls.return_value = mock_installer
+            mocks = [p.start() for p in base]
+            mocks[0].return_value = Distro.UBUNTU
             mock_lxc = MagicMock()
             mock_lxc.is_available.return_value = True
             mock_lxc_cls.return_value = mock_lxc
-            mock_lxc.get_info.return_value = _make_backend_info(BackendType.LXC)
-
-            result = runner.invoke(install_cmd, ["--backend", "lxc"])
+            try:
+                result = runner.invoke(install_cmd, ["--backend", "lxc"])
+            finally:
+                for p in base:
+                    p.stop()
 
         mock_set.assert_called_once_with(BackendType.LXC)
         assert result.exit_code == 0
 
     def test_install_warns_when_backend_unavailable(self) -> None:
         from waydroid_toolkit.cli.commands.install import cmd as install_cmd
+        from waydroid_toolkit.utils.distro import Distro
 
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.install.detect_distro") as mock_distro, \
-             patch("waydroid_toolkit.cli.commands.install.Installer") as mock_installer_cls, \
-             patch("waydroid_toolkit.cli.commands.install.IncusBackend") as mock_incus_cls, \
+        base = self._base_patches()
+        with patch("waydroid_toolkit.cli.commands.install.IncusBackend") as mock_incus_cls, \
              patch("waydroid_toolkit.cli.commands.install.set_active_backend") as mock_set, \
              patch("waydroid_toolkit.cli.commands.install.LxcBackend"):
-            from waydroid_toolkit.utils.distro import Distro
-            mock_distro.return_value = Distro.UBUNTU
-            mock_installer = MagicMock()
-            mock_installer_cls.return_value = mock_installer
+            mocks = [p.start() for p in base]
+            mocks[0].return_value = Distro.UBUNTU
             mock_incus = MagicMock()
             mock_incus.is_available.return_value = False
             mock_incus_cls.return_value = mock_incus
-
-            result = runner.invoke(install_cmd, ["--backend", "incus"])
+            try:
+                result = runner.invoke(install_cmd, ["--backend", "incus"])
+            finally:
+                for p in base:
+                    p.stop()
 
         mock_set.assert_not_called()
         assert "Warning" in result.output or "warning" in result.output.lower()

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from waydroid_toolkit.cli.commands.doctor import cmd as doctor_cmd

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,0 +1,233 @@
+"""Tests for wdt doctor — change C."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.doctor import cmd as doctor_cmd
+from waydroid_toolkit.core.container import BackendType
+
+
+def _make_backend_info(btype: BackendType = BackendType.INCUS, version: str = "6.0.0") -> MagicMock:
+    info = MagicMock()
+    info.backend_type = btype
+    info.version = version
+    return info
+
+
+def _make_backend(btype: BackendType = BackendType.INCUS, version: str = "6.0.0") -> MagicMock:
+    b = MagicMock()
+    b.get_info.return_value = _make_backend_info(btype, version)
+    return b
+
+
+def _patch_all(
+    *,
+    waydroid_bin: str | None = "/usr/bin/waydroid",
+    waydroid_init: bool = True,
+    backend: MagicMock | None = None,
+    incus_bin: str | None = "/usr/bin/incus",
+    incus_container_ok: bool = True,
+    modules: dict[str, bool] | None = None,
+    devices: dict[str, bool] | None = None,
+    adb_bin: str | None = "/usr/bin/adb",
+    adb_connected: bool = True,
+    audio: tuple[str, str] = ("pipewire", "/run/user/1000/pipewire-0"),
+):
+    """Return a context-manager stack that patches all external calls in doctor."""
+    if backend is None:
+        backend = _make_backend()
+    if modules is None:
+        modules = {"binder_linux": True, "ashmem_linux": True}
+    if devices is None:
+        devices = {
+            "/dev/binder": True,
+            "/dev/ashmem": True,
+            "/dev/dri/renderD128": True,
+            "/dev/dma_heap/system": True,
+            "/dev/dma_heap/system-uncached": True,
+        }
+
+    def _which(cmd: str) -> str | None:
+        return {
+            "waydroid": waydroid_bin,
+            "incus": incus_bin,
+            "adb": adb_bin,
+        }.get(cmd)
+
+    def _module_loaded(name: str) -> bool:
+        return modules.get(name, False)
+
+    def _device_exists(path: str) -> bool:
+        return devices.get(path, False)
+
+    incus_run = MagicMock()
+    incus_run.returncode = 0 if incus_container_ok else 1
+
+    patches = [
+        patch("waydroid_toolkit.cli.commands.doctor.shutil.which", side_effect=_which),
+        patch("waydroid_toolkit.cli.commands.doctor._module_loaded", side_effect=_module_loaded),
+        patch("waydroid_toolkit.cli.commands.doctor._device_exists", side_effect=_device_exists),
+        patch("waydroid_toolkit.cli.commands.doctor._audio_socket", return_value=audio),
+        patch("waydroid_toolkit.core.waydroid.is_initialized", return_value=waydroid_init),
+        patch("waydroid_toolkit.cli.commands.doctor.subprocess.run", return_value=incus_run),
+        patch("waydroid_toolkit.core.container.get_active", return_value=backend),
+    ]
+    if adb_bin:
+        patches.append(
+            patch("waydroid_toolkit.core.adb.is_connected", return_value=adb_connected)
+        )
+    return patches
+
+
+class TestDoctorCommand:
+    def _run(self, extra_args: list[str] | None = None, **kwargs) -> tuple[object, list]:
+        runner = CliRunner()
+        patches = _patch_all(**kwargs)
+        ctx_managers = [p.start() for p in patches]
+        try:
+            result = runner.invoke(doctor_cmd, extra_args or [])
+        finally:
+            for p in patches:
+                p.stop()
+        return result, ctx_managers
+
+    def test_all_ok_exits_zero(self) -> None:
+        result, _ = self._run()
+        assert result.exit_code == 0
+
+    def test_missing_waydroid_exits_nonzero(self) -> None:
+        result, _ = self._run(waydroid_bin=None)
+        assert result.exit_code != 0
+
+    def test_missing_incus_binary_exits_nonzero(self) -> None:
+        result, _ = self._run(incus_bin=None)
+        assert result.exit_code != 0
+
+    def test_missing_binder_module_exits_nonzero(self) -> None:
+        result, _ = self._run(modules={"binder_linux": False, "ashmem_linux": True})
+        assert result.exit_code != 0
+
+    def test_missing_binder_device_exits_nonzero(self) -> None:
+        result, _ = self._run(devices={
+            "/dev/binder": False,
+            "/dev/ashmem": True,
+            "/dev/dri/renderD128": True,
+            "/dev/dma_heap/system": True,
+            "/dev/dma_heap/system-uncached": True,
+        })
+        assert result.exit_code != 0
+
+    def test_lxc_backend_with_incus_available_shows_warning(self) -> None:
+        lxc_backend = _make_backend(BackendType.LXC, "5.0.0")
+        result, _ = self._run(backend=lxc_backend)
+        assert result.exit_code == 0  # warning, not failure
+        assert "warn" in result.output.lower() or "lxc" in result.output.lower()
+
+    def test_no_audio_socket_is_warning_not_failure(self) -> None:
+        result, _ = self._run(audio=("none", ""))
+        # Missing audio is a warning, not a hard failure — exit 0
+        assert result.exit_code == 0
+
+    def test_json_output_is_valid(self) -> None:
+        result, _ = self._run(extra_args=["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert all("check" in row and "status" in row for row in data)
+
+    def test_json_output_contains_expected_checks(self) -> None:
+        result, _ = self._run(extra_args=["--json"])
+        data = json.loads(result.output)
+        check_names = [row["check"] for row in data]
+        assert any("waydroid" in c for c in check_names)
+        assert any("backend" in c for c in check_names)
+        assert any("binder" in c for c in check_names)
+        assert any("adb" in c for c in check_names)
+
+    def test_incus_container_missing_exits_nonzero(self) -> None:
+        result, _ = self._run(incus_container_ok=False)
+        assert result.exit_code != 0
+
+    def test_fix_hints_present_on_failure(self) -> None:
+        result, _ = self._run(waydroid_bin=None, extra_args=["--json"])
+        data = json.loads(result.output)
+        waydroid_row = next(r for r in data if r["check"] == "waydroid binary")
+        assert "wdt install" in waydroid_row["fix"]
+
+
+class TestInstallBackendOption:
+    """Tests for --backend flag on wdt install (change A)."""
+
+    def test_install_defaults_to_incus(self) -> None:
+        from waydroid_toolkit.cli.commands.install import cmd as install_cmd
+
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.install.detect_distro") as mock_distro, \
+             patch("waydroid_toolkit.cli.commands.install.Installer") as mock_installer_cls, \
+             patch("waydroid_toolkit.cli.commands.install.IncusBackend") as mock_incus_cls, \
+             patch("waydroid_toolkit.cli.commands.install.set_active_backend") as mock_set, \
+             patch("waydroid_toolkit.cli.commands.install.LxcBackend"):
+            from waydroid_toolkit.utils.distro import Distro
+            mock_distro.return_value = Distro.UBUNTU
+            mock_installer = MagicMock()
+            mock_installer_cls.return_value = mock_installer
+            mock_incus = MagicMock()
+            mock_incus.is_available.return_value = True
+            mock_incus_cls.return_value = mock_incus
+            mock_incus.get_info.return_value = _make_backend_info()
+
+            result = runner.invoke(install_cmd, [])
+
+        mock_set.assert_called_once_with(BackendType.INCUS)
+        assert result.exit_code == 0
+
+    def test_install_lxc_backend_flag(self) -> None:
+        from waydroid_toolkit.cli.commands.install import cmd as install_cmd
+
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.install.detect_distro") as mock_distro, \
+             patch("waydroid_toolkit.cli.commands.install.Installer") as mock_installer_cls, \
+             patch("waydroid_toolkit.cli.commands.install.LxcBackend") as mock_lxc_cls, \
+             patch("waydroid_toolkit.cli.commands.install.set_active_backend") as mock_set, \
+             patch("waydroid_toolkit.cli.commands.install.IncusBackend"):
+            from waydroid_toolkit.utils.distro import Distro
+            mock_distro.return_value = Distro.UBUNTU
+            mock_installer = MagicMock()
+            mock_installer_cls.return_value = mock_installer
+            mock_lxc = MagicMock()
+            mock_lxc.is_available.return_value = True
+            mock_lxc_cls.return_value = mock_lxc
+            mock_lxc.get_info.return_value = _make_backend_info(BackendType.LXC)
+
+            result = runner.invoke(install_cmd, ["--backend", "lxc"])
+
+        mock_set.assert_called_once_with(BackendType.LXC)
+        assert result.exit_code == 0
+
+    def test_install_warns_when_backend_unavailable(self) -> None:
+        from waydroid_toolkit.cli.commands.install import cmd as install_cmd
+
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.install.detect_distro") as mock_distro, \
+             patch("waydroid_toolkit.cli.commands.install.Installer") as mock_installer_cls, \
+             patch("waydroid_toolkit.cli.commands.install.IncusBackend") as mock_incus_cls, \
+             patch("waydroid_toolkit.cli.commands.install.set_active_backend") as mock_set, \
+             patch("waydroid_toolkit.cli.commands.install.LxcBackend"):
+            from waydroid_toolkit.utils.distro import Distro
+            mock_distro.return_value = Distro.UBUNTU
+            mock_installer = MagicMock()
+            mock_installer_cls.return_value = mock_installer
+            mock_incus = MagicMock()
+            mock_incus.is_available.return_value = False
+            mock_incus_cls.return_value = mock_incus
+
+            result = runner.invoke(install_cmd, ["--backend", "incus"])
+
+        mock_set.assert_not_called()
+        assert "Warning" in result.output or "warning" in result.output.lower()

--- a/tests/unit/test_selector_detect_order.py
+++ b/tests/unit/test_selector_detect_order.py
@@ -1,0 +1,92 @@
+"""Tests for selector.detect() Incus-first preference (change A)."""
+
+from __future__ import annotations
+
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.core.container.selector import detect
+
+
+def _make_backend(available: bool, backend_type_value: str) -> MagicMock:
+    b = MagicMock()
+    b.is_available.return_value = available
+    b.backend_type.value = backend_type_value
+    return b
+
+
+class TestDetectOrder:
+    def test_prefers_incus_when_both_available(self) -> None:
+        """detect() returns Incus when both Incus and LXC are available."""
+        incus_instance = _make_backend(True, "incus")
+        lxc_instance = _make_backend(True, "lxc")
+
+        with patch(
+            "waydroid_toolkit.core.container.selector.IncusBackend",
+            return_value=incus_instance,
+        ):
+            with patch(
+                "waydroid_toolkit.core.container.selector.LxcBackend",
+                return_value=lxc_instance,
+            ):
+                result = detect()
+
+        assert result is incus_instance
+        lxc_instance.is_available.assert_not_called()
+
+    def test_falls_back_to_lxc_when_incus_unavailable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """detect() returns LXC and prints a warning when Incus is absent."""
+        incus_instance = _make_backend(False, "incus")
+        lxc_instance = _make_backend(True, "lxc")
+
+        with patch(
+            "waydroid_toolkit.core.container.selector.IncusBackend",
+            return_value=incus_instance,
+        ):
+            with patch(
+                "waydroid_toolkit.core.container.selector.LxcBackend",
+                return_value=lxc_instance,
+            ):
+                result = detect()
+
+        assert result is lxc_instance
+        captured = capsys.readouterr()
+        assert "Incus not found" in captured.err
+        assert "wdt backend switch incus" in captured.err
+
+    def test_raises_when_neither_available(self) -> None:
+        """detect() raises RuntimeError when no backend binary is found."""
+        incus_instance = _make_backend(False, "incus")
+        lxc_instance = _make_backend(False, "lxc")
+
+        with patch(
+            "waydroid_toolkit.core.container.selector.IncusBackend",
+            return_value=incus_instance,
+        ):
+            with patch(
+                "waydroid_toolkit.core.container.selector.LxcBackend",
+                return_value=lxc_instance,
+            ):
+                with pytest.raises(RuntimeError, match="No container backend found"):
+                    detect()
+
+    def test_incus_only_no_warning(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """No warning is printed when Incus is selected."""
+        incus_instance = _make_backend(True, "incus")
+        lxc_instance = _make_backend(True, "lxc")
+
+        with patch(
+            "waydroid_toolkit.core.container.selector.IncusBackend",
+            return_value=incus_instance,
+        ):
+            with patch(
+                "waydroid_toolkit.core.container.selector.LxcBackend",
+                return_value=lxc_instance,
+            ):
+                detect()
+
+        captured = capsys.readouterr()
+        assert captured.err == ""

--- a/tests/unit/test_selector_detect_order.py
+++ b/tests/unit/test_selector_detect_order.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
## Summary

Three related improvements to make Incus the preferred and most visible container backend.

## A — Incus-preferred detection

`selector.detect()` now tries Incus first and falls back to LXC only when Incus is not installed. When LXC is chosen as a fallback, a warning is printed to stderr directing users to `wdt backend switch incus`.

`wdt install` gains a `--backend {incus,lxc}` option (default: `incus`). After `waydroid init` completes, the chosen backend is activated and persisted to config. If the backend binary is not available, a warning is shown and activation is skipped gracefully.

## B — `wdt backend set` alias

`wdt backend set BACKEND` is a new alias for `wdt backend switch BACKEND`. Both call the same `_do_switch()` implementation. Added for discoverability — `set` is the more intuitive verb for new users.

## C — `wdt doctor`

New command that checks the full Waydroid runtime environment:

| Check | Fatal? |
|---|---|
| `waydroid` binary | ✅ |
| waydroid initialized | ✅ |
| container backend binary | ✅ |
| `incus` binary (when Incus active) | ✅ |
| `incus waydroid` container exists | ✅ |
| LXC active but Incus available | ⚠ warning |
| `binder_linux` kernel module | ✅ |
| `ashmem_linux` kernel module | ⚠ warning |
| `/dev/binder`, `/dev/ashmem` | ✅ |
| GPU/DMA device nodes | ⚠ warning |
| `adb` binary | ✅ |
| ADB connected | ⚠ warning |
| audio socket (PipeWire/PA) | ⚠ warning |

`wdt doctor --json` emits machine-readable output.

## Tests

- `test_selector_detect_order` — Incus preference, LXC fallback warning, no-backend error
- `test_backend_set_alias` — set/switch equivalence, unavailable backend, invalid backend
- `test_doctor` — all-ok, each failure mode, JSON output, install `--backend` flag