### PR TITLE
fix(doctor): read XDG_RUNTIME_DIR from os.environ instead of forking bash

### DIFF
--- a/src/waydroid_toolkit/cli/commands/doctor.py
+++ b/src/waydroid_toolkit/cli/commands/doctor.py
@@ -53,10 +53,7 @@ def _device_exists(path: str) -> bool:
 def _audio_socket() -> tuple[str, str]:
     """Return (backend_name, socket_path) for the detected audio backend."""
     runtime = Path(
-        subprocess.run(
-            ["bash", "-c", "echo $XDG_RUNTIME_DIR"],
-            capture_output=True, text=True,
-        ).stdout.strip() or f"/run/user/{os.getuid()}"
+        os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
     )
     pw_sock = runtime / "pipewire-0"
     pa_sock = runtime / "pulse" / "native"


### PR DESCRIPTION
Replaces `subprocess.run(['bash', '-c', 'echo $XDG_RUNTIME_DIR'])` in `_audio_socket()` with `os.environ.get('XDG_RUNTIME_DIR')`.

The subprocess approach fails silently on systems without bash and forks a shell for no reason. `os.environ` is always available, zero-cost, and handles the unset/empty-string case with the same `/run/user/<uid>` fallback.