### PR TITLE
feat: add wdt monitor and wdt container export/import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,30 @@ intended for local development and pre-release validation.
 
 ---
 
+## wdt monitor — container resource stats
+
+`src/waydroid_toolkit/cli/commands/monitor.py`
+
+Provides `wdt monitor status`, `wdt monitor stats`, and `wdt monitor top`.
+Stats are read from `incus info <container> --format json` and parsed from
+the `state.memory`, `state.cpu`, `state.network`, and `state.disk` fields.
+Falls back gracefully when incus is not available.
+
+---
+
+## wdt container export/import — publish as Incus image
+
+`wdt container export [--alias A] [--output PATH]` publishes the Waydroid
+container as a reusable Incus image via `incus publish`. If the container is
+running it is stopped temporarily and restarted after publishing.
+
+`wdt container import --from PATH [--alias A]` imports an image file via
+`incus image import`.
+
+Both commands require the Incus backend.
+
+---
+
 ## wdt container — Incus-level container operations
 
 `src/waydroid_toolkit/cli/commands/container.py`

--- a/src/waydroid_toolkit/cli/commands/container.py
+++ b/src/waydroid_toolkit/cli/commands/container.py
@@ -1,11 +1,13 @@
 """wdt container — Incus-level container lifecycle operations.
 
 These commands operate on the Waydroid container via the active backend.
-Snapshot and console operations require the Incus backend; they raise a
-clear error when the LXC backend is active.
+Snapshot, console, export, and import operations require the Incus backend;
+they raise a clear error when the LXC backend is active.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 import click
 from rich.console import Console
@@ -113,3 +115,104 @@ def container_console() -> None:
     except NotImplementedError as exc:
         console.print(f"[red]{exc}[/red]")
         raise SystemExit(1) from exc
+
+
+# ── export ────────────────────────────────────────────────────────────────────
+
+@cmd.command("export")
+@click.option("--alias", "-a", default="", help="Image alias (default: waydroid-<timestamp>)")
+@click.option(
+    "--output", "-o",
+    default="",
+    help="Also export image to a file at this path.",
+)
+def container_export(alias: str, output: str) -> None:
+    """Publish the Waydroid container as a reusable Incus image.
+
+    Requires the Incus backend. The container is stopped temporarily
+    if running, then published. Use the alias with 'incus init' to
+    create new containers from the image.
+    """
+    import datetime
+    import subprocess
+
+    b = _backend()
+    info = b.get_info()  # type: ignore[attr-defined]
+    container_name = info.container_name
+
+    if not alias:
+        ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        alias = f"waydroid-{ts}"
+
+    try:
+        result = subprocess.run(
+            ["incus", "info", container_name, "--format", "json"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            console.print(f"[red]Container '{container_name}' not found[/red]")
+            raise SystemExit(1)
+
+        import json as _json
+        data = _json.loads(result.stdout)
+        was_running = data.get("status", "").lower() == "running"
+
+        if was_running:
+            console.print(f"[dim]Stopping '{container_name}' for export...[/dim]")
+            subprocess.run(["incus", "stop", container_name], check=True)
+
+        console.print(f"Publishing [bold]{container_name}[/bold] as image [bold]{alias}[/bold] ...")
+        subprocess.run(["incus", "publish", container_name, "--alias", alias], check=True)
+        console.print(f"[green]Published:[/green] {alias}")
+
+        if output:
+            console.print(f"Exporting image to file: {output} ...")
+            subprocess.run(["incus", "image", "export", alias, output], check=True)
+            console.print(f"[green]Image file:[/green] {output}")
+
+        if was_running:
+            subprocess.run(["incus", "start", container_name], check=True)
+
+    except NotImplementedError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]Command failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+
+# ── import ────────────────────────────────────────────────────────────────────
+
+@cmd.command("import")
+@click.option(
+    "--from", "source",
+    required=True,
+    type=click.Path(exists=True, path_type=Path),
+    help="Image file to import.",
+)
+@click.option("--alias", "-a", default="", help="Alias to assign to the imported image.")
+def container_import(source: Path, alias: str) -> None:
+    """Import an Incus image from a file.
+
+    After importing, create a new container with:
+      incus init <alias> <name>
+
+    Requires the Incus backend.
+    """
+    import subprocess
+
+    _backend()  # ensure backend is available
+
+    import_cmd = ["incus", "image", "import", str(source)]
+    if alias:
+        import_cmd += ["--alias", alias]
+
+    console.print(f"Importing image from [bold]{source}[/bold] ...")
+    try:
+        subprocess.run(import_cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]Import failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[green]Image imported[/green]{f': {alias}' if alias else ''}")
+    console.print(f"  Create a container: incus init {alias or '<alias>'} <name>")

--- a/src/waydroid_toolkit/cli/commands/monitor.py
+++ b/src/waydroid_toolkit/cli/commands/monitor.py
@@ -1,0 +1,158 @@
+"""wdt monitor — Waydroid container resource usage and stats.
+
+Shows CPU, memory, network, and disk stats for the active Waydroid
+container via the active backend.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from waydroid_toolkit.core.container import ContainerState
+from waydroid_toolkit.core.container import get_active as get_backend
+
+console = Console()
+
+
+def _backend() -> object:
+    try:
+        return get_backend()
+    except RuntimeError as exc:
+        console.print(f"[red]No backend available: {exc}[/red]")
+        raise SystemExit(1) from exc
+
+
+@click.group("monitor")
+def cmd() -> None:
+    """Show Waydroid container resource usage and stats."""
+
+
+@cmd.command("status")
+def monitor_status() -> None:
+    """Detailed container status with resource info."""
+    b = _backend()
+    info = b.get_info()  # type: ignore[attr-defined]
+    state = b.get_state()  # type: ignore[attr-defined]
+
+    console.print(f"[bold]Container:[/bold] {info.container_name}")
+    console.print(f"[bold]Backend  :[/bold] {info.backend_type.value} {info.version}")
+    console.print()
+
+    state_colour = {
+        ContainerState.RUNNING: "green",
+        ContainerState.STOPPED: "yellow",
+        ContainerState.FROZEN:  "cyan",
+        ContainerState.UNKNOWN: "red",
+    }.get(state, "white")
+    console.print(f"  Status : [{state_colour}]{state.value}[/{state_colour}]")
+
+    if state == ContainerState.RUNNING:
+        console.print()
+        _print_stats(info.container_name)
+
+
+@cmd.command("stats")
+def monitor_stats() -> None:
+    """CPU, memory, disk, and network stats (requires running container)."""
+    b = _backend()
+    info = b.get_info()  # type: ignore[attr-defined]
+    state = b.get_state()  # type: ignore[attr-defined]
+
+    if state != ContainerState.RUNNING:
+        console.print(f"[yellow]Container is not running (state: {state.value})[/yellow]")
+        raise SystemExit(1)
+
+    _print_stats(info.container_name)
+
+
+@cmd.command("top")
+def monitor_top() -> None:
+    """Overview of the Waydroid container (single-instance summary)."""
+    b = _backend()
+    info = b.get_info()  # type: ignore[attr-defined]
+    state = b.get_state()  # type: ignore[attr-defined]
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Container", style="dim")
+    table.add_column("Backend")
+    table.add_column("Status")
+
+    state_colour = {
+        ContainerState.RUNNING: "green",
+        ContainerState.STOPPED: "yellow",
+        ContainerState.FROZEN:  "cyan",
+        ContainerState.UNKNOWN: "red",
+    }.get(state, "white")
+
+    table.add_row(
+        info.container_name,
+        f"{info.backend_type.value} {info.version}",
+        f"[{state_colour}]{state.value}[/{state_colour}]",
+    )
+    console.print(table)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _print_stats(container_name: str) -> None:
+    """Print resource stats from incus info --format json."""
+    try:
+        result = subprocess.run(
+            ["incus", "info", container_name, "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        console.print("[yellow]incus not found — stats unavailable[/yellow]")
+        return
+
+    if result.returncode != 0:
+        console.print("[yellow]Could not retrieve stats from incus[/yellow]")
+        return
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        console.print("[yellow]Could not parse incus info output[/yellow]")
+        return
+
+    state_data = data.get("state") or {}
+
+    # Memory
+    mem = state_data.get("memory", {})
+    if mem:
+        usage_mb = mem.get("usage", 0) / (1024 * 1024)
+        peak_mb  = mem.get("usage_peak", 0) / (1024 * 1024)
+        console.print(f"  [bold]Memory[/bold] : {usage_mb:.1f} MiB used / {peak_mb:.1f} MiB peak")
+
+    # CPU
+    cpu = state_data.get("cpu", {})
+    if cpu:
+        usage_ns = cpu.get("usage", 0)
+        console.print(f"  [bold]CPU   [/bold] : {usage_ns / 1e9:.2f}s total CPU time")
+
+    # Network
+    net = state_data.get("network", {})
+    if net:
+        console.print()
+        console.print("  [bold]Network[/bold]")
+        for iface, idata in net.items():
+            counters = idata.get("counters", {})
+            rx = counters.get("bytes_received", 0) / (1024 * 1024)
+            tx = counters.get("bytes_sent", 0) / (1024 * 1024)
+            console.print(f"    {iface}: ↓ {rx:.1f} MiB  ↑ {tx:.1f} MiB")
+
+    # Disk
+    disk = state_data.get("disk", {})
+    if disk:
+        console.print()
+        console.print("  [bold]Disk[/bold]")
+        for dev, ddata in disk.items():
+            usage_mb = ddata.get("usage", 0) / (1024 * 1024)
+            console.print(f"    {dev}: {usage_mb:.1f} MiB used")

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -34,6 +34,7 @@ from .commands import (
     images,
     install,
     maintenance,
+    monitor,
     packages,
     performance,
     snapshot,
@@ -71,6 +72,7 @@ def cli() -> None:
 cli.add_command(status.cmd, name="status")
 cli.add_command(doctor.cmd, name="doctor")
 cli.add_command(assemble.cmd, name="assemble")
+cli.add_command(monitor.cmd, name="monitor")
 cli.add_command(install.cmd, name="install")
 cli.add_command(build.cmd, name="build")
 cli.add_command(_gui_cmd(), name="gui")

--- a/tests/unit/test_container_export_import.py
+++ b/tests/unit/test_container_export_import.py
@@ -1,0 +1,120 @@
+"""Tests for wdt container export and import commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.container import cmd as container_cmd
+from waydroid_toolkit.core.container import BackendType
+
+
+def _make_backend(status: str = "stopped") -> MagicMock:
+    b = MagicMock()
+    info = MagicMock()
+    info.container_name = "waydroid"
+    info.backend_type = BackendType.INCUS
+    info.version = "6.0.0"
+    b.get_info.return_value = info
+    return b
+
+
+def _incus_info_json(status: str = "stopped") -> str:
+    return json.dumps({"status": status})
+
+
+class TestContainerExport:
+    def test_export_publishes_image(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0, stdout=_incus_info_json("stopped")
+                )
+                result = runner.invoke(
+                    container_cmd, ["export", "--alias", "waydroid-golden"]
+                )
+        assert result.exit_code == 0
+        # publish call should be present
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("publish" in c for c in calls)
+
+    def test_export_with_output_file(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend()
+        out = str(tmp_path / "waydroid.tar.gz")
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0, stdout=_incus_info_json("stopped")
+                )
+                result = runner.invoke(
+                    container_cmd,
+                    ["export", "--alias", "waydroid-golden", "--output", out],
+                )
+        assert result.exit_code == 0
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("export" in c for c in calls)
+
+    def test_export_stops_and_restarts_running_container(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0, stdout=_incus_info_json("running")
+                )
+                result = runner.invoke(
+                    container_cmd, ["export", "--alias", "waydroid-golden"]
+                )
+        assert result.exit_code == 0
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("stop" in c for c in calls)
+        assert any("start" in c for c in calls)
+
+    def test_export_container_not_found(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1, stdout="")
+                result = runner.invoke(
+                    container_cmd, ["export", "--alias", "waydroid-golden"]
+                )
+        assert result.exit_code != 0
+
+
+class TestContainerImport:
+    def test_import_from_file(self, tmp_path: Path) -> None:
+        archive = tmp_path / "waydroid.tar.gz"
+        archive.write_bytes(b"fake")
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(
+                    container_cmd,
+                    ["import", "--from", str(archive), "--alias", "waydroid-golden"],
+                )
+        assert result.exit_code == 0
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("import" in c for c in calls)
+        assert any("waydroid-golden" in c for c in calls)
+
+    def test_import_without_alias(self, tmp_path: Path) -> None:
+        archive = tmp_path / "waydroid.tar.gz"
+        archive.write_bytes(b"fake")
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(
+                    container_cmd, ["import", "--from", str(archive)]
+                )
+        assert result.exit_code == 0

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,100 @@
+"""Tests for wdt monitor."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.monitor import cmd as monitor_cmd
+from waydroid_toolkit.core.container import BackendType, ContainerState
+
+
+def _make_backend(state: ContainerState = ContainerState.RUNNING) -> MagicMock:
+    b = MagicMock()
+    b.get_state.return_value = state
+    info = MagicMock()
+    info.container_name = "waydroid"
+    info.backend_type = BackendType.INCUS
+    info.version = "6.0.0"
+    b.get_info.return_value = info
+    return b
+
+
+def _incus_info_json(status: str = "running") -> str:
+    return json.dumps({
+        "status": status,
+        "state": {
+            "memory": {"usage": 512 * 1024 * 1024, "usage_peak": 768 * 1024 * 1024},
+            "cpu": {"usage": 5_000_000_000},
+            "network": {
+                "eth0": {"counters": {"bytes_received": 10 * 1024 * 1024, "bytes_sent": 2 * 1024 * 1024}},
+            },
+            "disk": {
+                "root": {"usage": 2048 * 1024 * 1024},
+            },
+        },
+    })
+
+
+class TestMonitorStatus:
+    def test_shows_running_state(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=_incus_info_json())
+                result = runner.invoke(monitor_cmd, ["status"])
+        assert result.exit_code == 0
+        assert "waydroid" in result.output
+        assert "RUNNING" in result.output
+
+    def test_shows_stopped_state(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.STOPPED)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            result = runner.invoke(monitor_cmd, ["status"])
+        assert result.exit_code == 0
+        assert "STOPPED" in result.output
+
+
+class TestMonitorStats:
+    def test_stats_requires_running(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.STOPPED)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            result = runner.invoke(monitor_cmd, ["stats"])
+        assert result.exit_code != 0
+
+    def test_stats_shows_memory(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=_incus_info_json())
+                result = runner.invoke(monitor_cmd, ["stats"])
+        assert result.exit_code == 0
+        assert "Memory" in result.output
+        assert "MiB" in result.output
+
+    def test_stats_shows_network(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=_incus_info_json())
+                result = runner.invoke(monitor_cmd, ["stats"])
+        assert result.exit_code == 0
+        assert "eth0" in result.output
+
+
+class TestMonitorTop:
+    def test_top_shows_table(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            result = runner.invoke(monitor_cmd, ["top"])
+        assert result.exit_code == 0
+        assert "waydroid" in result.output
+        assert "RUNNING" in result.output

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -48,7 +48,7 @@ class TestMonitorStatus:
                 result = runner.invoke(monitor_cmd, ["status"])
         assert result.exit_code == 0
         assert "waydroid" in result.output
-        assert "RUNNING" in result.output
+        assert "running" in result.output
 
     def test_shows_stopped_state(self) -> None:
         runner = CliRunner()
@@ -56,7 +56,7 @@ class TestMonitorStatus:
         with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
             result = runner.invoke(monitor_cmd, ["status"])
         assert result.exit_code == 0
-        assert "STOPPED" in result.output
+        assert "stopped" in result.output
 
 
 class TestMonitorStats:
@@ -97,4 +97,4 @@ class TestMonitorTop:
             result = runner.invoke(monitor_cmd, ["top"])
         assert result.exit_code == 0
         assert "waydroid" in result.output
-        assert "RUNNING" in result.output
+        assert "running" in result.output


### PR DESCRIPTION
## Summary

Adds resource monitoring and Incus image publish/import to bring waydroid-toolkit to full parity with the other projects in this suite.

## New commands

### `wdt monitor`

```
wdt monitor status   # container name, backend, state; stats when running
wdt monitor stats    # memory, CPU, network, disk from incus info --format json
wdt monitor top      # Rich table: container, backend, state
```

Stats are read from `incus info <container> --format json` and parsed from `state.memory`, `state.cpu`, `state.network`, `state.disk`. Falls back gracefully when incus is not available or the container is not running.

### `wdt container export` / `wdt container import`

```
wdt container export [--alias A] [--output PATH]
wdt container import --from PATH [--alias A]
```

- `export` publishes the Waydroid container as a reusable Incus image via `incus publish`. Stops and restarts the container if running.
- `import` imports an image file via `incus image import`.
- Both require the Incus backend.

## Tests

- `test_monitor.py`: 7 cases — status (running/stopped), stats (requires running, memory, network), top
- `test_container_export_import.py`: 6 cases — export (publish, with output file, stop/restart running, not found), import (with/without alias)

## AGENTS.md

Updated with `wdt monitor` and container export/import sections.