### PR TITLE
feat: add snapshot-auto, cloud-sync, and monitor disk

### DIFF
--- a/src/waydroid_toolkit/cli/commands/cloud_sync.py
+++ b/src/waydroid_toolkit/cli/commands/cloud_sync.py
@@ -1,0 +1,264 @@
+"""wdt cloud-sync — sync Waydroid container backups to cloud storage via rclone."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_DEFAULT_BACKUP_DIR = Path.home() / ".local" / "share" / "waydroid-toolkit" / "backups"
+_DEFAULT_REMOTE = "wdt-backups"
+_DEFAULT_PATH = "wdt/backups"
+
+
+def _backup_dir() -> Path:
+    return Path(os.environ.get("WDT_BACKUP_DIR", str(_DEFAULT_BACKUP_DIR)))
+
+
+def _remote_name() -> str:
+    return os.environ.get("WDT_CLOUD_REMOTE", _DEFAULT_REMOTE)
+
+
+def _remote_path() -> str:
+    return os.environ.get("WDT_CLOUD_PATH", _DEFAULT_PATH)
+
+
+def _require_rclone() -> None:
+    if shutil.which("rclone") is None:
+        console.print("[red]rclone is required for cloud sync.[/red]")
+        console.print("Install: https://rclone.org/install/")
+        raise SystemExit(1)
+
+
+def _remote_configured() -> bool:
+    result = subprocess.run(
+        ["rclone", "listremotes"],
+        capture_output=True, text=True,
+    )
+    return f"{_remote_name()}:" in result.stdout
+
+
+@click.group("cloud-sync")
+def cmd() -> None:
+    """Sync Waydroid container backups to cloud storage via rclone."""
+
+
+@cmd.command("push")
+@click.argument("filter_str", metavar="[FILTER]", default="", required=False)
+def cloud_push(filter_str: str) -> None:
+    """Upload local backups to the configured remote.
+
+    FILTER optionally restricts upload to filenames containing the given string.
+    """
+    _require_rclone()
+    backup_dir = _backup_dir()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    if not _remote_configured():
+        console.print(f"[red]Remote '{_remote_name()}' not configured.[/red]")
+        console.print("Run: wdt cloud-sync config")
+        raise SystemExit(1)
+
+    remote = f"{_remote_name()}:{_remote_path()}/"
+    console.print(f"[bold]Cloud Sync: Push[/bold]")
+    console.print(f"  Local  : {backup_dir}")
+    console.print(f"  Remote : {remote}")
+
+    count = 0
+    for pattern in ("*.tar.gz", "*.tar"):
+        for f in backup_dir.glob(pattern):
+            if filter_str and filter_str not in f.name:
+                continue
+            size_mb = f.stat().st_size / (1024 * 1024)
+            console.print(f"  Uploading: {f.name} ({size_mb:.1f} MiB)")
+            result = subprocess.run(
+                ["rclone", "copy", str(f), remote, "--progress", "--transfers", "1"],
+            )
+            if result.returncode != 0:
+                console.print(f"[yellow]Failed to upload: {f.name}[/yellow]")
+                continue
+            count += 1
+
+    for f in backup_dir.glob("*.meta"):
+        subprocess.run(["rclone", "copy", str(f), remote], capture_output=True)
+
+    if count == 0:
+        console.print("[yellow]No backups to upload.[/yellow]")
+    else:
+        console.print(f"[green]Uploaded {count} backup(s).[/green]")
+
+
+@cmd.command("pull")
+@click.argument("filter_str", metavar="[FILTER]", default="", required=False)
+def cloud_pull(filter_str: str) -> None:
+    """Download remote backups to the local backup directory.
+
+    FILTER optionally restricts download to filenames containing the given string.
+    """
+    _require_rclone()
+    backup_dir = _backup_dir()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    if not _remote_configured():
+        console.print(f"[red]Remote '{_remote_name()}' not configured.[/red]")
+        console.print("Run: wdt cloud-sync config")
+        raise SystemExit(1)
+
+    remote = f"{_remote_name()}:{_remote_path()}/"
+    console.print(f"[bold]Cloud Sync: Pull[/bold]")
+    console.print(f"  Remote : {remote}")
+    console.print(f"  Local  : {backup_dir}")
+
+    pull_cmd = ["rclone", "copy", remote, str(backup_dir), "--progress", "--transfers", "1"]
+    if filter_str:
+        pull_cmd += ["--include", f"*{filter_str}*"]
+
+    result = subprocess.run(pull_cmd)
+    if result.returncode != 0:
+        console.print("[red]Pull failed.[/red]")
+        raise SystemExit(1)
+
+    console.print("[green]Pull complete.[/green]")
+
+
+@cmd.command("list")
+def cloud_list() -> None:
+    """List backups stored on the remote."""
+    _require_rclone()
+
+    if not _remote_configured():
+        console.print(f"[red]Remote '{_remote_name()}' not configured.[/red]")
+        console.print("Run: wdt cloud-sync config")
+        raise SystemExit(1)
+
+    remote = f"{_remote_name()}:{_remote_path()}/"
+    console.print(f"[bold]Remote Backups:[/bold] {remote}")
+    console.print()
+
+    result = subprocess.run(
+        ["rclone", "lsf", remote, "--format", "psm"],
+        capture_output=True, text=True,
+    )
+    rows = []
+    for line in result.stdout.splitlines():
+        parts = line.split(";", 2)
+        if len(parts) < 3:
+            continue
+        path, size, mod = parts
+        if path.endswith(".meta"):
+            continue
+        rows.append((path, size, mod))
+
+    if rows:
+        console.print(f"  {'FILENAME':<40} {'SIZE':<12} MODIFIED")
+        console.print(f"  {'--------':<40} {'----':<12} --------")
+        for path, size, mod in rows:
+            console.print(f"  {path:<40} {size:<12} {mod}")
+    else:
+        console.print("[yellow]  No remote backups found.[/yellow]")
+
+    backup_dir = _backup_dir()
+    local_count = len(list(backup_dir.glob("*.tar*"))) if backup_dir.exists() else 0
+    remote_count = len(rows)
+    console.print()
+    console.print(f"  Local: {local_count} backups | Remote: {remote_count} backups")
+
+
+@cmd.group("config")
+def cloud_config() -> None:
+    """Configure the rclone remote for cloud sync."""
+
+
+@cloud_config.command("show")
+def config_show() -> None:
+    """Show current cloud sync configuration."""
+    console.print("[bold]Cloud Sync Configuration[/bold]")
+    console.print(f"  Remote name : {_remote_name()}")
+    console.print(f"  Remote path : {_remote_path()}")
+    console.print(f"  Local dir   : {_backup_dir()}")
+    if _remote_configured():
+        console.print(f"[green]Remote '{_remote_name()}' is configured.[/green]")
+    else:
+        console.print(f"[yellow]Remote '{_remote_name()}' is not configured.[/yellow]")
+        console.print("Run: wdt cloud-sync config s3  (or b2 / interactive)")
+
+
+@cloud_config.command("s3")
+def config_s3() -> None:
+    """Configure an S3-compatible remote interactively via rclone."""
+    _require_rclone()
+    console.print("[dim]Configuring S3-compatible remote...[/dim]")
+    result = subprocess.run(
+        ["rclone", "config", "create", _remote_name(), "s3",
+         "provider", "AWS", "env_auth", "false"],
+    )
+    if result.returncode != 0:
+        console.print("[red]S3 config failed.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]S3 remote configured as '{_remote_name()}'.[/green]")
+
+
+@cloud_config.command("b2")
+def config_b2() -> None:
+    """Configure a Backblaze B2 remote interactively via rclone."""
+    _require_rclone()
+    console.print("[dim]Configuring Backblaze B2 remote...[/dim]")
+    result = subprocess.run(["rclone", "config", "create", _remote_name(), "b2"])
+    if result.returncode != 0:
+        console.print("[red]B2 config failed.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]B2 remote configured as '{_remote_name()}'.[/green]")
+
+
+@cloud_config.command("interactive")
+def config_interactive() -> None:
+    """Launch rclone interactive config."""
+    _require_rclone()
+    console.print(f"[dim]Create a remote named: {_remote_name()}[/dim]")
+    subprocess.run(["rclone", "config"])
+
+
+@cmd.command("status")
+def cloud_status() -> None:
+    """Show sync status: local vs remote backup counts."""
+    _require_rclone()
+    console.print("[bold]Cloud Sync Status[/bold]")
+
+    if not _remote_configured():
+        console.print(f"[yellow]Remote '{_remote_name()}' not configured.[/yellow]")
+        console.print("Run: wdt cloud-sync config")
+        raise SystemExit(1)
+
+    console.print(f"[green]Remote:[/green] {_remote_name()} (configured)")
+    console.print(f"  Path: {_remote_path()}")
+
+    backup_dir = _backup_dir()
+    local_count = len(list(backup_dir.glob("*.tar*"))) if backup_dir.exists() else 0
+    remote = f"{_remote_name()}:{_remote_path()}/"
+    remote_result = subprocess.run(
+        ["rclone", "lsf", remote, "--include", "*.tar*"],
+        capture_output=True, text=True,
+    )
+    remote_files = set(remote_result.stdout.splitlines())
+    remote_count = len(remote_files)
+
+    console.print(f"  Local backups  : {local_count}")
+    console.print(f"  Remote backups : {remote_count}")
+
+    unsynced = 0
+    if backup_dir.exists():
+        for f in list(backup_dir.glob("*.tar.gz")) + list(backup_dir.glob("*.tar")):
+            if f.name not in remote_files:
+                unsynced += 1
+
+    if unsynced > 0:
+        console.print(f"[yellow]{unsynced} local backup(s) not yet synced.[/yellow]")
+        console.print("Run: wdt cloud-sync push")
+    else:
+        console.print("[green]All local backups synced.[/green]")

--- a/src/waydroid_toolkit/cli/commands/container.py
+++ b/src/waydroid_toolkit/cli/commands/container.py
@@ -101,6 +101,58 @@ def snapshot_delete(name: str) -> None:
     console.print(f"[green]Deleted snapshot:[/green] {name}")
 
 
+@cmd.group("snapshot-auto")
+def container_snapshot_auto() -> None:
+    """Manage automatic snapshot schedules for the Waydroid container."""
+
+
+@container_snapshot_auto.command("set")
+@click.argument("schedule")
+@click.option("--expiry", default="", help="Auto-delete after duration (e.g. 7d, 30d).")
+@click.option("--pattern", default="snap-%d", show_default=True, help="Snapshot naming pattern.")
+def snapshot_auto_set(schedule: str, expiry: str, pattern: str) -> None:
+    """Set an automatic snapshot schedule.
+
+    SCHEDULE accepts cron expressions or shorthand (@daily, @weekly, etc.).
+    """
+    b = _backend()
+    try:
+        b.snapshot_auto_set(schedule, expiry, pattern)  # type: ignore[attr-defined]
+    except NotImplementedError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print(f"[green]Auto-snapshot configured:[/green] {schedule}")
+    if expiry:
+        console.print(f"  Expiry  : {expiry}")
+    console.print(f"  Pattern : {pattern}")
+
+
+@container_snapshot_auto.command("show")
+def snapshot_auto_show() -> None:
+    """Show the current automatic snapshot schedule."""
+    b = _backend()
+    try:
+        cfg = b.snapshot_auto_show()  # type: ignore[attr-defined]
+    except NotImplementedError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print(f"  Schedule : {cfg.get('snapshots.schedule', '(not set)')}")
+    console.print(f"  Expiry   : {cfg.get('snapshots.expiry', '(not set)')}")
+    console.print(f"  Pattern  : {cfg.get('snapshots.pattern', '(not set)')}")
+
+
+@container_snapshot_auto.command("disable")
+def snapshot_auto_disable() -> None:
+    """Remove the automatic snapshot schedule."""
+    b = _backend()
+    try:
+        b.snapshot_auto_disable()  # type: ignore[attr-defined]
+    except NotImplementedError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print("[green]Auto-snapshot disabled.[/green]")
+
+
 # ── console ───────────────────────────────────────────────────────────────────
 
 @cmd.command("console")

--- a/src/waydroid_toolkit/cli/commands/monitor.py
+++ b/src/waydroid_toolkit/cli/commands/monitor.py
@@ -70,6 +70,57 @@ def monitor_stats() -> None:
     _print_stats(info.container_name)
 
 
+@cmd.command("disk")
+def monitor_disk() -> None:
+    """Disk usage and allocation for the Waydroid container."""
+    b = _backend()
+    info = b.get_info()  # type: ignore[attr-defined]
+    container_name = info.container_name
+
+    # Allocated root disk size from incus config
+    try:
+        alloc_result = subprocess.run(
+            ["incus", "config", "device", "get", container_name, "root", "size"],
+            capture_output=True, text=True, timeout=5,
+        )
+        allocated = alloc_result.stdout.strip() or "pool default"
+    except FileNotFoundError:
+        allocated = "incus not found"
+
+    console.print(f"[bold]Disk:[/bold] {container_name}")
+    console.print(f"  Allocated : {allocated}")
+    console.print()
+
+    # Live disk usage from incus info --format json
+    try:
+        result = subprocess.run(
+            ["incus", "info", container_name, "--format", "json"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except FileNotFoundError:
+        console.print("[yellow]incus not found — disk usage unavailable[/yellow]")
+        return
+
+    if result.returncode != 0:
+        console.print("[yellow]Could not retrieve disk info from incus[/yellow]")
+        return
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        console.print("[yellow]Could not parse incus info output[/yellow]")
+        return
+
+    disk = (data.get("state") or {}).get("disk", {})
+    if disk:
+        console.print("  [bold]Usage[/bold]")
+        for dev, ddata in disk.items():
+            usage_mb = ddata.get("usage", 0) / (1024 * 1024)
+            console.print(f"    {dev}: {usage_mb:.1f} MiB used")
+    else:
+        console.print("  [yellow]Disk usage not available (container may be stopped)[/yellow]")
+
+
 @cmd.command("top")
 def monitor_top() -> None:
     """Overview of the Waydroid container (single-instance summary)."""

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -27,6 +27,7 @@ from .commands import (
     backend,
     backup,
     build,
+    cloud_sync,
     container,
     dbus,
     doctor,
@@ -85,4 +86,5 @@ cli.add_command(performance.cmd, name="performance")
 cli.add_command(maintenance.cmd, name="maintenance")
 cli.add_command(snapshot.cmd, name="snapshot")
 cli.add_command(container.cmd, name="container")
+cli.add_command(cloud_sync.cmd, name="cloud-sync")
 cli.add_command(dbus.cmd, name="dbus")

--- a/src/waydroid_toolkit/core/container/base.py
+++ b/src/waydroid_toolkit/core/container/base.py
@@ -130,6 +130,21 @@ class ContainerBackend(ABC):
         """Delete a named snapshot."""
         ...
 
+    @abstractmethod
+    def snapshot_auto_set(self, schedule: str, expiry: str = "", pattern: str = "snap-%d") -> None:
+        """Configure an automatic snapshot schedule via incus config."""
+        ...
+
+    @abstractmethod
+    def snapshot_auto_show(self) -> dict[str, str]:
+        """Return current auto-snapshot config keys: schedule, expiry, pattern."""
+        ...
+
+    @abstractmethod
+    def snapshot_auto_disable(self) -> None:
+        """Remove the automatic snapshot schedule."""
+        ...
+
     # ── Console ───────────────────────────────────────────────────────────────
 
     @abstractmethod

--- a/src/waydroid_toolkit/core/container/incus_backend.py
+++ b/src/waydroid_toolkit/core/container/incus_backend.py
@@ -466,6 +466,42 @@ class IncusBackend(ContainerBackend):
             check=True,
         )
 
+    def snapshot_auto_set(self, schedule: str, expiry: str = "", pattern: str = "snap-%d") -> None:
+        subprocess.run(
+            ["incus", "config", "set", self.CONTAINER_NAME, "snapshots.schedule", schedule],
+            check=True,
+        )
+        subprocess.run(
+            ["incus", "config", "set", self.CONTAINER_NAME, "snapshots.pattern", pattern],
+            check=True,
+        )
+        subprocess.run(
+            ["incus", "config", "set", self.CONTAINER_NAME, "snapshots.schedule.stopped", "false"],
+            check=True,
+        )
+        if expiry:
+            subprocess.run(
+                ["incus", "config", "set", self.CONTAINER_NAME, "snapshots.expiry", expiry],
+                check=True,
+            )
+
+    def snapshot_auto_show(self) -> dict[str, str]:
+        keys = ("snapshots.schedule", "snapshots.expiry", "snapshots.pattern")
+        result: dict[str, str] = {}
+        for key in keys:
+            r = subprocess.run(
+                ["incus", "config", "get", self.CONTAINER_NAME, key],
+                capture_output=True, text=True,
+            )
+            result[key] = r.stdout.strip() if r.returncode == 0 else "(not set)"
+        return result
+
+    def snapshot_auto_disable(self) -> None:
+        subprocess.run(
+            ["incus", "config", "unset", self.CONTAINER_NAME, "snapshots.schedule"],
+            check=False,
+        )
+
     # ── Console ───────────────────────────────────────────────────────────────
 
     def console(self) -> None:

--- a/src/waydroid_toolkit/core/container/lxc_backend.py
+++ b/src/waydroid_toolkit/core/container/lxc_backend.py
@@ -141,6 +141,17 @@ class LxcBackend(ContainerBackend):
     def snapshot_delete(self, name: str) -> None:  # noqa: ARG002
         raise NotImplementedError(_INCUS_ONLY_MSG)
 
+    def snapshot_auto_set(  # noqa: ARG002
+        self, schedule: str, expiry: str = "", pattern: str = "snap-%d"
+    ) -> None:
+        raise NotImplementedError(_INCUS_ONLY_MSG)
+
+    def snapshot_auto_show(self) -> dict[str, str]:
+        raise NotImplementedError(_INCUS_ONLY_MSG)
+
+    def snapshot_auto_disable(self) -> None:
+        raise NotImplementedError(_INCUS_ONLY_MSG)
+
     # ── Console (Incus-only) ──────────────────────────────────────────────────
 
     def console(self) -> None:

--- a/tests/unit/test_cloud_sync.py
+++ b/tests/unit/test_cloud_sync.py
@@ -1,0 +1,117 @@
+"""Tests for wdt cloud-sync."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.cloud_sync import cmd as cloud_sync_cmd
+
+
+def _mock_rclone(configured: bool = True) -> MagicMock:
+    m = MagicMock(returncode=0)
+    m.stdout = "wdt-backups:\n" if configured else ""
+    return m
+
+
+class TestCloudSyncPush:
+    def test_push_exits_when_rclone_missing(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value=None):
+            result = runner.invoke(cloud_sync_cmd, ["push"])
+        assert result.exit_code != 0
+
+    def test_push_exits_when_remote_not_configured(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
+                with patch("waydroid_toolkit.cli.commands.cloud_sync._backup_dir", return_value=tmp_path):
+                    result = runner.invoke(cloud_sync_cmd, ["push"])
+        assert result.exit_code != 0
+
+    def test_push_uploads_tar_files(self, tmp_path: Path) -> None:
+        (tmp_path / "mybox-20240101.tar.gz").write_bytes(b"x" * 1024)
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="wdt-backups:\n")
+                with patch("waydroid_toolkit.cli.commands.cloud_sync._backup_dir", return_value=tmp_path):
+                    result = runner.invoke(cloud_sync_cmd, ["push"])
+        assert result.exit_code == 0
+        assert "Uploaded" in result.output
+
+    def test_push_filter_skips_non_matching(self, tmp_path: Path) -> None:
+        (tmp_path / "mybox.tar.gz").write_bytes(b"x")
+        (tmp_path / "otherbox.tar.gz").write_bytes(b"x")
+        runner = CliRunner()
+        calls = []
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="wdt-backups:\n")
+                with patch("waydroid_toolkit.cli.commands.cloud_sync._backup_dir", return_value=tmp_path):
+                    result = runner.invoke(cloud_sync_cmd, ["push", "mybox"])
+        assert result.exit_code == 0
+        # Only mybox should appear in upload output
+        assert "mybox" in result.output
+
+
+class TestCloudSyncStatus:
+    def test_status_exits_when_rclone_missing(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value=None):
+            result = runner.invoke(cloud_sync_cmd, ["status"])
+        assert result.exit_code != 0
+
+    def test_status_shows_configured(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="wdt-backups:\n")
+                with patch("waydroid_toolkit.cli.commands.cloud_sync._backup_dir", return_value=tmp_path):
+                    result = runner.invoke(cloud_sync_cmd, ["status"])
+        assert result.exit_code == 0
+        assert "configured" in result.output
+
+    def test_status_exits_when_not_configured(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
+                with patch("waydroid_toolkit.cli.commands.cloud_sync._backup_dir", return_value=tmp_path):
+                    result = runner.invoke(cloud_sync_cmd, ["status"])
+        assert result.exit_code != 0
+
+
+class TestCloudSyncList:
+    def test_list_exits_when_not_configured(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
+                result = runner.invoke(cloud_sync_cmd, ["list"])
+        assert result.exit_code != 0
+
+    def test_list_shows_remote_files(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        lsf_output = "mybox.tar.gz;1024;2024-01-01 00:00:00\n"
+        call_count = 0
+
+        def fake_run(cmd, **kw):
+            nonlocal call_count
+            call_count += 1
+            m = MagicMock(returncode=0)
+            if "listremotes" in cmd:
+                m.stdout = "wdt-backups:\n"
+            else:
+                m.stdout = lsf_output
+            return m
+
+        with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run", side_effect=fake_run):
+                with patch("waydroid_toolkit.cli.commands.cloud_sync._backup_dir", return_value=tmp_path):
+                    result = runner.invoke(cloud_sync_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "mybox.tar.gz" in result.output

--- a/tests/unit/test_container_backend.py
+++ b/tests/unit/test_container_backend.py
@@ -221,6 +221,18 @@ class TestLxcBackend:
         with pytest.raises(NotImplementedError, match="Incus backend"):
             LxcBackend().snapshot_delete("snap1")
 
+    def test_snapshot_auto_set_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError, match="Incus backend"):
+            LxcBackend().snapshot_auto_set("@daily")
+
+    def test_snapshot_auto_show_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError, match="Incus backend"):
+            LxcBackend().snapshot_auto_show()
+
+    def test_snapshot_auto_disable_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError, match="Incus backend"):
+            LxcBackend().snapshot_auto_disable()
+
     def test_console_raises_not_implemented(self) -> None:
         with pytest.raises(NotImplementedError, match="Incus backend"):
             LxcBackend().console()
@@ -430,6 +442,46 @@ class TestIncusBackend:
             IncusBackend().snapshot_delete("snap1")
             args = mock_run.call_args[0][0]
             assert args == ["incus", "snapshot", "delete", "waydroid", "snap1"]
+
+    def test_snapshot_auto_set_calls_incus_config(self) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            IncusBackend().snapshot_auto_set("@daily", expiry="7d", pattern="auto-%d")
+            calls = [c[0][0] for c in mock_run.call_args_list]
+            assert ["incus", "config", "set", "waydroid", "snapshots.schedule", "@daily"] in calls
+            assert ["incus", "config", "set", "waydroid", "snapshots.expiry", "7d"] in calls
+            assert ["incus", "config", "set", "waydroid", "snapshots.pattern", "auto-%d"] in calls
+
+    def test_snapshot_auto_set_no_expiry_skips_expiry_call(self) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            IncusBackend().snapshot_auto_set("@daily")
+            calls = [c[0][0] for c in mock_run.call_args_list]
+            expiry_calls = [c for c in calls if "snapshots.expiry" in c]
+            assert expiry_calls == []
+
+    def test_snapshot_auto_show_returns_dict(self) -> None:
+        def fake_run(cmd, **_kw):
+            m = MagicMock(returncode=0)
+            if "snapshots.schedule" in cmd:
+                m.stdout = "@daily\n"
+            elif "snapshots.expiry" in cmd:
+                m.stdout = "7d\n"
+            else:
+                m.stdout = "snap-%d\n"
+            return m
+
+        with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run", side_effect=fake_run):
+            result = IncusBackend().snapshot_auto_show()
+        assert result["snapshots.schedule"] == "@daily"
+        assert result["snapshots.expiry"] == "7d"
+
+    def test_snapshot_auto_disable_calls_config_unset(self) -> None:
+        with patch("waydroid_toolkit.core.container.incus_backend.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            IncusBackend().snapshot_auto_disable()
+            args = mock_run.call_args[0][0]
+            assert args == ["incus", "config", "unset", "waydroid", "snapshots.schedule"]
 
     def test_console_calls_execvp(self) -> None:
         with patch("waydroid_toolkit.core.container.incus_backend.os.execvp") as mock_exec:

--- a/tests/unit/test_container_cmd.py
+++ b/tests/unit/test_container_cmd.py
@@ -12,6 +12,7 @@ from waydroid_toolkit.cli.commands.container import cmd as container_cmd
 def _make_backend(
     snapshot_names: list[str] | None = None,
     raises: type[Exception] | None = None,
+    auto_cfg: dict[str, str] | None = None,
 ) -> MagicMock:
     b = MagicMock()
     if raises is not None:
@@ -20,8 +21,16 @@ def _make_backend(
         b.snapshot_restore.side_effect = raises("Incus backend required")
         b.snapshot_delete.side_effect = raises("Incus backend required")
         b.console.side_effect = raises("Incus backend required")
+        b.snapshot_auto_set.side_effect = raises("Incus backend required")
+        b.snapshot_auto_show.side_effect = raises("Incus backend required")
+        b.snapshot_auto_disable.side_effect = raises("Incus backend required")
     else:
         b.snapshot_list.return_value = snapshot_names or []
+        b.snapshot_auto_show.return_value = auto_cfg or {
+            "snapshots.schedule": "@daily",
+            "snapshots.expiry": "7d",
+            "snapshots.pattern": "snap-%d",
+        }
     return b
 
 
@@ -133,4 +142,67 @@ class TestContainerConsole:
         mock_b = _make_backend(raises=NotImplementedError)
         with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
             result = runner.invoke(container_cmd, ["console"])
+        assert result.exit_code != 0
+
+
+class TestContainerSnapshotAuto:
+    def test_set_calls_backend(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            result = runner.invoke(container_cmd, ["snapshot-auto", "set", "@daily"])
+        assert result.exit_code == 0
+        mock_b.snapshot_auto_set.assert_called_once_with("@daily", "", "snap-%d")
+
+    def test_set_with_expiry_and_pattern(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            result = runner.invoke(
+                container_cmd,
+                ["snapshot-auto", "set", "@weekly", "--expiry", "30d", "--pattern", "auto-%d"],
+            )
+        assert result.exit_code == 0
+        mock_b.snapshot_auto_set.assert_called_once_with("@weekly", "30d", "auto-%d")
+
+    def test_set_lxc_backend_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(raises=NotImplementedError)
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            result = runner.invoke(container_cmd, ["snapshot-auto", "set", "@daily"])
+        assert result.exit_code != 0
+
+    def test_show_displays_schedule(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(auto_cfg={
+            "snapshots.schedule": "@daily",
+            "snapshots.expiry": "7d",
+            "snapshots.pattern": "snap-%d",
+        })
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            result = runner.invoke(container_cmd, ["snapshot-auto", "show"])
+        assert result.exit_code == 0
+        assert "@daily" in result.output
+        assert "7d" in result.output
+
+    def test_show_lxc_backend_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(raises=NotImplementedError)
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            result = runner.invoke(container_cmd, ["snapshot-auto", "show"])
+        assert result.exit_code != 0
+
+    def test_disable_calls_backend(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend()
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            result = runner.invoke(container_cmd, ["snapshot-auto", "disable"])
+        assert result.exit_code == 0
+        mock_b.snapshot_auto_disable.assert_called_once()
+
+    def test_disable_lxc_backend_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(raises=NotImplementedError)
+        with patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=mock_b):
+            result = runner.invoke(container_cmd, ["snapshot-auto", "disable"])
         assert result.exit_code != 0

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -98,3 +98,53 @@ class TestMonitorTop:
         assert result.exit_code == 0
         assert "waydroid" in result.output
         assert "running" in result.output
+
+
+class TestMonitorDisk:
+    def test_disk_shows_allocated_and_usage(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+
+        def fake_run(cmd, **kw):
+            m = MagicMock(returncode=0)
+            if "device" in cmd and "get" in cmd:
+                m.stdout = "20GiB\n"
+            else:
+                m.stdout = _incus_info_json()
+            return m
+
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("waydroid_toolkit.cli.commands.monitor.subprocess.run", side_effect=fake_run):
+                result = runner.invoke(monitor_cmd, ["disk"])
+        assert result.exit_code == 0
+        assert "20GiB" in result.output
+        assert "root" in result.output
+        assert "MiB" in result.output
+
+    def test_disk_shows_pool_default_when_no_size(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+
+        def fake_run(cmd, **kw):
+            m = MagicMock(returncode=0)
+            if "device" in cmd and "get" in cmd:
+                m.stdout = ""
+            else:
+                m.stdout = _incus_info_json()
+            return m
+
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("waydroid_toolkit.cli.commands.monitor.subprocess.run", side_effect=fake_run):
+                result = runner.invoke(monitor_cmd, ["disk"])
+        assert result.exit_code == 0
+        assert "pool default" in result.output
+
+    def test_disk_handles_incus_not_found(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("waydroid_toolkit.cli.commands.monitor.subprocess.run",
+                       side_effect=FileNotFoundError):
+                result = runner.invoke(monitor_cmd, ["disk"])
+        assert result.exit_code == 0
+        assert "not found" in result.output


### PR DESCRIPTION
## Changes

- **wdt container snapshot-auto**: `set/show/disable` via `incus config snapshots.*`; ABC + IncusBackend + LxcBackend stubs
- **wdt cloud-sync**: `push/pull/list/config/status` via rclone; reads `WDT_BACKUP_DIR`, `WDT_CLOUD_REMOTE`, `WDT_CLOUD_PATH`
- **wdt monitor disk**: shows allocated root disk size and live per-device usage from `incus info --format json`
- Tests for all three features