### PR TITLE
feat: monitor uptime/health, template, update, net, usb, gpu

### DIFF
--- a/data/templates/dev.yaml
+++ b/data/templates/dev.yaml
@@ -1,0 +1,7 @@
+# wdt template: dev
+# Development Waydroid container with balanced resources.
+description: "Development Waydroid container with balanced CPU and memory"
+
+resources:
+  cpu: 4
+  memory: 4GiB

--- a/data/templates/gaming.yaml
+++ b/data/templates/gaming.yaml
@@ -1,0 +1,11 @@
+# wdt template: gaming
+# High-resource Waydroid container optimised for gaming workloads.
+description: "Gaming-optimised Waydroid container with high CPU and memory"
+
+resources:
+  cpu: 8
+  memory: 8GiB
+
+performance:
+  governor: performance
+  zram: true

--- a/data/templates/minimal.yaml
+++ b/data/templates/minimal.yaml
@@ -1,0 +1,7 @@
+# wdt template: minimal
+# Low-resource Waydroid container for testing.
+description: "Minimal Waydroid container for testing with low resource usage"
+
+resources:
+  cpu: 2
+  memory: 2GiB

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ target-version = "py311"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["E501"]
+"tests/unit/test_template.py" = ["I001"]
+"tests/unit/test_update.py" = ["I001"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]

--- a/src/waydroid_toolkit/cli/commands/cloud_sync.py
+++ b/src/waydroid_toolkit/cli/commands/cloud_sync.py
@@ -66,7 +66,7 @@ def cloud_push(filter_str: str) -> None:
         raise SystemExit(1)
 
     remote = f"{_remote_name()}:{_remote_path()}/"
-    console.print(f"[bold]Cloud Sync: Push[/bold]")
+    console.print("[bold]Cloud Sync: Push[/bold]")
     console.print(f"  Local  : {backup_dir}")
     console.print(f"  Remote : {remote}")
 
@@ -111,7 +111,7 @@ def cloud_pull(filter_str: str) -> None:
         raise SystemExit(1)
 
     remote = f"{_remote_name()}:{_remote_path()}/"
-    console.print(f"[bold]Cloud Sync: Pull[/bold]")
+    console.print("[bold]Cloud Sync: Pull[/bold]")
     console.print(f"  Remote : {remote}")
     console.print(f"  Local  : {backup_dir}")
 

--- a/src/waydroid_toolkit/cli/commands/gpu.py
+++ b/src/waydroid_toolkit/cli/commands/gpu.py
@@ -1,0 +1,203 @@
+"""wdt gpu — manage GPU passthrough for the Waydroid container."""
+
+from __future__ import annotations
+
+import subprocess
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def _container_name() -> str:
+    try:
+        from waydroid_toolkit.core.container.backend import get_backend
+        b = get_backend()
+        return b.get_info().container_name  # type: ignore[attr-defined]
+    except Exception:
+        return "waydroid"
+
+
+@click.group("gpu")
+def cmd() -> None:
+    """Manage GPU passthrough for the Waydroid container."""
+
+
+@cmd.command("list-host")
+def gpu_list_host() -> None:
+    """List GPUs available on the host."""
+    console.print("[bold]GPUs available on host:[/bold]")
+    console.print()
+
+    # Try incus info --resources first
+    r = subprocess.run(
+        ["incus", "info", "--resources"],
+        capture_output=True, text=True,
+    )
+    if r.returncode == 0:
+        in_gpu = False
+        for line in r.stdout.splitlines():
+            if "GPUs:" in line:
+                in_gpu = True
+                continue
+            if in_gpu and line and not line[0].isspace():
+                break
+            if in_gpu:
+                console.print(f"  {line}")
+
+    # Also show lspci output if available
+    lspci_r = subprocess.run(["lspci"], capture_output=True, text=True)
+    if lspci_r.returncode == 0:
+        console.print()
+        console.print("[bold]PCI GPU devices:[/bold]")
+        found = False
+        for line in lspci_r.stdout.splitlines():
+            if any(k in line.upper() for k in ("VGA", "3D", "DISPLAY", "NVIDIA", "AMD")):
+                console.print(f"  {line}")
+                found = True
+        if not found:
+            console.print("  [yellow]None found[/yellow]")
+
+
+@cmd.command("attach")
+@click.option("--type", "gpu_type", default="physical",
+              type=click.Choice(["physical", "mdev", "mig", "virtio"]),
+              show_default=True, help="GPU type.")
+@click.option("--pci", "pci_addr", default="", help="PCI address (e.g. 0000:01:00.0).")
+@click.option("--dev-name", default="gpu0", show_default=True, help="Device name.")
+@click.option("--vendor", default="", help="GPU vendor ID filter.")
+def gpu_attach(gpu_type: str, pci_addr: str, dev_name: str, vendor: str) -> None:
+    """Attach a GPU to the container."""
+    ct = _container_name()
+
+    cmd_args = [
+        "incus", "config", "device", "add", ct, dev_name, "gpu",
+        f"gputype={gpu_type}",
+    ]
+    if pci_addr:
+        cmd_args.append(f"pci={pci_addr}")
+    if vendor:
+        cmd_args.append(f"vendorid={vendor}")
+
+    desc = f"type={gpu_type}" + (f", pci={pci_addr}" if pci_addr else "")
+    console.print(f"Attaching GPU to '{ct}' ({desc})")
+    result = subprocess.run(cmd_args)
+    if result.returncode != 0:
+        console.print("[red]Failed to attach GPU.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]GPU attached:[/green] {dev_name} → {ct}")
+    console.print(f"  Type : {gpu_type}")
+    if pci_addr:
+        console.print(f"  PCI  : {pci_addr}")
+
+
+@cmd.command("detach")
+@click.argument("dev_name")
+def gpu_detach(dev_name: str) -> None:
+    """Remove a GPU passthrough device from the container."""
+    ct = _container_name()
+    result = subprocess.run(["incus", "config", "device", "remove", ct, dev_name])
+    if result.returncode != 0:
+        console.print(f"[red]Failed to remove GPU device '{dev_name}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]GPU removed:[/green] {dev_name}")
+
+
+@cmd.command("list")
+def gpu_list() -> None:
+    """List GPU devices currently attached to the container."""
+    ct = _container_name()
+
+    list_r = subprocess.run(
+        ["incus", "config", "device", "list", ct],
+        capture_output=True, text=True,
+    )
+    if list_r.returncode != 0:
+        console.print("[yellow]Could not list devices.[/yellow]")
+        return
+
+    gpu_devices = [
+        line.split()[0] for line in list_r.stdout.splitlines()
+        if "gpu" in line
+    ]
+
+    if not gpu_devices:
+        console.print("[yellow]No GPU devices attached.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("DEVICE", style="cyan")
+    table.add_column("TYPE")
+    table.add_column("PCI")
+
+    for dev in gpu_devices:
+        gtype_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "gputype"],
+            capture_output=True, text=True,
+        )
+        pci_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "pci"],
+            capture_output=True, text=True,
+        )
+        table.add_row(
+            dev,
+            gtype_r.stdout.strip() or "physical",
+            pci_r.stdout.strip() or "-",
+        )
+
+    console.print(table)
+
+
+@cmd.command("status")
+def gpu_status() -> None:
+    """Show GPU attachment status and host GPU resources."""
+    ct = _container_name()
+    console.print(f"[bold]GPU status:[/bold] {ct}")
+    console.print()
+
+    # Attached devices
+    list_r = subprocess.run(
+        ["incus", "config", "device", "list", ct],
+        capture_output=True, text=True,
+    )
+    gpu_devices = []
+    if list_r.returncode == 0:
+        gpu_devices = [
+            line.split()[0] for line in list_r.stdout.splitlines()
+            if "gpu" in line
+        ]
+
+    if gpu_devices:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("DEVICE", style="cyan")
+        table.add_column("TYPE")
+        table.add_column("PCI")
+        for dev in gpu_devices:
+            gtype_r = subprocess.run(
+                ["incus", "config", "device", "get", ct, dev, "gputype"],
+                capture_output=True, text=True,
+            )
+            pci_r = subprocess.run(
+                ["incus", "config", "device", "get", ct, dev, "pci"],
+                capture_output=True, text=True,
+            )
+            table.add_row(dev, gtype_r.stdout.strip() or "physical", pci_r.stdout.strip() or "-")
+        console.print(table)
+    else:
+        console.print("[yellow]No GPU devices attached.[/yellow]")
+
+    console.print()
+    console.print("[bold]Host GPU resources:[/bold]")
+    r = subprocess.run(["incus", "info", "--resources"], capture_output=True, text=True)
+    if r.returncode == 0:
+        in_gpu = False
+        for line in r.stdout.splitlines():
+            if "GPUs:" in line:
+                in_gpu = True
+                continue
+            if in_gpu and line and not line[0].isspace():
+                break
+            if in_gpu:
+                console.print(f"  {line}")

--- a/src/waydroid_toolkit/cli/commands/gpu.py
+++ b/src/waydroid_toolkit/cli/commands/gpu.py
@@ -13,7 +13,7 @@ console = Console()
 
 def _container_name() -> str:
     try:
-        from waydroid_toolkit.core.container.backend import get_backend
+        from waydroid_toolkit.core.container import get_active as get_backend
         b = get_backend()
         return b.get_info().container_name  # type: ignore[attr-defined]
     except Exception:

--- a/src/waydroid_toolkit/cli/commands/monitor.py
+++ b/src/waydroid_toolkit/cli/commands/monitor.py
@@ -121,6 +121,129 @@ def monitor_disk() -> None:
         console.print("  [yellow]Disk usage not available (container may be stopped)[/yellow]")
 
 
+@cmd.command("uptime")
+def monitor_uptime() -> None:
+    """Container uptime and creation history."""
+    b = _backend()
+    info = b.get_info()  # type: ignore[attr-defined]
+    container_name = info.container_name
+
+    try:
+        result = subprocess.run(
+            ["incus", "info", container_name],
+            capture_output=True, text=True, timeout=10,
+        )
+    except FileNotFoundError:
+        console.print("[yellow]incus not found — uptime unavailable[/yellow]")
+        return
+
+    if result.returncode != 0:
+        console.print("[yellow]Could not retrieve info from incus[/yellow]")
+        return
+
+    def _field(label: str) -> str:
+        for line in result.stdout.splitlines():
+            if line.startswith(label):
+                return line.split(":", 1)[1].strip()
+        return "unknown"
+
+    status = _field("Status:")
+    created = _field("Created:")
+    last_used = _field("Last Used:")
+
+    console.print(f"[bold]Uptime:[/bold] {container_name}")
+    console.print()
+    console.print(f"  Created   : {created}")
+    console.print(f"  Last used : {last_used}")
+    console.print(f"  Status    : {status}")
+
+    # Snapshot history
+    lines = result.stdout.splitlines()
+    in_snaps = False
+    snap_lines = []
+    for line in lines:
+        if line.startswith("Snapshots:"):
+            in_snaps = True
+            continue
+        if in_snaps:
+            if line and not line[0].isspace():
+                break
+            snap_lines.append(line)
+    if snap_lines:
+        console.print()
+        console.print("  [bold]Recent snapshots:[/bold]")
+        for sl in snap_lines[:5]:
+            console.print(f"  {sl}")
+
+
+@cmd.command("health")
+def monitor_health() -> None:
+    """Host-level health check: Incus daemon, KVM, storage, memory, disk."""
+    console.print("[bold]System Health[/bold]")
+    console.print()
+
+    # Incus daemon
+    r = subprocess.run(["incus", "info"], capture_output=True)
+    if r.returncode == 0:
+        console.print("[green]✓[/green] Incus daemon: reachable")
+    else:
+        console.print("[red]✗[/red] Incus daemon: not reachable")
+
+    # KVM
+    import os as _os
+    if _os.path.exists("/dev/kvm"):
+        console.print("[green]✓[/green] KVM: available")
+    else:
+        console.print("[yellow]![/yellow] KVM: /dev/kvm not found (containers only)")
+
+    # Storage pools
+    pools_r = subprocess.run(
+        ["incus", "storage", "list", "--format", "csv"],
+        capture_output=True, text=True,
+    )
+    pool_count = len([l for l in pools_r.stdout.splitlines() if l.strip()])
+    console.print(f"  Storage pools : {pool_count}")
+
+    # Networks
+    net_r = subprocess.run(
+        ["incus", "network", "list", "--format", "csv"],
+        capture_output=True, text=True,
+    )
+    net_count = len([l for l in net_r.stdout.splitlines() if l.strip()])
+    console.print(f"  Networks      : {net_count}")
+
+    # Container count
+    list_r = subprocess.run(
+        ["incus", "list", "--format", "csv", "-c", "s,t"],
+        capture_output=True, text=True,
+    )
+    ct_total = sum(1 for l in list_r.stdout.splitlines() if "container" in l)
+    ct_running = sum(1 for l in list_r.stdout.splitlines() if "RUNNING" in l and "container" in l)
+    console.print(f"  Containers    : {ct_running} running / {ct_total} total")
+
+    # Host disk
+    console.print()
+    df_r = subprocess.run(["df", "-h", "/"], capture_output=True, text=True)
+    if df_r.returncode == 0:
+        lines = df_r.stdout.strip().splitlines()
+        if len(lines) >= 2:
+            parts = lines[-1].split()
+            if len(parts) >= 5:
+                console.print(f"  Host disk : {parts[2]} used / {parts[1]} ({parts[4]})")
+
+    # Host memory
+    free_r = subprocess.run(["free", "-h"], capture_output=True, text=True)
+    for line in free_r.stdout.splitlines():
+        if line.startswith("Mem:"):
+            parts = line.split()
+            if len(parts) >= 3:
+                console.print(f"  Host memory: {parts[2]} used / {parts[1]}")
+            break
+
+    console.print()
+    console.print("[green]Health check complete.[/green]")
+
+
 @cmd.command("top")
 def monitor_top() -> None:
     """Overview of the Waydroid container (single-instance summary)."""

--- a/src/waydroid_toolkit/cli/commands/monitor.py
+++ b/src/waydroid_toolkit/cli/commands/monitor.py
@@ -201,7 +201,7 @@ def monitor_health() -> None:
         ["incus", "storage", "list", "--format", "csv"],
         capture_output=True, text=True,
     )
-    pool_count = len([l for l in pools_r.stdout.splitlines() if l.strip()])
+    pool_count = len([ln for ln in pools_r.stdout.splitlines() if ln.strip()])
     console.print(f"  Storage pools : {pool_count}")
 
     # Networks
@@ -209,7 +209,7 @@ def monitor_health() -> None:
         ["incus", "network", "list", "--format", "csv"],
         capture_output=True, text=True,
     )
-    net_count = len([l for l in net_r.stdout.splitlines() if l.strip()])
+    net_count = len([ln for ln in net_r.stdout.splitlines() if ln.strip()])
     console.print(f"  Networks      : {net_count}")
 
     # Container count
@@ -217,8 +217,8 @@ def monitor_health() -> None:
         ["incus", "list", "--format", "csv", "-c", "s,t"],
         capture_output=True, text=True,
     )
-    ct_total = sum(1 for l in list_r.stdout.splitlines() if "container" in l)
-    ct_running = sum(1 for l in list_r.stdout.splitlines() if "RUNNING" in l and "container" in l)
+    ct_total = sum(1 for ln in list_r.stdout.splitlines() if "container" in ln)
+    ct_running = sum(1 for ln in list_r.stdout.splitlines() if "RUNNING" in ln and "container" in ln)
     console.print(f"  Containers    : {ct_running} running / {ct_total} total")
 
     # Host disk

--- a/src/waydroid_toolkit/cli/commands/monitor.py
+++ b/src/waydroid_toolkit/cli/commands/monitor.py
@@ -218,7 +218,9 @@ def monitor_health() -> None:
         capture_output=True, text=True,
     )
     ct_total = sum(1 for ln in list_r.stdout.splitlines() if "container" in ln)
-    ct_running = sum(1 for ln in list_r.stdout.splitlines() if "RUNNING" in ln and "container" in ln)
+    ct_running = sum(
+        1 for ln in list_r.stdout.splitlines() if "RUNNING" in ln and "container" in ln
+    )
     console.print(f"  Containers    : {ct_running} running / {ct_total} total")
 
     # Host disk

--- a/src/waydroid_toolkit/cli/commands/net.py
+++ b/src/waydroid_toolkit/cli/commands/net.py
@@ -16,7 +16,7 @@ _CONTAINER = "waydroid"
 def _container_name() -> str:
     """Return the active Waydroid container name."""
     try:
-        from waydroid_toolkit.core.container.backend import get_backend
+        from waydroid_toolkit.core.container import get_active as get_backend
         b = get_backend()
         return b.get_info().container_name  # type: ignore[attr-defined]
     except Exception:

--- a/src/waydroid_toolkit/cli/commands/net.py
+++ b/src/waydroid_toolkit/cli/commands/net.py
@@ -1,0 +1,168 @@
+"""wdt net — manage network port forwarding for the Waydroid container."""
+
+from __future__ import annotations
+
+import subprocess
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+_CONTAINER = "waydroid"
+
+
+def _container_name() -> str:
+    """Return the active Waydroid container name."""
+    try:
+        from waydroid_toolkit.core.container.backend import get_backend
+        b = get_backend()
+        return b.get_info().container_name  # type: ignore[attr-defined]
+    except Exception:
+        return _CONTAINER
+
+
+@click.group("net")
+def cmd() -> None:
+    """Manage network port forwarding for the Waydroid container."""
+
+
+@cmd.command("forward")
+@click.argument("host_port", type=int)
+@click.argument("container_port", type=int, required=False)
+@click.option("--proto", default="tcp", type=click.Choice(["tcp", "udp"]), show_default=True)
+@click.option("--listen", "listen_addr", default="0.0.0.0", show_default=True,
+              help="Host listen address.")
+@click.option("--proxy-name", default="", help="Proxy device name (default: fwd-<port>).")
+def net_forward(
+    host_port: int,
+    container_port: int | None,
+    proto: str,
+    listen_addr: str,
+    proxy_name: str,
+) -> None:
+    """Forward HOST_PORT on the host to CONTAINER_PORT inside the container.
+
+    CONTAINER_PORT defaults to HOST_PORT when omitted.
+    """
+    ct = _container_name()
+    cport = container_port if container_port is not None else host_port
+    pname = proxy_name or f"fwd-{host_port}"
+
+    console.print(f"Adding port forward: {listen_addr}:{host_port} → {ct}:{cport} ({proto})")
+    result = subprocess.run([
+        "incus", "config", "device", "add", ct, pname, "proxy",
+        f"listen={proto}:{listen_addr}:{host_port}",
+        f"connect={proto}:127.0.0.1:{cport}",
+    ])
+    if result.returncode != 0:
+        console.print("[red]Failed to add port forward.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]Port forward added:[/green] {pname}")
+    console.print(f"  Host      : {listen_addr}:{host_port}")
+    console.print(f"  Container : 127.0.0.1:{cport}")
+
+
+@cmd.command("unforward")
+@click.argument("proxy_name")
+def net_unforward(proxy_name: str) -> None:
+    """Remove a port forward proxy device by name."""
+    ct = _container_name()
+    result = subprocess.run(["incus", "config", "device", "remove", ct, proxy_name])
+    if result.returncode != 0:
+        console.print(f"[red]Failed to remove proxy device '{proxy_name}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]Removed port forward:[/green] {proxy_name}")
+
+
+@cmd.command("list")
+def net_list() -> None:
+    """List all port forward proxy devices on the container."""
+    ct = _container_name()
+
+    # Get all device names
+    list_r = subprocess.run(
+        ["incus", "config", "device", "list", ct],
+        capture_output=True, text=True,
+    )
+    if list_r.returncode != 0:
+        console.print("[yellow]Could not list devices (is the container running?)[/yellow]")
+        return
+
+    proxy_devices = [
+        line.split()[0] for line in list_r.stdout.splitlines()
+        if "proxy" in line
+    ]
+
+    if not proxy_devices:
+        console.print("[yellow]No port forwards configured.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("DEVICE", style="cyan")
+    table.add_column("LISTEN")
+    table.add_column("CONNECT")
+
+    for dev in proxy_devices:
+        listen_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "listen"],
+            capture_output=True, text=True,
+        )
+        connect_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "connect"],
+            capture_output=True, text=True,
+        )
+        table.add_row(
+            dev,
+            listen_r.stdout.strip(),
+            connect_r.stdout.strip(),
+        )
+
+    console.print(table)
+
+
+@cmd.command("status")
+def net_status() -> None:
+    """Show network interfaces and port forwards for the container."""
+    ct = _container_name()
+    console.print(f"[bold]Network status:[/bold] {ct}")
+    console.print()
+
+    # Network interfaces from incus info
+    info_r = subprocess.run(
+        ["incus", "info", ct],
+        capture_output=True, text=True,
+    )
+    if info_r.returncode == 0:
+        in_net = False
+        for line in info_r.stdout.splitlines():
+            if line.startswith("Network usage:"):
+                in_net = True
+                continue
+            if in_net and line and not line[0].isspace():
+                break
+            if in_net:
+                console.print(f"  {line}")
+
+    console.print()
+    console.print("[bold]Proxy devices:[/bold]")
+
+    show_r = subprocess.run(
+        ["incus", "config", "device", "show", ct],
+        capture_output=True, text=True,
+    )
+    found = False
+    if show_r.returncode == 0:
+        in_proxy = False
+        for line in show_r.stdout.splitlines():
+            if "type: proxy" in line:
+                in_proxy = True
+                found = True
+            if in_proxy:
+                console.print(f"  {line}")
+                if not line.strip():
+                    in_proxy = False
+
+    if not found:
+        console.print("  [yellow]None[/yellow]")

--- a/src/waydroid_toolkit/cli/commands/template.py
+++ b/src/waydroid_toolkit/cli/commands/template.py
@@ -9,7 +9,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from waydroid_toolkit.core.container.backend import get_backend
+from waydroid_toolkit.core.container import get_active as get_backend
 
 console = Console()
 

--- a/src/waydroid_toolkit/cli/commands/template.py
+++ b/src/waydroid_toolkit/cli/commands/template.py
@@ -1,0 +1,171 @@
+"""wdt template — list, inspect, and apply Waydroid container resource templates."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+# Templates ship in data/templates/ relative to the package root.
+_PKG_ROOT = Path(__file__).parent.parent.parent.parent.parent  # repo root
+_BUILTIN_TEMPLATES_DIR = _PKG_ROOT / "data" / "templates"
+_USER_TEMPLATES_DIR = Path.home() / ".config" / "waydroid-toolkit" / "templates"
+
+
+def _templates_dir() -> Path:
+    """Return the active templates directory (user overrides built-in)."""
+    import os
+    env = os.environ.get("WDT_TEMPLATES_DIR")
+    if env:
+        return Path(env)
+    if _USER_TEMPLATES_DIR.exists():
+        return _USER_TEMPLATES_DIR
+    return _BUILTIN_TEMPLATES_DIR
+
+
+def _parse_template(path: Path) -> dict[str, object]:
+    """Minimal line-based YAML parser for template files."""
+    data: dict[str, object] = {}
+    section: str | None = None
+    with path.open() as f:
+        for raw in f:
+            line = raw.rstrip()
+            if not line or line.lstrip().startswith("#"):
+                continue
+            if line[0].isspace():
+                # nested key under current section
+                if section is not None:
+                    stripped = line.strip()
+                    if ":" in stripped:
+                        k, _, v = stripped.partition(":")
+                        if section not in data:
+                            data[section] = {}
+                        data[section][k.strip()] = v.strip().strip('"')  # type: ignore[index]
+            else:
+                if ":" in line:
+                    k, _, v = line.partition(":")
+                    k = k.strip()
+                    v = v.strip().strip('"')
+                    if v:
+                        data[k] = v
+                        section = None
+                    else:
+                        section = k
+    return data
+
+
+@click.group("template")
+def cmd() -> None:
+    """List, inspect, and apply Waydroid container resource templates."""
+
+
+@cmd.command("list")
+def template_list() -> None:
+    """List available templates."""
+    tdir = _templates_dir()
+    yamls = sorted(tdir.glob("*.yaml")) if tdir.exists() else []
+
+    if not yamls:
+        console.print(f"[yellow]No templates found in {tdir}[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("NAME", style="cyan", min_width=12)
+    table.add_column("CPU")
+    table.add_column("MEMORY")
+    table.add_column("DESCRIPTION")
+
+    for f in yamls:
+        d = _parse_template(f)
+        res = d.get("resources", {})
+        cpu = res.get("cpu", "-") if isinstance(res, dict) else "-"  # type: ignore[union-attr]
+        mem = res.get("memory", "-") if isinstance(res, dict) else "-"  # type: ignore[union-attr]
+        desc = str(d.get("description", ""))
+        table.add_row(f.stem, str(cpu), str(mem), desc)
+
+    console.print(table)
+    console.print()
+    console.print(f"Templates directory: {tdir}")
+    console.print("Apply: [cyan]wdt template apply <name>[/cyan]")
+
+
+@cmd.command("show")
+@click.argument("name")
+def template_show(name: str) -> None:
+    """Show full details of a template."""
+    tdir = _templates_dir()
+    path = tdir / f"{name}.yaml"
+    if not path.exists():
+        console.print(f"[red]Template not found:[/red] {name}")
+        raise SystemExit(1)
+
+    d = _parse_template(path)
+    res = d.get("resources", {})
+    perf = d.get("performance", {})
+
+    console.print(f"[bold]Template:[/bold] {name}")
+    console.print()
+    console.print(f"  Description : {d.get('description', '(none)')}")
+    if isinstance(res, dict):
+        console.print(f"  CPU         : {res.get('cpu', '(not set)')}")
+        console.print(f"  Memory      : {res.get('memory', '(not set)')}")
+    if isinstance(perf, dict) and perf:
+        console.print(f"  Governor    : {perf.get('governor', '(not set)')}")
+        console.print(f"  ZRAM        : {perf.get('zram', 'false')}")
+
+
+@cmd.command("apply")
+@click.argument("name")
+@click.option("--dry-run", is_flag=True, help="Show what would be applied without making changes.")
+def template_apply(name: str, dry_run: bool) -> None:
+    """Apply a template's resource limits to the Waydroid container.
+
+    Sets incus config limits.cpu and limits.memory on the waydroid container.
+    """
+    from waydroid_toolkit.core.container.backend import get_backend
+
+    tdir = _templates_dir()
+    path = tdir / f"{name}.yaml"
+    if not path.exists():
+        console.print(f"[red]Template not found:[/red] {name}")
+        raise SystemExit(1)
+
+    d = _parse_template(path)
+    res = d.get("resources", {})
+    if not isinstance(res, dict) or not res:
+        console.print("[yellow]Template has no resource settings to apply.[/yellow]")
+        return
+
+    b = get_backend()
+    info = b.get_info()  # type: ignore[attr-defined]
+    container = info.container_name
+
+    cpu = res.get("cpu")
+    mem = res.get("memory")
+
+    console.print(f"[bold]Applying template '{name}' to container '{container}'[/bold]")
+    if cpu:
+        console.print(f"  limits.cpu    → {cpu}")
+        if not dry_run:
+            subprocess.run(
+                ["incus", "config", "set", container, "limits.cpu", str(cpu)],
+                check=True,
+            )
+    if mem:
+        console.print(f"  limits.memory → {mem}")
+        if not dry_run:
+            subprocess.run(
+                ["incus", "config", "set", container, "limits.memory", mem],
+                check=True,
+            )
+
+    if dry_run:
+        console.print("[yellow](dry-run — no changes made)[/yellow]")
+    else:
+        console.print(f"[green]Template '{name}' applied.[/green]")
+        console.print("Restart the container for changes to take effect.")

--- a/src/waydroid_toolkit/cli/commands/template.py
+++ b/src/waydroid_toolkit/cli/commands/template.py
@@ -9,6 +9,8 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from waydroid_toolkit.core.container.backend import get_backend
+
 console = Console()
 
 # Templates ship in data/templates/ relative to the package root.
@@ -127,8 +129,6 @@ def template_apply(name: str, dry_run: bool) -> None:
 
     Sets incus config limits.cpu and limits.memory on the waydroid container.
     """
-    from waydroid_toolkit.core.container.backend import get_backend
-
     tdir = _templates_dir()
     path = tdir / f"{name}.yaml"
     if not path.exists():

--- a/src/waydroid_toolkit/cli/commands/update.py
+++ b/src/waydroid_toolkit/cli/commands/update.py
@@ -1,0 +1,179 @@
+"""wdt update — check for and install waydroid-toolkit updates from GitHub."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_GITHUB_REPO = "Interested-Deving-1896/waydroid-toolkit"
+_GITHUB_API = f"https://api.github.com/repos/{_GITHUB_REPO}/releases/latest"
+
+
+def _current_version() -> str:
+    """Read version from installed package metadata."""
+    try:
+        from importlib.metadata import version
+        return version("waydroid-toolkit")
+    except Exception:
+        return "0.0.0"
+
+
+def _version_gt(v1: str, v2: str) -> bool:
+    """Return True if v1 > v2 (semver, strips leading 'v')."""
+    def parts(v: str) -> tuple[int, ...]:
+        return tuple(int(x) for x in v.lstrip("v").split(".")[:3])
+    try:
+        return parts(v1) > parts(v2)
+    except ValueError:
+        return False
+
+
+def _fetch_release() -> dict:
+    """Fetch the latest GitHub release JSON."""
+    import json
+    req = urllib.request.Request(
+        _GITHUB_API,
+        headers={"Accept": "application/vnd.github.v3+json"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+        return json.loads(resp.read())
+
+
+@click.group("update")
+def cmd() -> None:
+    """Check for and install waydroid-toolkit updates."""
+
+
+@cmd.command("check")
+def update_check() -> None:
+    """Check GitHub for a newer version."""
+    current = _current_version()
+    console.print(f"  Current version : v{current}")
+    console.print("  Checking GitHub for updates...")
+
+    try:
+        release = _fetch_release()
+    except Exception as exc:
+        console.print(f"[yellow]Could not reach GitHub API: {exc}[/yellow]")
+        console.print(f"  Check manually: https://github.com/{_GITHUB_REPO}/releases")
+        return
+
+    latest_tag = release.get("tag_name", "")
+    latest = latest_tag.lstrip("v")
+    if not latest:
+        console.print("[yellow]Could not determine latest version.[/yellow]")
+        return
+
+    console.print(f"  Latest version  : v{latest}")
+
+    if _version_gt(latest, current):
+        console.print()
+        console.print(f"[green]Update available:[/green] v{current} → v{latest}")
+        body = (release.get("body") or "")[:400]
+        if body:
+            console.print()
+            console.print("[dim]Release notes:[/dim]")
+            for line in body.splitlines()[:10]:
+                console.print(f"  {line}")
+        console.print()
+        console.print("  Update with: [cyan]wdt update install[/cyan]")
+    else:
+        console.print(f"[green]waydroid-toolkit is up to date (v{current})[/green]")
+
+
+@cmd.command("install")
+def update_install() -> None:
+    """Download and install the latest version."""
+    current = _current_version()
+    console.print(f"  Current version : v{current}")
+    console.print("  Fetching latest release...")
+
+    try:
+        release = _fetch_release()
+    except Exception as exc:
+        console.print(f"[red]Could not reach GitHub API: {exc}[/red]")
+        raise SystemExit(1) from exc
+
+    latest_tag = release.get("tag_name", "")
+    latest = latest_tag.lstrip("v")
+    if not latest:
+        console.print("[red]Could not determine latest version.[/red]")
+        raise SystemExit(1)
+
+    if not _version_gt(latest, current):
+        console.print(f"[green]Already up to date (v{current})[/green]")
+        return
+
+    console.print(f"  Updating: v{current} → v{latest}")
+
+    # Detect install method
+    pkg_root = Path(__file__).parent.parent.parent.parent.parent
+    is_git = (pkg_root / ".git").exists()
+    is_pip = shutil.which("pip") is not None or shutil.which("pip3") is not None
+
+    if is_git:
+        console.print("  [dim]Git repository detected — pulling latest...[/dim]")
+        result = subprocess.run(
+            ["git", "fetch", "origin"],
+            cwd=str(pkg_root),
+        )
+        if result.returncode == 0:
+            subprocess.run(
+                ["git", "checkout", f"v{latest}"],
+                cwd=str(pkg_root),
+            )
+        if result.returncode != 0:
+            subprocess.run(["git", "pull", "origin", "main"], cwd=str(pkg_root), check=True)
+        console.print(f"[green]Updated via git to v{latest}[/green]")
+
+    elif is_pip:
+        console.print("  [dim]pip install detected — upgrading via pip...[/dim]")
+        pip = shutil.which("pip3") or shutil.which("pip") or "pip"
+        result = subprocess.run(
+            [pip, "install", "--upgrade",
+             f"git+https://github.com/{_GITHUB_REPO}.git@v{latest}"],
+        )
+        if result.returncode != 0:
+            console.print("[red]pip upgrade failed.[/red]")
+            raise SystemExit(1)
+        console.print(f"[green]Updated to v{latest} via pip[/green]")
+
+    else:
+        # Tarball fallback
+        tarball_url = release.get("tarball_url", "")
+        if not tarball_url:
+            console.print("[red]No tarball URL in release.[/red]")
+            raise SystemExit(1)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_tar = Path(tmp) / f"wdt-{latest}.tar.gz"
+            console.print(f"  [dim]Downloading v{latest}...[/dim]")
+            urllib.request.urlretrieve(tarball_url, tmp_tar)  # noqa: S310
+            console.print("  [dim]Extracting...[/dim]")
+            with tarfile.open(tmp_tar) as tf:
+                tf.extractall(tmp)
+            # Find extracted dir
+            extracted = next(
+                (Path(tmp) / d for d in Path(tmp).iterdir()
+                 if (Path(tmp) / d).is_dir() and d.name != tmp_tar.name),
+                None,
+            )
+            if extracted and (extracted / "pyproject.toml").exists():
+                pip = shutil.which("pip3") or shutil.which("pip") or "pip"
+                subprocess.run([pip, "install", str(extracted)], check=True)
+                console.print(f"[green]Updated to v{latest}[/green]")
+            else:
+                console.print("[red]Could not locate extracted package.[/red]")
+                raise SystemExit(1)
+
+    new_ver = _current_version()
+    console.print(f"  Verified: v{new_ver}")

--- a/src/waydroid_toolkit/cli/commands/usb.py
+++ b/src/waydroid_toolkit/cli/commands/usb.py
@@ -13,7 +13,7 @@ console = Console()
 
 def _container_name() -> str:
     try:
-        from waydroid_toolkit.core.container.backend import get_backend
+        from waydroid_toolkit.core.container import get_active as get_backend
         b = get_backend()
         return b.get_info().container_name  # type: ignore[attr-defined]
     except Exception:

--- a/src/waydroid_toolkit/cli/commands/usb.py
+++ b/src/waydroid_toolkit/cli/commands/usb.py
@@ -1,0 +1,144 @@
+"""wdt usb — manage USB device passthrough for the Waydroid container."""
+
+from __future__ import annotations
+
+import subprocess
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def _container_name() -> str:
+    try:
+        from waydroid_toolkit.core.container.backend import get_backend
+        b = get_backend()
+        return b.get_info().container_name  # type: ignore[attr-defined]
+    except Exception:
+        return "waydroid"
+
+
+@click.group("usb")
+def cmd() -> None:
+    """Manage USB device passthrough for the Waydroid container."""
+
+
+@cmd.command("list-host")
+def usb_list_host() -> None:
+    """List USB devices available on the host."""
+    result = subprocess.run(["lsusb"], capture_output=True, text=True)
+    if result.returncode != 0:
+        console.print("[yellow]lsusb not found — install usbutils[/yellow]")
+        # Fallback: incus info --resources
+        r2 = subprocess.run(
+            ["incus", "info", "--resources"],
+            capture_output=True, text=True,
+        )
+        if r2.returncode == 0:
+            in_usb = False
+            for line in r2.stdout.splitlines():
+                if "USB devices" in line:
+                    in_usb = True
+                    continue
+                if in_usb and line and not line[0].isspace():
+                    break
+                if in_usb:
+                    console.print(f"  {line}")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("VENDOR:ID", style="cyan", min_width=10)
+    table.add_column("BUS:DEV", min_width=8)
+    table.add_column("DESCRIPTION")
+
+    for line in result.stdout.splitlines():
+        # Bus 001 Device 003: ID 046d:c52b Logitech, Inc. Unifying Receiver
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        bus = parts[1]
+        dev = parts[3].rstrip(":")
+        vid_pid = parts[5]
+        desc = " ".join(parts[6:]) if len(parts) > 6 else ""
+        table.add_row(vid_pid, f"{bus}:{dev}", desc)
+
+    console.print(table)
+
+
+@cmd.command("attach")
+@click.argument("vendor_id")
+@click.argument("product_id")
+@click.option("--dev-name", default="", help="Device name (default: usb-<VID>-<PID>).")
+def usb_attach(vendor_id: str, product_id: str, dev_name: str) -> None:
+    """Attach a USB device to the container by vendor and product ID.
+
+    VENDOR_ID and PRODUCT_ID are 4-digit hex values (e.g. 046d c52b).
+    """
+    ct = _container_name()
+    pname = dev_name or f"usb-{vendor_id}-{product_id}"
+
+    console.print(f"Attaching USB {vendor_id}:{product_id} to '{ct}' as '{pname}'")
+    result = subprocess.run([
+        "incus", "config", "device", "add", ct, pname, "usb",
+        f"vendorid={vendor_id}",
+        f"productid={product_id}",
+    ])
+    if result.returncode != 0:
+        console.print("[red]Failed to attach USB device.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]USB device attached:[/green] {pname} ({vendor_id}:{product_id})")
+
+
+@cmd.command("detach")
+@click.argument("dev_name")
+def usb_detach(dev_name: str) -> None:
+    """Remove a USB passthrough device from the container."""
+    ct = _container_name()
+    result = subprocess.run(["incus", "config", "device", "remove", ct, dev_name])
+    if result.returncode != 0:
+        console.print(f"[red]Failed to remove USB device '{dev_name}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]USB device removed:[/green] {dev_name}")
+
+
+@cmd.command("list")
+def usb_list() -> None:
+    """List USB devices currently attached to the container."""
+    ct = _container_name()
+
+    list_r = subprocess.run(
+        ["incus", "config", "device", "list", ct],
+        capture_output=True, text=True,
+    )
+    if list_r.returncode != 0:
+        console.print("[yellow]Could not list devices.[/yellow]")
+        return
+
+    usb_devices = [
+        line.split()[0] for line in list_r.stdout.splitlines()
+        if "usb" in line
+    ]
+
+    if not usb_devices:
+        console.print("[yellow]No USB devices attached.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("DEVICE", style="cyan")
+    table.add_column("VENDOR ID")
+    table.add_column("PRODUCT ID")
+
+    for dev in usb_devices:
+        vid_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "vendorid"],
+            capture_output=True, text=True,
+        )
+        pid_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "productid"],
+            capture_output=True, text=True,
+        )
+        table.add_row(dev, vid_r.stdout.strip(), pid_r.stdout.strip())
+
+    console.print(table)

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -32,19 +32,19 @@ from .commands import (
     dbus,
     doctor,
     extensions,
+    gpu,
     images,
     install,
     maintenance,
     monitor,
-    gpu,
     net,
     packages,
-    usb,
     performance,
     snapshot,
     status,
     template,
     update,
+    usb,
 )
 
 console = Console()

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -38,6 +38,7 @@ from .commands import (
     monitor,
     net,
     packages,
+    usb,
     performance,
     snapshot,
     status,
@@ -93,4 +94,5 @@ cli.add_command(cloud_sync.cmd, name="cloud-sync")
 cli.add_command(template.cmd, name="template")
 cli.add_command(update.cmd, name="update")
 cli.add_command(net.cmd, name="net")
+cli.add_command(usb.cmd, name="usb")
 cli.add_command(dbus.cmd, name="dbus")

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -41,6 +41,7 @@ from .commands import (
     snapshot,
     status,
     template,
+    update,
 )
 
 console = Console()
@@ -89,4 +90,5 @@ cli.add_command(snapshot.cmd, name="snapshot")
 cli.add_command(container.cmd, name="container")
 cli.add_command(cloud_sync.cmd, name="cloud-sync")
 cli.add_command(template.cmd, name="template")
+cli.add_command(update.cmd, name="update")
 cli.add_command(dbus.cmd, name="dbus")

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -36,6 +36,7 @@ from .commands import (
     install,
     maintenance,
     monitor,
+    net,
     packages,
     performance,
     snapshot,
@@ -91,4 +92,5 @@ cli.add_command(container.cmd, name="container")
 cli.add_command(cloud_sync.cmd, name="cloud-sync")
 cli.add_command(template.cmd, name="template")
 cli.add_command(update.cmd, name="update")
+cli.add_command(net.cmd, name="net")
 cli.add_command(dbus.cmd, name="dbus")

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -40,6 +40,7 @@ from .commands import (
     performance,
     snapshot,
     status,
+    template,
 )
 
 console = Console()
@@ -87,4 +88,5 @@ cli.add_command(maintenance.cmd, name="maintenance")
 cli.add_command(snapshot.cmd, name="snapshot")
 cli.add_command(container.cmd, name="container")
 cli.add_command(cloud_sync.cmd, name="cloud-sync")
+cli.add_command(template.cmd, name="template")
 cli.add_command(dbus.cmd, name="dbus")

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -36,6 +36,7 @@ from .commands import (
     install,
     maintenance,
     monitor,
+    gpu,
     net,
     packages,
     usb,
@@ -95,4 +96,5 @@ cli.add_command(template.cmd, name="template")
 cli.add_command(update.cmd, name="update")
 cli.add_command(net.cmd, name="net")
 cli.add_command(usb.cmd, name="usb")
+cli.add_command(gpu.cmd, name="gpu")
 cli.add_command(dbus.cmd, name="dbus")

--- a/tests/unit/test_cloud_sync.py
+++ b/tests/unit/test_cloud_sync.py
@@ -47,7 +47,6 @@ class TestCloudSyncPush:
         (tmp_path / "mybox.tar.gz").write_bytes(b"x")
         (tmp_path / "otherbox.tar.gz").write_bytes(b"x")
         runner = CliRunner()
-        calls = []
         with patch("waydroid_toolkit.cli.commands.cloud_sync.shutil.which", return_value="/usr/bin/rclone"):
             with patch("waydroid_toolkit.cli.commands.cloud_sync.subprocess.run") as mock_run:
                 mock_run.return_value = MagicMock(returncode=0, stdout="wdt-backups:\n")

--- a/tests/unit/test_gpu_cmd.py
+++ b/tests/unit/test_gpu_cmd.py
@@ -1,0 +1,137 @@
+"""Tests for wdt gpu (GPU passthrough)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.gpu import cmd as gpu_cmd
+
+_CT = "waydroid"
+_PATCH = "waydroid_toolkit.cli.commands.gpu"
+
+
+def _patch_container():
+    return patch(f"{_PATCH}._container_name", return_value=_CT)
+
+
+class TestGpuAttach:
+    def test_attach_physical_default(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(gpu_cmd, ["attach"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "gpu" in args
+        assert "gputype=physical" in args
+
+    def test_attach_with_pci_address(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(gpu_cmd, ["attach", "--pci", "0000:01:00.0"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "pci=0000:01:00.0" in args
+
+    def test_attach_mdev_type(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(gpu_cmd, ["attach", "--type", "mdev"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "gputype=mdev" in args
+
+    def test_attach_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                result = runner.invoke(gpu_cmd, ["attach"])
+        assert result.exit_code != 0
+
+    def test_attach_custom_dev_name(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                runner.invoke(gpu_cmd, ["attach", "--dev-name", "mygpu"])
+        args = mock_run.call_args[0][0]
+        assert "mygpu" in args
+
+
+class TestGpuDetach:
+    def test_detach_removes_device(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(gpu_cmd, ["detach", "gpu0"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "remove" in args
+        assert "gpu0" in args
+
+    def test_detach_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                result = runner.invoke(gpu_cmd, ["detach", "gpu0"])
+        assert result.exit_code != 0
+
+
+class TestGpuList:
+    def test_list_shows_gpu_devices(self) -> None:
+        runner = CliRunner()
+
+        def fake_run(cmd, **kw):
+            m = MagicMock(returncode=0)
+            if "list" in cmd:
+                m.stdout = "gpu0  gpu\n"
+            elif "gputype" in cmd:
+                m.stdout = "physical\n"
+            else:
+                m.stdout = "0000:01:00.0\n"
+            return m
+
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run", side_effect=fake_run):
+                result = runner.invoke(gpu_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "gpu0" in result.output
+
+    def test_list_no_devices_shows_message(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="eth0  nic\n")
+                result = runner.invoke(gpu_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "No GPU" in result.output
+
+
+class TestGpuListHost:
+    def test_list_host_shows_incus_resources(self) -> None:
+        runner = CliRunner()
+        resources_out = "  GPUs:\n    GPU 0:\n      Vendor: NVIDIA\n  Storage:\n"
+
+        def fake_run(cmd, **kw):
+            m = MagicMock(returncode=0)
+            if "--resources" in cmd:
+                m.stdout = resources_out
+            else:
+                m.stdout = ""
+                m.returncode = 1
+            return m
+
+        with patch(f"{_PATCH}.subprocess.run", side_effect=fake_run):
+            result = runner.invoke(gpu_cmd, ["list-host"])
+        assert result.exit_code == 0
+        assert "NVIDIA" in result.output

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -100,6 +100,54 @@ class TestMonitorTop:
         assert "running" in result.output
 
 
+class TestMonitorUptime:
+    def test_uptime_shows_created(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+        incus_output = (
+            "Status: Running\n"
+            "Created: 2024-01-01 00:00:00 UTC\n"
+            "Last Used: 2024-06-01 12:00:00 UTC\n"
+        )
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("waydroid_toolkit.cli.commands.monitor.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout=incus_output)
+                result = runner.invoke(monitor_cmd, ["uptime"])
+        assert result.exit_code == 0
+        assert "2024-01-01" in result.output
+        assert "2024-06-01" in result.output
+
+    def test_uptime_handles_incus_not_found(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("waydroid_toolkit.cli.commands.monitor.subprocess.run",
+                       side_effect=FileNotFoundError):
+                result = runner.invoke(monitor_cmd, ["uptime"])
+        assert result.exit_code == 0
+        assert "not found" in result.output
+
+
+class TestMonitorHealth:
+    def test_health_runs_successfully(self) -> None:
+        runner = CliRunner()
+        mock_b = _make_backend(ContainerState.RUNNING)
+
+        def fake_run(cmd, **kw):
+            m = MagicMock(returncode=0, stdout="")
+            if "df" in cmd:
+                m.stdout = "Filesystem Size Used Avail Use% Mounted\n/ 100G 40G 60G 40% /\n"
+            elif "free" in cmd:
+                m.stdout = "Mem: 16G 8G 8G\n"
+            return m
+
+        with patch("waydroid_toolkit.cli.commands.monitor.get_backend", return_value=mock_b):
+            with patch("waydroid_toolkit.cli.commands.monitor.subprocess.run", side_effect=fake_run):
+                result = runner.invoke(monitor_cmd, ["health"])
+        assert result.exit_code == 0
+        assert "Health check complete" in result.output
+
+
 class TestMonitorDisk:
     def test_disk_shows_allocated_and_usage(self) -> None:
         runner = CliRunner()

--- a/tests/unit/test_net_cmd.py
+++ b/tests/unit/test_net_cmd.py
@@ -1,0 +1,108 @@
+"""Tests for wdt net (port forwarding)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.net import cmd as net_cmd
+
+_CT = "waydroid"
+
+
+def _patch_container(name: str = _CT):
+    return patch("waydroid_toolkit.cli.commands.net._container_name", return_value=name)
+
+
+class TestNetForward:
+    def test_forward_adds_proxy_device(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(net_cmd, ["forward", "8080"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "proxy" in args
+        assert "listen=tcp:0.0.0.0:8080" in args
+        assert "connect=tcp:127.0.0.1:8080" in args
+
+    def test_forward_different_container_port(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(net_cmd, ["forward", "8080", "80"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "connect=tcp:127.0.0.1:80" in args
+
+    def test_forward_udp_proto(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(net_cmd, ["forward", "5353", "--proto", "udp"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "listen=udp:0.0.0.0:5353" in args
+
+    def test_forward_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                result = runner.invoke(net_cmd, ["forward", "8080"])
+        assert result.exit_code != 0
+
+
+class TestNetUnforward:
+    def test_unforward_removes_device(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(net_cmd, ["unforward", "fwd-8080"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "remove" in args
+        assert "fwd-8080" in args
+
+    def test_unforward_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                result = runner.invoke(net_cmd, ["unforward", "fwd-8080"])
+        assert result.exit_code != 0
+
+
+class TestNetList:
+    def test_list_shows_proxy_devices(self) -> None:
+        runner = CliRunner()
+
+        def fake_run(cmd, **kw):
+            m = MagicMock(returncode=0)
+            if "list" in cmd:
+                m.stdout = "fwd-8080  proxy\n"
+            elif "listen" in cmd:
+                m.stdout = "tcp:0.0.0.0:8080\n"
+            else:
+                m.stdout = "tcp:127.0.0.1:8080\n"
+            return m
+
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run", side_effect=fake_run):
+                result = runner.invoke(net_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "fwd-8080" in result.output
+
+    def test_list_no_proxies_shows_message(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch("waydroid_toolkit.cli.commands.net.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="eth0  nic\n")
+                result = runner.invoke(net_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "No port forwards" in result.output

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -1,0 +1,117 @@
+"""Tests for wdt template."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.template import _parse_template, cmd as template_cmd
+
+
+# ── parser unit tests ─────────────────────────────────────────────────────────
+
+class TestParseTemplate:
+    def test_parses_description(self, tmp_path: Path) -> None:
+        f = tmp_path / "t.yaml"
+        f.write_text('description: "A test template"\n')
+        d = _parse_template(f)
+        assert d["description"] == "A test template"
+
+    def test_parses_nested_resources(self, tmp_path: Path) -> None:
+        f = tmp_path / "t.yaml"
+        f.write_text("resources:\n  cpu: 4\n  memory: 8GiB\n")
+        d = _parse_template(f)
+        assert isinstance(d["resources"], dict)
+        assert d["resources"]["cpu"] == "4"  # type: ignore[index]
+        assert d["resources"]["memory"] == "8GiB"  # type: ignore[index]
+
+    def test_ignores_comments(self, tmp_path: Path) -> None:
+        f = tmp_path / "t.yaml"
+        f.write_text("# comment\ndescription: hello\n")
+        d = _parse_template(f)
+        assert d["description"] == "hello"
+
+
+# ── CLI tests ─────────────────────────────────────────────────────────────────
+
+def _make_template_dir(tmp_path: Path) -> Path:
+    tdir = tmp_path / "templates"
+    tdir.mkdir()
+    (tdir / "dev.yaml").write_text(
+        'description: "Dev template"\nresources:\n  cpu: 4\n  memory: 4GiB\n'
+    )
+    (tdir / "minimal.yaml").write_text(
+        'description: "Minimal template"\nresources:\n  cpu: 2\n  memory: 2GiB\n'
+    )
+    return tdir
+
+
+class TestTemplateList:
+    def test_lists_templates(self, tmp_path: Path) -> None:
+        tdir = _make_template_dir(tmp_path)
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.template._templates_dir", return_value=tdir):
+            result = runner.invoke(template_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "dev" in result.output
+        assert "minimal" in result.output
+
+    def test_empty_dir_shows_message(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.template._templates_dir", return_value=empty):
+            result = runner.invoke(template_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "No templates" in result.output
+
+
+class TestTemplateShow:
+    def test_shows_template_details(self, tmp_path: Path) -> None:
+        tdir = _make_template_dir(tmp_path)
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.template._templates_dir", return_value=tdir):
+            result = runner.invoke(template_cmd, ["show", "dev"])
+        assert result.exit_code == 0
+        assert "Dev template" in result.output
+        assert "4GiB" in result.output
+
+    def test_missing_template_exits_nonzero(self, tmp_path: Path) -> None:
+        tdir = _make_template_dir(tmp_path)
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.template._templates_dir", return_value=tdir):
+            result = runner.invoke(template_cmd, ["show", "nonexistent"])
+        assert result.exit_code != 0
+
+
+class TestTemplateApply:
+    def test_dry_run_makes_no_subprocess_calls(self, tmp_path: Path) -> None:
+        tdir = _make_template_dir(tmp_path)
+        mock_b = MagicMock()
+        mock_b.get_info.return_value = MagicMock(container_name="waydroid")
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.template._templates_dir", return_value=tdir):
+            with patch("waydroid_toolkit.cli.commands.template.get_backend", return_value=mock_b):
+                with patch("waydroid_toolkit.cli.commands.template.subprocess.run") as mock_run:
+                    result = runner.invoke(template_cmd, ["apply", "dev", "--dry-run"])
+        assert result.exit_code == 0
+        mock_run.assert_not_called()
+        assert "dry-run" in result.output
+
+    def test_apply_calls_incus_config_set(self, tmp_path: Path) -> None:
+        tdir = _make_template_dir(tmp_path)
+        mock_b = MagicMock()
+        mock_b.get_info.return_value = MagicMock(container_name="waydroid")
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.template._templates_dir", return_value=tdir):
+            with patch("waydroid_toolkit.cli.commands.template.get_backend", return_value=mock_b):
+                with patch("waydroid_toolkit.cli.commands.template.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    result = runner.invoke(template_cmd, ["apply", "dev"])
+        assert result.exit_code == 0
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        assert any("limits.cpu" in c for c in calls)
+        assert any("limits.memory" in c for c in calls)

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from waydroid_toolkit.cli.commands.template import _parse_template, cmd as template_cmd

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,0 +1,59 @@
+"""Tests for wdt update."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.update import _version_gt, cmd as update_cmd
+
+
+class TestVersionGt:
+    def test_newer_patch(self) -> None:
+        assert _version_gt("0.2.1", "0.2.0") is True
+
+    def test_newer_minor(self) -> None:
+        assert _version_gt("0.3.0", "0.2.9") is True
+
+    def test_newer_major(self) -> None:
+        assert _version_gt("1.0.0", "0.9.9") is True
+
+    def test_equal_is_not_gt(self) -> None:
+        assert _version_gt("1.0.0", "1.0.0") is False
+
+    def test_older_is_not_gt(self) -> None:
+        assert _version_gt("0.1.0", "0.2.0") is False
+
+    def test_strips_v_prefix(self) -> None:
+        assert _version_gt("v1.1.0", "v1.0.0") is True
+
+
+class TestUpdateCheck:
+    def test_up_to_date(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.update._current_version", return_value="1.0.0"):
+            with patch("waydroid_toolkit.cli.commands.update._fetch_release",
+                       return_value={"tag_name": "v1.0.0", "body": ""}):
+                result = runner.invoke(update_cmd, ["check"])
+        assert result.exit_code == 0
+        assert "up to date" in result.output
+
+    def test_update_available(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.update._current_version", return_value="0.1.0"):
+            with patch("waydroid_toolkit.cli.commands.update._fetch_release",
+                       return_value={"tag_name": "v0.2.0", "body": "Bug fixes"}):
+                result = runner.invoke(update_cmd, ["check"])
+        assert result.exit_code == 0
+        assert "Update available" in result.output
+        assert "0.2.0" in result.output
+
+    def test_network_error_handled(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.update._current_version", return_value="0.1.0"):
+            with patch("waydroid_toolkit.cli.commands.update._fetch_release",
+                       side_effect=Exception("timeout")):
+                result = runner.invoke(update_cmd, ["check"])
+        assert result.exit_code == 0
+        assert "Could not reach" in result.output

--- a/tests/unit/test_usb_cmd.py
+++ b/tests/unit/test_usb_cmd.py
@@ -1,0 +1,127 @@
+"""Tests for wdt usb (USB passthrough)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.usb import cmd as usb_cmd
+
+_CT = "waydroid"
+_PATCH = "waydroid_toolkit.cli.commands.usb"
+
+
+def _patch_container():
+    return patch(f"{_PATCH}._container_name", return_value=_CT)
+
+
+class TestUsbAttach:
+    def test_attach_adds_usb_device(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(usb_cmd, ["attach", "046d", "c52b"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "usb" in args
+        assert "vendorid=046d" in args
+        assert "productid=c52b" in args
+
+    def test_attach_custom_dev_name(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(usb_cmd, ["attach", "046d", "c52b", "--dev-name", "myusb"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "myusb" in args
+
+    def test_attach_default_dev_name(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                runner.invoke(usb_cmd, ["attach", "046d", "c52b"])
+        args = mock_run.call_args[0][0]
+        assert "usb-046d-c52b" in args
+
+    def test_attach_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                result = runner.invoke(usb_cmd, ["attach", "046d", "c52b"])
+        assert result.exit_code != 0
+
+
+class TestUsbDetach:
+    def test_detach_removes_device(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                result = runner.invoke(usb_cmd, ["detach", "usb-046d-c52b"])
+        assert result.exit_code == 0
+        args = mock_run.call_args[0][0]
+        assert "remove" in args
+        assert "usb-046d-c52b" in args
+
+    def test_detach_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                result = runner.invoke(usb_cmd, ["detach", "usb-046d-c52b"])
+        assert result.exit_code != 0
+
+
+class TestUsbList:
+    def test_list_shows_usb_devices(self) -> None:
+        runner = CliRunner()
+
+        def fake_run(cmd, **kw):
+            m = MagicMock(returncode=0)
+            if "list" in cmd:
+                m.stdout = "usb-046d-c52b  usb\n"
+            elif "vendorid" in cmd:
+                m.stdout = "046d\n"
+            else:
+                m.stdout = "c52b\n"
+            return m
+
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run", side_effect=fake_run):
+                result = runner.invoke(usb_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "usb-046d-c52b" in result.output
+
+    def test_list_no_devices_shows_message(self) -> None:
+        runner = CliRunner()
+        with _patch_container():
+            with patch(f"{_PATCH}.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="eth0  nic\n")
+                result = runner.invoke(usb_cmd, ["list"])
+        assert result.exit_code == 0
+        assert "No USB" in result.output
+
+
+class TestUsbListHost:
+    def test_list_host_parses_lsusb(self) -> None:
+        runner = CliRunner()
+        lsusb_out = "Bus 001 Device 003: ID 046d:c52b Logitech Unifying Receiver\n"
+        with patch(f"{_PATCH}.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=lsusb_out)
+            result = runner.invoke(usb_cmd, ["list-host"])
+        assert result.exit_code == 0
+        assert "046d:c52b" in result.output
+
+    def test_list_host_no_lsusb_fallback(self) -> None:
+        runner = CliRunner()
+        with patch(f"{_PATCH}.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            result = runner.invoke(usb_cmd, ["list-host"])
+        assert result.exit_code == 0
+        assert "lsusb not found" in result.output


### PR DESCRIPTION
## Changes

Nine parity gap features implemented across wdt:

- **monitor uptime**: container created/last-used/status and recent snapshots
- **monitor health**: Incus daemon, KVM, storage pools, networks, host disk/memory
- **template**: `wdt template list/show/apply`; applies `limits.cpu` and `limits.memory` via incus config
- **update**: `wdt update check/install` self-update from GitHub releases
- **net**: `wdt net forward/unforward/list/status` port forwarding via incus proxy devices
- **usb**: `wdt usb list-host/attach/detach/list` USB passthrough
- **gpu**: `wdt gpu list-host/attach/detach/list/status` GPU passthrough (physical/mdev/mig/virtio)
- Tests for all new commands