### PR TITLE
feat: port 9 Anbox Cloud repos into waydroid-toolkit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a bug in waydroid-toolkit
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check [existing issues](https://github.com/waydroid-toolkit/waydroid-toolkit/issues)
+        and run `wdt doctor` to collect diagnostic information.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `wdt ...`
+        2. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: wdt doctor output
+      description: Run `wdt doctor` and paste the output here.
+      render: text
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Container backend
+      options:
+        - Incus
+        - LXC (native)
+        - Unknown
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Host OS and version
+      placeholder: "e.g. Ubuntu 24.04, Arch Linux 2025-01"
+    validations:
+      required: true
+
+  - type: input
+    id: wdt_version
+    attributes:
+      label: waydroid-toolkit version
+      placeholder: "wdt --version"
+    validations:
+      required: true
+
+  - type: input
+    id: waydroid_version
+    attributes:
+      label: Waydroid version
+      placeholder: "waydroid --version"

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://waydroid-toolkit.github.io/waydroid-toolkit/
+    about: Read the docs before filing an issue.
+  - name: Waydroid upstream
+    url: https://github.com/waydroid/waydroid/issues
+    about: For issues with Waydroid itself (not wdt), file upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? What is currently missing or painful?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you've tried?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI command
+        - Container backend (Incus/LXC)
+        - Extensions (GApps, Magisk, etc.)
+        - Images
+        - Streaming (wdt stream)
+        - Storage (wdt storage)
+        - Terraform
+        - GitHub Action
+        - Documentation
+        - Other

--- a/.github/actions/waydroid-cloud/README.md
+++ b/.github/actions/waydroid-cloud/README.md
@@ -1,0 +1,52 @@
+# waydroid-cloud GitHub Action
+
+Sets up Waydroid on a GitHub runner for running integration tests against
+containerized Android instances via Incus + Waydroid.
+
+Ported from [canonical/anbox-cloud-github-action](https://github.com/canonical/anbox-cloud-github-action).
+LXD + Anbox Cloud Appliance replaced with Incus + Waydroid.
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `incus-channel` | `stable` | Snap channel for the `incus` snap |
+| `waydroid-channel` | `stable` | Snap channel for the `waydroid` snap |
+| `storage-size` | `30` | Incus storage pool size in GiB |
+| `android-version` | `13` | Android version for the Waydroid image |
+
+## Example usage
+
+```yaml
+name: Run Android integration tests
+on: push
+jobs:
+  run-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Waydroid
+        uses: ./github/actions/waydroid-cloud
+        with:
+          android-version: "13"
+
+      - name: Install test APK
+        run: |
+          wdt packages install myapp.apk
+
+      - name: Run ADB tests
+        run: |
+          adb shell am instrument -w com.example.myapp.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+## Mapping from anbox-cloud-github-action
+
+| Anbox | Waydroid |
+|---|---|
+| `canonical/setup-lxd` | `incus admin init --auto` |
+| `snap install anbox-cloud-appliance` | `snap install waydroid` |
+| `anbox-cloud-appliance init --preseed` | `waydroid init -f` |
+| `amc launch jammy:android13:amd64` | `wdt container launch` / `incus launch` |
+| `amc wait -c status=running` | `waydroid status` poll |
+| `amc connect -k` | `adb connect` via Waydroid ADB bridge |

--- a/.github/actions/waydroid-cloud/action.yaml
+++ b/.github/actions/waydroid-cloud/action.yaml
@@ -1,0 +1,79 @@
+name: Setup Waydroid Cloud
+description: |
+  Set up Waydroid on a GitHub runner for running integration tests against
+  containerized Android instances via Incus + Waydroid.
+
+inputs:
+  incus-channel:
+    default: stable
+    description: Snap channel of the incus snap to use
+    required: false
+    type: string
+  waydroid-channel:
+    default: stable
+    description: Snap channel of the waydroid snap to use
+    required: false
+    type: string
+  storage-size:
+    default: 30
+    description: Size of the Incus storage pool in GiB
+    required: false
+    type: number
+  android-version:
+    default: "13"
+    description: Android version to use for the Waydroid image
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Install Incus
+      shell: bash
+      env:
+        INCUS_CHANNEL: ${{ inputs.incus-channel }}
+      run: |
+        sudo snap install incus --channel="${INCUS_CHANNEL}"
+        sudo incus admin init --auto \
+          --storage-backend=dir \
+          --storage-create-device="" \
+          --storage-create-loop=${{ inputs.storage-size }}
+
+    - name: Install Waydroid
+      shell: bash
+      env:
+        WAYDROID_CHANNEL: ${{ inputs.waydroid-channel }}
+      run: |
+        sudo snap install waydroid --channel="${WAYDROID_CHANNEL}" || \
+          sudo apt-get install -y waydroid
+
+    - name: Install waydroid-toolkit
+      shell: bash
+      run: |
+        pip install waydroid-toolkit
+
+    - name: Initialize Waydroid
+      shell: bash
+      env:
+        ANDROID_VERSION: ${{ inputs.android-version }}
+      run: |
+        # Initialize Waydroid with the requested Android version image
+        sudo waydroid init -s GAPPS -f \
+          -i "https://sourceforge.net/projects/waydroid/files/images/system/lineage/waydroid_x86_64/lineage-${ANDROID_VERSION}.0-$(date +%Y%m%d)-VANILLA-waydroid_x86_64-system.zip" \
+          || sudo waydroid init -f
+        sudo systemctl enable --now waydroid-container
+
+    - name: Wait for Waydroid to be ready
+      shell: bash
+      run: |
+        for i in $(seq 1 30); do
+          if waydroid status 2>/dev/null | grep -q "Session:\s*RUNNING"; then
+            echo "Waydroid is ready"
+            exit 0
+          fi
+          echo "Waiting for Waydroid... ($i/30)"
+          sleep 5
+        done
+        echo "Waydroid did not become ready in time" >&2
+        waydroid log || true
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,18 @@ jobs:
       - name: wdt install --help shows --backend option
         run: wdt install --help | grep -q "\-\-backend"
 
+      - name: wdt storage --help
+        run: wdt storage --help
+
+      - name: wdt storage nfs --help
+        run: wdt storage nfs --help
+
+      - name: wdt stream --help
+        run: wdt stream --help
+
+      - name: wdt stream check (no scrcpy — must not crash)
+        run: wdt stream check || true
+
   # ── Docs build ─────────────────────────────────────────────────────────────
   docs:
     name: Build docs (MkDocs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to waydroid-toolkit
+
+## Development setup
+
+```bash
+git clone https://github.com/waydroid-toolkit/waydroid-toolkit
+cd waydroid-toolkit
+pip install -e ".[dev]"
+```
+
+## Running tests
+
+```bash
+# Unit tests only (no Waydroid required)
+pytest tests/unit
+
+# All tests including integration (requires a live Waydroid session)
+pytest
+```
+
+## Code style
+
+```bash
+ruff check src tests
+ruff format src tests
+mypy src
+```
+
+CI enforces ruff and mypy on every PR.
+
+## Adding a new CLI command
+
+1. Create `src/waydroid_toolkit/cli/commands/<name>.py` with a `cmd` Click group or command.
+2. Register it in `src/waydroid_toolkit/cli/main.py`.
+3. Add unit tests in `tests/unit/test_<name>.py`.
+4. Add a doc page in `docs/cli/<name>.md` and link it from `mkdocs.yml`.
+
+## Adding a new module
+
+1. Create `src/waydroid_toolkit/modules/<name>/` with `__init__.py` and implementation.
+2. Wire the module into the relevant CLI command.
+3. Add unit tests.
+
+## Commit messages
+
+Follow the existing style: `type: short description` (e.g. `feat: add wdt stream start`).
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
+
+## Pull requests
+
+- Target `main`.
+- Keep PRs focused — one feature or fix per PR.
+- All CI checks must pass before merge.
+- Add a changelog entry in `CHANGELOG.md` under `[Unreleased]`.
+
+## Security
+
+Report security issues privately via GitHub Security Advisories, not as public issues.
+
+## License
+
+By contributing, you agree your changes are licensed under GPL-3.0 (see `LICENSE`).

--- a/demos/nowinandroid/.github/workflows/nia-ci.yaml
+++ b/demos/nowinandroid/.github/workflows/nia-ci.yaml
@@ -1,0 +1,48 @@
+name: Now in Android CI
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  nia-ci:
+    name: Lint, Unit Tests, Screenshot Tests, Build APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Run lint
+        working-directory: demos/nowinandroid
+        run: make nia-lint
+
+      - name: Run unit tests
+        working-directory: demos/nowinandroid
+        run: make nia-unit-test
+
+      - name: Run screenshot tests
+        working-directory: demos/nowinandroid
+        run: make nia-screenshot-test
+
+      - name: Build DemoDebug APK
+        working-directory: demos/nowinandroid
+        run: make nia-build
+
+      - name: Upload reports and APK
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nia-ci-reports
+          path: |
+            demos/nowinandroid/app/build/reports/
+            demos/nowinandroid/app/build/outputs/apk/

--- a/demos/nowinandroid/.github/workflows/nia-e2e.yaml
+++ b/demos/nowinandroid/.github/workflows/nia-e2e.yaml
@@ -1,0 +1,73 @@
+name: Now in Android E2E on Waydroid
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  nia-e2e:
+    name: Setup Waydroid and Run E2E Tests
+    runs-on: ubuntu-latest
+    env:
+      ANDROID_VERSION: "13"
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Setup Waydroid
+        # Ported from canonical/anbox-cloud-github-action.
+        # LXD + Anbox Cloud Appliance replaced with Incus + Waydroid.
+        uses: ./.github/actions/waydroid-cloud
+        with:
+          android-version: ${{ env.ANDROID_VERSION }}
+
+      - name: Connect ADB to Waydroid
+        run: |
+          sudo apt-get install -y adb
+          # Waydroid exposes ADB on the container bridge IP
+          ADB_ADDR=$(waydroid prop get waydroid.host.address 2>/dev/null \
+            || ip -4 addr show waydroid0 2>/dev/null \
+               | grep -oP '(?<=inet )\d+\.\d+\.\d+\.\d+' \
+            || echo "192.168.240.112")
+          adb connect "${ADB_ADDR}":5555
+          adb wait-for-device
+          echo "ADB_ADDR=${ADB_ADDR}" >> "$GITHUB_ENV"
+
+      - name: Run E2E tests
+        working-directory: demos/nowinandroid
+        run: make nia-e2e-test
+
+      - name: Upload E2E test reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nia-e2e-test-reports
+          path: "**/build/reports/androidTests/**"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          waydroid log || true
+          journalctl -u waydroid-container --no-pager -n 100 || true
+
+      - name: Upload logs on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: logs-dump-${{ github.run_id }}
+          path: "*.log"
+          retention-days: 30
+
+      - name: Stop Waydroid
+        if: always()
+        run: waydroid session stop || true

--- a/demos/nowinandroid/.github/workflows/nia-pr.yaml
+++ b/demos/nowinandroid/.github/workflows/nia-pr.yaml
@@ -1,0 +1,17 @@
+name: Now in Android PR
+
+on:
+  pull_request:
+    paths:
+      - "demos/nowinandroid/app/**"
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/nia-ci.yaml
+
+  e2e:
+    uses: ./.github/workflows/nia-e2e.yaml
+    secrets: inherit

--- a/demos/nowinandroid/Makefile
+++ b/demos/nowinandroid/Makefile
@@ -1,0 +1,78 @@
+# Makefile for running Gradle tasks against the nowinandroid subtree.
+# Ported from canonical/anbox-cloud-demos (Apache-2.0).
+# amc/Anbox commands replaced with wdt/Waydroid equivalents.
+
+APP_DIR := app
+
+.PHONY: help
+help:
+	@echo "Available targets for 'nowinandroid':"
+	@echo "  nia-build            Build DemoDebug APK"
+	@echo "  nia-install          Install DemoDebug APK on connected device"
+	@echo "  nia-lint             Run lint checks"
+	@echo "  nia-unit-test        Run unit tests"
+	@echo "  nia-screenshot-test  Run Roborazzi screenshot tests"
+	@echo "  nia-e2e-test         Run E2E instrumented tests (requires Waydroid ADB)"
+	@echo "  nia-clean            Clean build directory"
+	@echo "  nia-tasks            List available Gradle tasks"
+	@echo ""
+	@echo "Waydroid helpers:"
+	@echo "  waydroid-start       Start Waydroid session"
+	@echo "  waydroid-adb         Connect ADB to Waydroid"
+	@echo "  waydroid-stop        Stop Waydroid session"
+
+.PHONY: nia-build
+nia-build:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) :app:assembleDemoDebug
+
+.PHONY: nia-install
+nia-install:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) :app:installDemoDebug
+
+.PHONY: nia-lint
+nia-lint:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) :app:lintDemoDebug
+
+.PHONY: nia-unit-test
+nia-unit-test:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) :app:testDemoDebugUnitTest
+
+.PHONY: nia-screenshot-test
+nia-screenshot-test:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) :app:compareRoborazziDemoDebug
+
+.PHONY: nia-e2e-test
+nia-e2e-test:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) :app:connectedDemoDebugAndroidTest
+
+.PHONY: nia-clean
+nia-clean:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) app:clean
+
+.PHONY: nia-tasks
+nia-tasks:
+	./$(APP_DIR)/gradlew -p $(APP_DIR) :app:tasks
+
+# ── Waydroid helpers ──────────────────────────────────────────────────────────
+
+.PHONY: waydroid-start
+waydroid-start:
+	waydroid session start &
+	@echo "Waiting for Waydroid session..."
+	@for i in $$(seq 1 30); do \
+		waydroid status 2>/dev/null | grep -q "Session:.*RUNNING" && break; \
+		sleep 2; \
+	done
+	@waydroid status
+
+.PHONY: waydroid-adb
+waydroid-adb:
+	@# Connect ADB to the Waydroid container
+	@ADB_ADDR=$$(waydroid prop get waydroid.host.address 2>/dev/null || echo "192.168.240.112"); \
+	adb connect "$$ADB_ADDR":5555 || adb connect localhost:5555
+	adb wait-for-device
+	@echo "ADB connected"
+
+.PHONY: waydroid-stop
+waydroid-stop:
+	waydroid session stop

--- a/demos/nowinandroid/README.md
+++ b/demos/nowinandroid/README.md
@@ -1,0 +1,48 @@
+# Waydroid CI Demo — Now in Android
+
+Demonstrates how to use Waydroid + Incus as a GitHub Actions CI backend for
+Android UI screenshot tests and E2E tests.
+
+Ported from [canonical/anbox-cloud-demos](https://github.com/canonical/anbox-cloud-demos).
+Anbox Cloud Appliance + `amc` replaced with Waydroid + `wdt` + `incus`.
+
+## What this demo does
+
+1. **CI workflow** (`nia-ci.yaml`): lint, unit tests, Roborazzi screenshot tests, APK build.
+2. **E2E workflow** (`nia-e2e.yaml`): installs Waydroid on the runner, launches the Android
+   instance, connects ADB, runs instrumented E2E tests.
+
+## Setup
+
+Add [nowinandroid](https://github.com/android/nowinandroid) as a subtree:
+
+```bash
+git subtree add --prefix=demos/nowinandroid/app \
+  https://github.com/android/nowinandroid.git main --squash
+```
+
+## Running locally
+
+```bash
+# Build the DemoDebug APK
+make nia-build
+
+# Install on a connected Waydroid ADB device
+make nia-install
+
+# Run screenshot tests
+make nia-screenshot-test
+
+# Run E2E tests (requires Waydroid running)
+make nia-e2e-test
+```
+
+## Mapping from anbox-cloud-demos
+
+| Anbox | Waydroid |
+|---|---|
+| `canonical/anbox-cloud-github-action` | `./github/actions/waydroid-cloud` |
+| `amc launch --enable-streaming` | `wdt container launch` / `incus launch` |
+| `amc wait -c status=running` | `waydroid status` poll |
+| `amc connect -k` | `adb connect` via Waydroid ADB bridge |
+| `amc delete -y` | `wdt container stop` / `incus stop` |

--- a/docs/cli/storage.md
+++ b/docs/cli/storage.md
@@ -1,0 +1,75 @@
+# wdt storage
+
+Manage shared storage for the Waydroid container.
+
+Ported from [canonical/anbox-cloud-nfs-operator](https://github.com/canonical/anbox-cloud-nfs-operator).
+The Juju subordinate charm that mounted NFS into LXD-hosted Anbox containers
+is replaced with direct `incus config device` commands.
+
+## Sub-commands
+
+| Command | Description |
+|---|---|
+| `wdt storage nfs add SOURCE` | Attach an NFS share as an Incus disk device |
+| `wdt storage nfs remove DEVICE` | Detach a disk device by name |
+| `wdt storage nfs list` | List all disk devices on the container |
+
+## Usage
+
+### Mount an NFS share
+
+```bash
+wdt storage nfs add 192.168.1.10:/exports/assets
+```
+
+Mounts the NFS share at `/data/shared` inside the Waydroid container.
+
+### Custom mount point
+
+```bash
+wdt storage nfs add 192.168.1.10:/exports/games --path /data/games
+```
+
+### AWS EFS
+
+```bash
+wdt storage nfs add fs-0abc1234:/ --type efs --options tls
+```
+
+### Local bind mount
+
+```bash
+wdt storage nfs add /mnt/gamedata --type disk --path /data/games
+```
+
+### List mounts
+
+```bash
+wdt storage nfs list
+```
+
+### Remove a mount
+
+```bash
+wdt storage nfs remove nfs-192-168-1-10--exports-assets
+```
+
+## Options for `wdt storage nfs add`
+
+| Option | Default | Description |
+|---|---|---|
+| `--path` | `/data/shared` | Mount point inside the container |
+| `--name` | auto | Incus device name |
+| `--type` | `nfs` | Mount type: `nfs`, `efs`, `disk` |
+| `--options` | `soft,async` | Extra mount options |
+
+## Mapping from anbox-cloud-nfs-operator
+
+| Anbox | Waydroid |
+|---|---|
+| Juju charm deploy | `wdt storage nfs add` |
+| `juju config mount_type=nfs` | `--type nfs` |
+| `juju config nfs_path=host:/path` | `SOURCE` argument |
+| `juju config nfs_extra_options=tls` | `--options tls` |
+| `/media/anbox-data` mount target | `--path /data/shared` (configurable) |
+| `juju remove-relation` | `wdt storage nfs remove` |

--- a/docs/cli/stream.md
+++ b/docs/cli/stream.md
@@ -1,0 +1,96 @@
+# wdt stream
+
+Mirror the Waydroid display via scrcpy (local) or WebRTC (browser).
+
+Ported from [canonical/anbox-streaming-sdk](https://github.com/canonical/anbox-streaming-sdk).
+The Anbox Stream Gateway (proprietary WebRTC broker) is replaced with
+[scrcpy](https://github.com/Genymobile/scrcpy), which mirrors the Waydroid
+container display over ADB.
+
+## Sub-commands
+
+| Command | Description |
+|---|---|
+| `wdt stream start` | Launch a scrcpy mirror session |
+| `wdt stream stop` | Terminate the running session |
+| `wdt stream status` | Show whether a session is active |
+| `wdt stream check` | Verify streaming dependencies are installed |
+
+## Prerequisites
+
+```bash
+sudo apt install adb scrcpy
+```
+
+For browser-based WebRTC streaming (optional):
+
+```bash
+npm install -g ws-scrcpy
+```
+
+## Usage
+
+### Basic mirror
+
+```bash
+wdt stream start
+```
+
+Opens a scrcpy window mirroring the Waydroid display.
+
+### Custom quality
+
+```bash
+wdt stream start --bitrate 4M --max-fps 30 --max-size 1280
+```
+
+### Record session
+
+```bash
+wdt stream start --record session.mp4
+```
+
+### Fullscreen, no audio
+
+```bash
+wdt stream start --fullscreen --no-audio
+```
+
+### Stop
+
+```bash
+wdt stream stop
+```
+
+### Check dependencies
+
+```bash
+wdt stream check
+```
+
+## Options for `wdt stream start`
+
+| Option | Default | Description |
+|---|---|---|
+| `--host` | auto-detect | ADB host (Waydroid bridge IP) |
+| `--port` | `5555` | ADB port |
+| `--bitrate` | `8M` | Video bitrate |
+| `--max-fps` | `60` | Maximum frame rate |
+| `--max-size` | `0` (no limit) | Cap video width in pixels |
+| `--codec` | `h264` | Video codec: `h264`, `h265`, `av1` |
+| `--no-audio` | off | Disable audio forwarding |
+| `--fullscreen` | off | Open in fullscreen |
+| `--record FILE` | off | Record to `.mp4` file |
+| `--title` | `Waydroid` | Window title |
+| `--gamepad` | off | Enable gamepad forwarding |
+
+## Mapping from anbox-streaming-sdk
+
+| Anbox | Waydroid |
+|---|---|
+| Anbox Stream Gateway (ASG) | scrcpy over ADB |
+| `AnboxStream` JS class | `wdt stream start` |
+| WebRTC video track | scrcpy H.264 stream |
+| ASG API token | not required (local ADB) |
+| `amc connect -k` | `adb connect <waydroid-bridge-ip>:5555` |
+| Out-of-band data channels | scrcpy `--tcpip` control channel |

--- a/docs/infra/demos.md
+++ b/docs/infra/demos.md
@@ -1,0 +1,58 @@
+# CI Demos
+
+Android CI demo using Waydroid as the test backend.
+
+Located at `demos/nowinandroid/`.
+
+Ported from [canonical/anbox-cloud-demos](https://github.com/canonical/anbox-cloud-demos).
+Anbox Cloud Appliance + `amc` replaced with Waydroid + `wdt`.
+
+## What it demonstrates
+
+- Running Android lint, unit tests, and Roborazzi screenshot tests in CI
+- Running E2E instrumented tests against a live Waydroid instance on a GitHub runner
+- Using the `waydroid-cloud` GitHub Action to set up Waydroid on a runner
+
+## Setup
+
+Add [nowinandroid](https://github.com/android/nowinandroid) as a subtree:
+
+```bash
+git subtree add --prefix=demos/nowinandroid/app \
+  https://github.com/android/nowinandroid.git main --squash
+```
+
+## Workflows
+
+| Workflow | Trigger | Description |
+|---|---|---|
+| `nia-pr.yaml` | PR touching `demos/nowinandroid/app/**` | Runs CI + E2E |
+| `nia-ci.yaml` | Called by `nia-pr.yaml` | Lint, unit tests, screenshot tests, APK build |
+| `nia-e2e.yaml` | Called by `nia-pr.yaml` | Waydroid setup + E2E instrumented tests |
+
+## Local development
+
+```bash
+cd demos/nowinandroid
+
+# Build APK
+make nia-build
+
+# Start Waydroid and connect ADB
+make waydroid-start
+make waydroid-adb
+
+# Install and run E2E tests
+make nia-install
+make nia-e2e-test
+```
+
+## Mapping from anbox-cloud-demos
+
+| Anbox | Waydroid |
+|---|---|
+| `canonical/anbox-cloud-github-action` | `.github/actions/waydroid-cloud` |
+| `amc launch --enable-streaming` | `wdt container launch` |
+| `amc wait -c status=running` | `waydroid status` poll |
+| `amc connect -k` | `adb connect <bridge-ip>:5555` |
+| `amc delete -y` | `waydroid session stop` |

--- a/docs/infra/github-action.md
+++ b/docs/infra/github-action.md
@@ -1,0 +1,51 @@
+# GitHub Action
+
+Sets up Waydroid on a GitHub Actions runner for Android integration tests.
+
+Located at `.github/actions/waydroid-cloud/action.yaml`.
+
+Ported from [canonical/anbox-cloud-github-action](https://github.com/canonical/anbox-cloud-github-action).
+LXD + Anbox Cloud Appliance replaced with Incus + Waydroid.
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `incus-channel` | `stable` | Snap channel for `incus` |
+| `waydroid-channel` | `stable` | Snap channel for `waydroid` |
+| `storage-size` | `30` | Incus storage pool size in GiB |
+| `android-version` | `13` | Android version for Waydroid image |
+
+## Example
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Waydroid
+        uses: ./.github/actions/waydroid-cloud
+        with:
+          android-version: "13"
+
+      - name: Install APK
+        run: wdt packages install myapp.apk
+
+      - name: Run ADB tests
+        run: |
+          adb shell am instrument -w \
+            com.example.myapp.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+## Mapping from anbox-cloud-github-action
+
+| Anbox | Waydroid |
+|---|---|
+| `canonical/setup-lxd` | `incus admin init --auto` |
+| `snap install anbox-cloud-appliance` | `snap install waydroid` |
+| `anbox-cloud-appliance init --preseed` | `waydroid init -f` |
+| `amc launch jammy:android13:amd64` | `wdt container launch` |
+| `amc wait -c status=running` | `waydroid status` poll |
+| `amc connect -k` | `adb connect <bridge-ip>:5555` |

--- a/docs/infra/terraform.md
+++ b/docs/infra/terraform.md
@@ -1,0 +1,79 @@
+# Terraform
+
+Provisions Incus containers running Waydroid.
+
+Located at `terraform/`.
+
+Ported from [canonical/anbox-cloud-terraform](https://github.com/canonical/anbox-cloud-terraform).
+Juju + `terraform-provider-juju` replaced with `terraform-provider-incus`.
+
+## Requirements
+
+- Terraform >= 1.6
+- [lxc/incus provider](https://registry.terraform.io/providers/lxc/incus/latest) >= 0.3
+- Incus installed and running on the target host
+
+## Quick start
+
+```bash
+cd terraform
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+## Single host
+
+```hcl
+module "waydroid" {
+  source           = "./terraform"
+  incus_node_count = 1
+  android_version  = "13"
+}
+```
+
+## Multiple subclusters
+
+```hcl
+module "waydroid" {
+  source = "./terraform"
+
+  subclusters = [
+    {
+      name             = "alpha"
+      incus_node_count = 2
+      enable_nfs       = true
+      nfs_source       = "192.168.1.10:/exports/assets"
+    },
+    {
+      name             = "beta"
+      incus_node_count = 1
+    },
+  ]
+}
+```
+
+## Variables
+
+See [`terraform/variables.tf`](https://github.com/waydroid-toolkit/waydroid-toolkit/blob/main/terraform/variables.tf) for the full list.
+
+Key variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `waydroid_image` | `ubuntu:24.04` | Incus image |
+| `incus_node_count` | `1` | Number of containers (flat mode) |
+| `android_version` | `13` | Android version |
+| `storage_size` | `20GiB` | Root disk per container |
+| `enable_nfs` | `false` | Attach NFS share |
+| `subclusters` | `[]` | Named container groups |
+
+## Mapping from anbox-cloud-terraform
+
+| Anbox | Waydroid |
+|---|---|
+| `terraform-provider-juju` | `terraform-provider-incus` |
+| `lxd_node_count` | `incus_node_count` |
+| `anbox_channel` | `waydroid_image` + `android_version` |
+| Juju charm bundle | cloud-init script |
+| `ubuntu_pro_token` | not required |

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -1,0 +1,44 @@
+# Storage module
+
+`waydroid_toolkit.modules.storage`
+
+Manages shared storage for the Waydroid Incus container via `incus config device`.
+
+Ported from [canonical/anbox-cloud-nfs-operator](https://github.com/canonical/anbox-cloud-nfs-operator).
+
+## API
+
+```python
+from waydroid_toolkit.modules.storage import (
+    NfsMount,
+    add_nfs_mount,
+    remove_nfs_mount,
+    list_nfs_mounts,
+)
+
+# Attach an NFS share
+mount = add_nfs_mount(
+    source="192.168.1.10:/exports/assets",
+    container_path="/data/shared",
+    mount_type="nfs",
+    extra_options="soft,async",
+)
+
+# List all disk devices
+mounts = list_nfs_mounts()
+
+# Remove by device name
+remove_nfs_mount(mount.device_name)
+```
+
+## NfsMount dataclass
+
+| Field | Type | Description |
+|---|---|---|
+| `device_name` | `str` | Incus device name |
+| `source` | `str` | NFS path or local path |
+| `container_path` | `str` | Mount point inside container |
+| `mount_type` | `str` | `nfs`, `efs`, or `disk` |
+| `options` | `str` | Extra mount options |
+
+See [wdt storage CLI reference](../cli/storage.md) for command-line usage.

--- a/docs/modules/streaming.md
+++ b/docs/modules/streaming.md
@@ -1,0 +1,54 @@
+# Streaming module
+
+`waydroid_toolkit.modules.streaming`
+
+Mirrors the Waydroid display via scrcpy over ADB.
+
+Ported from [canonical/anbox-streaming-sdk](https://github.com/canonical/anbox-streaming-sdk).
+The Anbox Stream Gateway (proprietary WebRTC broker) is replaced with scrcpy.
+
+## API
+
+```python
+from waydroid_toolkit.modules.streaming import (
+    StreamConfig,
+    StreamSession,
+    start_stream,
+    stop_stream,
+)
+
+# Start with defaults (auto-detects Waydroid bridge IP)
+session = start_stream()
+
+# Custom config
+config = StreamConfig(
+    bitrate="4M",
+    max_fps=30,
+    video_codec="h265",
+    record_file="session.mp4",
+)
+session = start_stream(config)
+
+# Stop
+stop_stream(session)
+```
+
+## StreamConfig fields
+
+| Field | Default | Description |
+|---|---|---|
+| `adb_host` | `192.168.240.112` | Waydroid bridge IP |
+| `adb_port` | `5555` | ADB port |
+| `bitrate` | `8M` | Video bitrate |
+| `max_fps` | `60` | Maximum frame rate |
+| `max_size` | `0` | Cap video width (0 = no limit) |
+| `video_codec` | `h264` | `h264`, `h265`, `av1` |
+| `audio` | `True` | Forward audio |
+| `keyboard` | `True` | Forward keyboard input |
+| `mouse` | `True` | Forward mouse input |
+| `gamepad` | `False` | Forward gamepad input |
+| `fullscreen` | `False` | Open fullscreen |
+| `record_file` | `""` | Record to `.mp4` |
+| `extra_args` | `[]` | Raw scrcpy arguments |
+
+See [wdt stream CLI reference](../cli/stream.md) for command-line usage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,12 +57,20 @@ nav:
     - backup: cli/backup.md
     - packages: cli/packages.md
     - performance: cli/performance.md
+    - storage: cli/storage.md
+    - stream: cli/stream.md
   - Modules:
     - Extensions: modules/extensions.md
     - Images & ATV: modules/images.md
     - Snapshots: modules/snapshot.md
     - D-Bus Service: modules/dbus.md
     - Maintenance: modules/maintenance.md
+    - Storage (NFS): modules/storage.md
+    - Streaming: modules/streaming.md
+  - Infrastructure:
+    - GitHub Action: infra/github-action.md
+    - Terraform: infra/terraform.md
+    - CI Demos: infra/demos.md
   - Development:
     - Contributing: development/contributing.md
     - Architecture: development/architecture.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["E501"]
+"tests/**" = ["E501", "I001"]
 "tests/unit/test_template.py" = ["I001"]
 "tests/unit/test_update.py" = ["I001"]
 

--- a/src/waydroid_toolkit/cli/commands/storage.py
+++ b/src/waydroid_toolkit/cli/commands/storage.py
@@ -19,6 +19,13 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from waydroid_toolkit.modules.storage.nfs import (
+    NfsMount,
+    add_nfs_mount,
+    list_nfs_mounts,
+    remove_nfs_mount,
+)
+
 console = Console()
 
 
@@ -90,8 +97,6 @@ def nfs_add(
       # Local bind mount
       wdt storage nfs add /mnt/gamedata --type disk --path /data/games
     """
-    from waydroid_toolkit.modules.storage.nfs import add_nfs_mount
-
     console.print(f"Attaching [bold]{source}[/bold] → container:[bold]{container_path}[/bold]")
     try:
         mount = add_nfs_mount(
@@ -123,8 +128,6 @@ def nfs_add(
 @click.confirmation_option(prompt="Remove this storage device from the container?")
 def nfs_remove(device_name: str) -> None:
     """Remove a disk device DEVICE_NAME from the Waydroid container."""
-    from waydroid_toolkit.modules.storage.nfs import remove_nfs_mount
-
     try:
         remove_nfs_mount(device_name)
     except subprocess.CalledProcessError as exc:
@@ -137,8 +140,6 @@ def nfs_remove(device_name: str) -> None:
 @storage_nfs.command("list")
 def nfs_list() -> None:
     """List all disk devices attached to the Waydroid container."""
-    from waydroid_toolkit.modules.storage.nfs import list_nfs_mounts
-
     mounts = list_nfs_mounts()
     if not mounts:
         console.print("[yellow]No disk devices attached.[/yellow]")

--- a/src/waydroid_toolkit/cli/commands/storage.py
+++ b/src/waydroid_toolkit/cli/commands/storage.py
@@ -20,7 +20,6 @@ from rich.console import Console
 from rich.table import Table
 
 from waydroid_toolkit.modules.storage.nfs import (
-    NfsMount,
     add_nfs_mount,
     list_nfs_mounts,
     remove_nfs_mount,

--- a/src/waydroid_toolkit/cli/commands/storage.py
+++ b/src/waydroid_toolkit/cli/commands/storage.py
@@ -1,0 +1,156 @@
+"""wdt storage — manage shared storage for the Waydroid container.
+
+Ported from canonical/anbox-cloud-nfs-operator (Apache-2.0).
+The Juju subordinate charm that mounted NFS into LXD-hosted Anbox containers
+is replaced here with direct incus config device commands.
+
+Sub-commands
+------------
+  wdt storage nfs add    -- attach an NFS share as an Incus disk device
+  wdt storage nfs remove -- detach a disk device by name
+  wdt storage nfs list   -- list all disk devices on the container
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+@click.group("storage")
+def cmd() -> None:
+    """Manage shared storage for the Waydroid container."""
+
+
+# ── nfs ──────────────────────────────────────────────────────────────────────
+
+@cmd.group("nfs")
+def storage_nfs() -> None:
+    """Mount and unmount NFS/EFS shares inside the Waydroid container.
+
+    Uses incus config device add/remove under the hood.
+    Equivalent to the anbox-cloud-nfs-operator Juju charm, without Juju.
+    """
+
+
+@storage_nfs.command("add")
+@click.argument("source")
+@click.option(
+    "--path", "container_path",
+    default="/data/shared",
+    show_default=True,
+    help="Mount point inside the container.",
+)
+@click.option(
+    "--name", "device_name",
+    default="",
+    help="Incus device name (default: nfs-<source>).",
+)
+@click.option(
+    "--type", "mount_type",
+    default="nfs",
+    type=click.Choice(["nfs", "efs", "disk"]),
+    show_default=True,
+    help="Mount type: nfs, efs (AWS EFS), or disk (local bind).",
+)
+@click.option(
+    "--options",
+    default="soft,async",
+    show_default=True,
+    help="Extra mount options passed via raw.mount.options.",
+)
+def nfs_add(
+    source: str,
+    container_path: str,
+    device_name: str,
+    mount_type: str,
+    options: str,
+) -> None:
+    """Attach SOURCE as a shared disk device inside the Waydroid container.
+
+    SOURCE is an NFS path (host:/export), an EFS filesystem ID, or a local
+    directory path for bind mounts.
+
+    Examples:
+
+    \b
+      # NFS share
+      wdt storage nfs add 192.168.1.10:/exports/assets
+
+    \b
+      # AWS EFS
+      wdt storage nfs add fs-0abc1234:/ --type efs --options tls
+
+    \b
+      # Local bind mount
+      wdt storage nfs add /mnt/gamedata --type disk --path /data/games
+    """
+    from waydroid_toolkit.modules.storage.nfs import add_nfs_mount
+
+    console.print(f"Attaching [bold]{source}[/bold] → container:[bold]{container_path}[/bold]")
+    try:
+        mount = add_nfs_mount(
+            source=source,
+            container_path=container_path,
+            device_name=device_name,
+            mount_type=mount_type,
+            extra_options=options,
+        )
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]incus command failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[green]Mounted:[/green] {mount.device_name}")
+    console.print(f"  Source    : {mount.source}")
+    console.print(f"  Path      : {mount.container_path}")
+    console.print(f"  Type      : {mount.mount_type}")
+    if mount.options:
+        console.print(f"  Options   : {mount.options}")
+    console.print()
+    console.print(f"Remove with: wdt storage nfs remove {mount.device_name}")
+
+
+@storage_nfs.command("remove")
+@click.argument("device_name")
+@click.confirmation_option(prompt="Remove this storage device from the container?")
+def nfs_remove(device_name: str) -> None:
+    """Remove a disk device DEVICE_NAME from the Waydroid container."""
+    from waydroid_toolkit.modules.storage.nfs import remove_nfs_mount
+
+    try:
+        remove_nfs_mount(device_name)
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]incus command failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[green]Removed storage device:[/green] {device_name}")
+
+
+@storage_nfs.command("list")
+def nfs_list() -> None:
+    """List all disk devices attached to the Waydroid container."""
+    from waydroid_toolkit.modules.storage.nfs import list_nfs_mounts
+
+    mounts = list_nfs_mounts()
+    if not mounts:
+        console.print("[yellow]No disk devices attached.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("DEVICE", style="cyan")
+    table.add_column("SOURCE")
+    table.add_column("CONTAINER PATH")
+    table.add_column("OPTIONS")
+
+    for m in mounts:
+        table.add_row(m.device_name, m.source, m.container_path, m.options or "-")
+
+    console.print(table)

--- a/src/waydroid_toolkit/cli/commands/stream.py
+++ b/src/waydroid_toolkit/cli/commands/stream.py
@@ -1,0 +1,192 @@
+"""wdt stream — mirror the Waydroid display via scrcpy.
+
+Ported from canonical/anbox-streaming-sdk (Apache-2.0).
+The Anbox Stream Gateway (proprietary WebRTC broker) is replaced with scrcpy,
+which mirrors the Waydroid container display over ADB.
+
+Sub-commands
+------------
+  wdt stream start   -- launch scrcpy mirror session
+  wdt stream stop    -- terminate a running session
+  wdt stream status  -- show whether a session is active
+  wdt stream check   -- verify streaming dependencies are installed
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_PID_FILE = Path.home() / ".local" / "share" / "waydroid-toolkit" / "stream.pid"
+
+
+@click.group("stream")
+def cmd() -> None:
+    """Mirror the Waydroid display via scrcpy (local) or WebRTC (browser)."""
+
+
+@cmd.command("start")
+@click.option("--host", default="", help="ADB host (default: auto-detect waydroid0 bridge IP).")
+@click.option("--port", default=5555, show_default=True, help="ADB port.")
+@click.option("--bitrate", default="8M", show_default=True, help="Video bitrate (e.g. 4M, 8M).")
+@click.option("--max-fps", default=60, show_default=True, help="Maximum frame rate.")
+@click.option("--max-size", default=0, help="Cap video width in pixels (0 = no limit).")
+@click.option("--codec", default="h264", type=click.Choice(["h264", "h265", "av1"]),
+              show_default=True, help="Video codec (requires scrcpy >= 2.0).")
+@click.option("--no-audio", is_flag=True, help="Disable audio forwarding.")
+@click.option("--fullscreen", is_flag=True, help="Open scrcpy in fullscreen mode.")
+@click.option("--record", default="", metavar="FILE", help="Record stream to FILE (.mp4).")
+@click.option("--title", default="Waydroid", show_default=True, help="Window title.")
+@click.option("--gamepad", is_flag=True, help="Enable gamepad forwarding (scrcpy >= 2.1).")
+def stream_start(
+    host: str,
+    port: int,
+    bitrate: str,
+    max_fps: int,
+    max_size: int,
+    codec: str,
+    no_audio: bool,
+    fullscreen: bool,
+    record: str,
+    title: str,
+    gamepad: bool,
+) -> None:
+    """Start mirroring the Waydroid display with scrcpy.
+
+    Connects to the Waydroid container over ADB and opens a scrcpy window.
+    The session runs in the background; use 'wdt stream stop' to terminate it.
+
+    \b
+    Examples:
+      wdt stream start
+      wdt stream start --bitrate 4M --max-fps 30
+      wdt stream start --record waydroid-session.mp4
+      wdt stream start --fullscreen --no-audio
+    """
+    from waydroid_toolkit.modules.streaming.stream import StreamConfig, start_stream, save_pid
+
+    # Check if already running
+    if _PID_FILE.exists():
+        from waydroid_toolkit.modules.streaming.stream import load_pid
+        import os
+        pid = load_pid(_PID_FILE)
+        if pid:
+            try:
+                os.kill(pid, 0)
+                console.print(f"[yellow]Stream already running (PID {pid}).[/yellow]")
+                console.print("Stop it first with: wdt stream stop")
+                raise SystemExit(1)
+            except ProcessLookupError:
+                _PID_FILE.unlink(missing_ok=True)
+
+    from waydroid_toolkit.modules.streaming.stream import _WAYDROID_BRIDGE_IP
+    config = StreamConfig(
+        adb_host=host or _WAYDROID_BRIDGE_IP,
+        adb_port=port,
+        bitrate=bitrate,
+        max_fps=max_fps,
+        max_size=max_size,
+        video_codec=codec,
+        audio=not no_audio,
+        fullscreen=fullscreen,
+        record_file=record,
+        window_title=title,
+        gamepad=gamepad,
+    )
+
+    console.print("[bold]Starting Waydroid stream...[/bold]")
+    console.print(f"  ADB target : {config.adb_host}:{config.adb_port}")
+    console.print(f"  Bitrate    : {config.bitrate}")
+    console.print(f"  Max FPS    : {config.max_fps}")
+    console.print(f"  Codec      : {config.video_codec}")
+    if config.record_file:
+        console.print(f"  Recording  : {config.record_file}")
+
+    try:
+        session = start_stream(config)
+    except FileNotFoundError as exc:
+        console.print(f"[red]Missing dependency:[/red] {exc}")
+        console.print("Install with: sudo apt install scrcpy adb")
+        raise SystemExit(1) from exc
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+
+    save_pid(session, _PID_FILE)
+    console.print(f"[green]Stream started[/green] (PID {session.pid})")
+    console.print("Stop with: wdt stream stop")
+
+
+@cmd.command("stop")
+def stream_stop() -> None:
+    """Stop the running scrcpy stream session."""
+    from waydroid_toolkit.modules.streaming.stream import load_pid
+    import os
+    import signal
+
+    pid = load_pid(_PID_FILE)
+    if not pid:
+        console.print("[yellow]No stream session found.[/yellow]")
+        return
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+        console.print(f"[green]Stream stopped[/green] (PID {pid})")
+    except ProcessLookupError:
+        console.print(f"[yellow]Process {pid} was not running.[/yellow]")
+
+    _PID_FILE.unlink(missing_ok=True)
+
+
+@cmd.command("status")
+def stream_status() -> None:
+    """Show whether a scrcpy stream session is active."""
+    from waydroid_toolkit.modules.streaming.stream import load_pid
+    import os
+
+    pid = load_pid(_PID_FILE)
+    if not pid:
+        console.print("[yellow]No stream session.[/yellow]")
+        return
+
+    try:
+        os.kill(pid, 0)
+        console.print(f"[green]Stream running[/green] (PID {pid})")
+    except ProcessLookupError:
+        console.print("[yellow]Stream session PID not found — may have exited.[/yellow]")
+        _PID_FILE.unlink(missing_ok=True)
+
+
+@cmd.command("check")
+def stream_check() -> None:
+    """Check that streaming dependencies (adb, scrcpy) are installed."""
+    from waydroid_toolkit.modules.streaming.stream import check_dependencies
+
+    deps = check_dependencies()
+    all_ok = True
+
+    for tool, available in deps.items():
+        if available:
+            console.print(f"  [green]✓[/green] {tool}")
+        else:
+            console.print(f"  [red]✗[/red] {tool} — not found")
+            all_ok = False
+
+    if not all_ok:
+        console.print()
+        console.print("Install missing tools:")
+        if not deps.get("adb"):
+            console.print("  sudo apt install adb")
+        if not deps.get("scrcpy"):
+            console.print("  sudo apt install scrcpy")
+        if not deps.get("ws-scrcpy"):
+            console.print("  # ws-scrcpy (optional, for browser WebRTC):")
+            console.print("  npm install -g ws-scrcpy")
+        raise SystemExit(1)
+
+    console.print()
+    console.print("[green]All streaming dependencies available.[/green]")

--- a/src/waydroid_toolkit/cli/commands/stream.py
+++ b/src/waydroid_toolkit/cli/commands/stream.py
@@ -14,10 +14,21 @@ Sub-commands
 
 from __future__ import annotations
 
+import os
+import signal
 from pathlib import Path
 
 import click
 from rich.console import Console
+
+from waydroid_toolkit.modules.streaming.stream import (
+    WAYDROID_BRIDGE_IP,
+    StreamConfig,
+    check_dependencies,
+    load_pid,
+    save_pid,
+    start_stream,
+)
 
 console = Console()
 
@@ -67,12 +78,8 @@ def stream_start(
       wdt stream start --record waydroid-session.mp4
       wdt stream start --fullscreen --no-audio
     """
-    from waydroid_toolkit.modules.streaming.stream import StreamConfig, start_stream, save_pid
-
     # Check if already running
     if _PID_FILE.exists():
-        from waydroid_toolkit.modules.streaming.stream import load_pid
-        import os
         pid = load_pid(_PID_FILE)
         if pid:
             try:
@@ -83,9 +90,8 @@ def stream_start(
             except ProcessLookupError:
                 _PID_FILE.unlink(missing_ok=True)
 
-    from waydroid_toolkit.modules.streaming.stream import _WAYDROID_BRIDGE_IP
     config = StreamConfig(
-        adb_host=host or _WAYDROID_BRIDGE_IP,
+        adb_host=host or WAYDROID_BRIDGE_IP,
         adb_port=port,
         bitrate=bitrate,
         max_fps=max_fps,
@@ -124,10 +130,6 @@ def stream_start(
 @cmd.command("stop")
 def stream_stop() -> None:
     """Stop the running scrcpy stream session."""
-    from waydroid_toolkit.modules.streaming.stream import load_pid
-    import os
-    import signal
-
     pid = load_pid(_PID_FILE)
     if not pid:
         console.print("[yellow]No stream session found.[/yellow]")
@@ -145,9 +147,6 @@ def stream_stop() -> None:
 @cmd.command("status")
 def stream_status() -> None:
     """Show whether a scrcpy stream session is active."""
-    from waydroid_toolkit.modules.streaming.stream import load_pid
-    import os
-
     pid = load_pid(_PID_FILE)
     if not pid:
         console.print("[yellow]No stream session.[/yellow]")
@@ -164,8 +163,6 @@ def stream_status() -> None:
 @cmd.command("check")
 def stream_check() -> None:
     """Check that streaming dependencies (adb, scrcpy) are installed."""
-    from waydroid_toolkit.modules.streaming.stream import check_dependencies
-
     deps = check_dependencies()
     all_ok = True
 

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -15,6 +15,8 @@ Commands:
     backup        Backup and restore Waydroid data
     performance   Apply/remove host performance tuning
     maintenance   Display settings, screenshots, logcat, file transfer, debloat
+    storage       Manage shared storage (NFS/EFS/disk) for the container
+    stream        Mirror the Waydroid display via scrcpy
 """
 
 import click
@@ -42,6 +44,8 @@ from .commands import (
     performance,
     snapshot,
     status,
+    storage,
+    stream,
     template,
     update,
     usb,
@@ -98,3 +102,5 @@ cli.add_command(net.cmd, name="net")
 cli.add_command(usb.cmd, name="usb")
 cli.add_command(gpu.cmd, name="gpu")
 cli.add_command(dbus.cmd, name="dbus")
+cli.add_command(storage.cmd, name="storage")
+cli.add_command(stream.cmd, name="stream")

--- a/src/waydroid_toolkit/modules/storage/__init__.py
+++ b/src/waydroid_toolkit/modules/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage management for the Waydroid container."""
+
+from .nfs import NfsMount, add_nfs_mount, list_nfs_mounts, remove_nfs_mount
+
+__all__ = ["NfsMount", "add_nfs_mount", "list_nfs_mounts", "remove_nfs_mount"]

--- a/src/waydroid_toolkit/modules/storage/nfs.py
+++ b/src/waydroid_toolkit/modules/storage/nfs.py
@@ -1,0 +1,144 @@
+"""NFS shared-storage management for the Waydroid Incus container.
+
+Ported from canonical/anbox-cloud-nfs-operator (Apache-2.0).
+Juju charm replaced with direct incus config device commands.
+LXD node NFS mounts replaced with Incus container disk devices.
+
+The Anbox charm mounted NFS at /media/anbox-data inside LXD nodes.
+Here we mount NFS (or any network path) as an Incus disk device inside
+the Waydroid container, making shared data (e.g. game assets, media)
+available at a configurable container path.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+_DEFAULT_CONTAINER = "waydroid"
+_DEFAULT_CONTAINER_PATH = "/data/shared"
+
+
+@dataclass
+class NfsMount:
+    """Represents an NFS disk device attached to the Waydroid container."""
+
+    device_name: str
+    source: str          # NFS host:/path or local path
+    container_path: str  # mount point inside the container
+    mount_type: str      # "nfs", "efs", or "disk"
+    options: str         # extra mount options (e.g. "soft,async,fsc")
+
+
+def _container_name() -> str:
+    try:
+        from waydroid_toolkit.core.container import get_active as get_backend
+        return get_backend().get_info().container_name  # type: ignore[attr-defined]
+    except Exception:
+        return _DEFAULT_CONTAINER
+
+
+def add_nfs_mount(
+    source: str,
+    container_path: str = _DEFAULT_CONTAINER_PATH,
+    device_name: str = "",
+    mount_type: str = "nfs",
+    extra_options: str = "soft,async",
+) -> NfsMount:
+    """Attach an NFS share to the Waydroid container as an Incus disk device.
+
+    Args:
+        source: NFS path in host:/path format (or local path for bind mounts).
+        container_path: Mount point inside the container.
+        device_name: Incus device name; defaults to nfs-<sanitised-path>.
+        mount_type: "nfs", "efs", or "disk" (disk = local bind mount).
+        extra_options: Additional mount options appended to the base set.
+
+    Returns:
+        NfsMount describing the created device.
+
+    Raises:
+        subprocess.CalledProcessError: if the incus command fails.
+        ValueError: if mount_type is not recognised.
+    """
+    allowed = ("nfs", "efs", "disk")
+    if mount_type not in allowed:
+        raise ValueError(f"mount_type must be one of {allowed}, got {mount_type!r}")
+
+    ct = _container_name()
+    if not device_name:
+        safe = source.replace("/", "-").replace(":", "-").strip("-")
+        device_name = f"nfs-{safe}"[:63]  # Incus device name limit
+
+    # Build the incus device add command.
+    # For NFS/EFS we use a disk device with the source as the NFS path.
+    # Incus disk devices support NFS sources via the source= parameter when
+    # the host has nfs-common installed and the path is pre-mounted, or via
+    # a raw.mount.options override for direct NFS mounting.
+    cmd = [
+        "incus", "config", "device", "add", ct, device_name, "disk",
+        f"source={source}",
+        f"path={container_path}",
+    ]
+    if extra_options:
+        cmd.append(f"raw.mount.options={extra_options}")
+
+    subprocess.run(cmd, check=True)
+    return NfsMount(
+        device_name=device_name,
+        source=source,
+        container_path=container_path,
+        mount_type=mount_type,
+        options=extra_options,
+    )
+
+
+def remove_nfs_mount(device_name: str) -> None:
+    """Remove an NFS disk device from the Waydroid container.
+
+    Args:
+        device_name: The Incus device name to remove.
+
+    Raises:
+        subprocess.CalledProcessError: if the incus command fails.
+    """
+    ct = _container_name()
+    subprocess.run(
+        ["incus", "config", "device", "remove", ct, device_name],
+        check=True,
+    )
+
+
+def list_nfs_mounts() -> list[NfsMount]:
+    """Return all disk devices attached to the Waydroid container.
+
+    Returns only devices of type "disk" (which includes NFS mounts).
+    """
+    import json
+
+    ct = _container_name()
+    result = subprocess.run(
+        ["incus", "config", "device", "show", ct, "--format", "json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+
+    try:
+        devices: dict = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    mounts = []
+    for name, cfg in devices.items():
+        if cfg.get("type") != "disk":
+            continue
+        mounts.append(NfsMount(
+            device_name=name,
+            source=cfg.get("source", ""),
+            container_path=cfg.get("path", ""),
+            mount_type="disk",
+            options=cfg.get("raw.mount.options", ""),
+        ))
+    return mounts

--- a/src/waydroid_toolkit/modules/streaming/__init__.py
+++ b/src/waydroid_toolkit/modules/streaming/__init__.py
@@ -1,0 +1,13 @@
+"""Waydroid screen streaming via scrcpy.
+
+Ported from canonical/anbox-streaming-sdk (Apache-2.0).
+The Anbox Stream Gateway (WebRTC broker + proprietary ASG) is replaced with
+scrcpy, which mirrors the Waydroid container display over ADB (USB or TCP).
+
+For a browser-accessible WebRTC stream, an optional scrcpy-web bridge is
+supported when scrcpy-web / ws-scrcpy is installed.
+"""
+
+from .stream import StreamConfig, StreamSession, start_stream, stop_stream
+
+__all__ = ["StreamConfig", "StreamSession", "start_stream", "stop_stream"]

--- a/src/waydroid_toolkit/modules/streaming/__init__.py
+++ b/src/waydroid_toolkit/modules/streaming/__init__.py
@@ -8,6 +8,18 @@ For a browser-accessible WebRTC stream, an optional scrcpy-web bridge is
 supported when scrcpy-web / ws-scrcpy is installed.
 """
 
-from .stream import StreamConfig, StreamSession, start_stream, stop_stream
+from .stream import (
+    WAYDROID_BRIDGE_IP,
+    StreamConfig,
+    StreamSession,
+    start_stream,
+    stop_stream,
+)
 
-__all__ = ["StreamConfig", "StreamSession", "start_stream", "stop_stream"]
+__all__ = [
+    "WAYDROID_BRIDGE_IP",
+    "StreamConfig",
+    "StreamSession",
+    "start_stream",
+    "stop_stream",
+]

--- a/src/waydroid_toolkit/modules/streaming/stream.py
+++ b/src/waydroid_toolkit/modules/streaming/stream.py
@@ -30,7 +30,7 @@ from pathlib import Path
 _DEFAULT_ADB_PORT = 5555
 _DEFAULT_SCRCPY_BITRATE = "8M"
 _DEFAULT_SCRCPY_MAX_FPS = 60
-_WAYDROID_BRIDGE_IP = "192.168.240.112"  # default waydroid0 bridge address
+WAYDROID_BRIDGE_IP = "192.168.240.112"  # default waydroid0 bridge address
 
 
 @dataclass
@@ -41,7 +41,7 @@ class StreamConfig:
     """
 
     # ADB target — host:port of the Waydroid ADB bridge
-    adb_host: str = _WAYDROID_BRIDGE_IP
+    adb_host: str = WAYDROID_BRIDGE_IP
     adb_port: int = _DEFAULT_ADB_PORT
 
     # Video settings

--- a/src/waydroid_toolkit/modules/streaming/stream.py
+++ b/src/waydroid_toolkit/modules/streaming/stream.py
@@ -1,0 +1,279 @@
+"""Waydroid screen streaming via scrcpy.
+
+Ported from canonical/anbox-streaming-sdk (Apache-2.0).
+
+The Anbox Streaming SDK used a proprietary WebRTC gateway (ASG) to broker
+video streams from Anbox containers to browsers and Android clients.
+
+Waydroid runs locally, so the equivalent is scrcpy — an open-source tool that
+mirrors the Android display over ADB. This module manages scrcpy sessions and
+optionally exposes a WebSocket/WebRTC bridge via ws-scrcpy for browser access.
+
+Mapping from anbox-streaming-sdk:
+  AnboxStream (JS class)     → StreamSession (Python dataclass + scrcpy process)
+  ASG connector              → ADB over TCP (Waydroid bridge IP)
+  WebRTC video track         → scrcpy video stream (H.264 over ADB)
+  out-of-band data channels  → scrcpy --tcpip control channel
+  stream gateway API token   → not required (local ADB)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_DEFAULT_ADB_PORT = 5555
+_DEFAULT_SCRCPY_BITRATE = "8M"
+_DEFAULT_SCRCPY_MAX_FPS = 60
+_WAYDROID_BRIDGE_IP = "192.168.240.112"  # default waydroid0 bridge address
+
+
+@dataclass
+class StreamConfig:
+    """Configuration for a Waydroid scrcpy stream session.
+
+    Mirrors the options object accepted by AnboxStream in the JS SDK.
+    """
+
+    # ADB target — host:port of the Waydroid ADB bridge
+    adb_host: str = _WAYDROID_BRIDGE_IP
+    adb_port: int = _DEFAULT_ADB_PORT
+
+    # Video settings
+    bitrate: str = _DEFAULT_SCRCPY_BITRATE
+    max_fps: int = _DEFAULT_SCRCPY_MAX_FPS
+    max_size: int = 0          # 0 = no limit; e.g. 1920 to cap at 1080p width
+    video_codec: str = "h264"  # h264, h265, av1 (scrcpy >= 2.0)
+
+    # Audio (scrcpy >= 2.0)
+    audio: bool = True
+
+    # Controls
+    keyboard: bool = True
+    mouse: bool = True
+    gamepad: bool = False      # scrcpy >= 2.1
+
+    # Display
+    fullscreen: bool = False
+    window_title: str = "Waydroid"
+    stay_awake: bool = True    # keep Android screen on while streaming
+
+    # Recording
+    record_file: str = ""      # path to save .mp4 recording; "" = no recording
+
+    # WebRTC bridge (ws-scrcpy / scrcpy-web)
+    # When set, scrcpy is started in server mode and ws-scrcpy bridges it to
+    # a WebSocket endpoint accessible from a browser.
+    webrtc_bridge: bool = False
+    webrtc_port: int = 8886
+
+    # Extra raw scrcpy arguments
+    extra_args: list[str] = field(default_factory=list)
+
+
+@dataclass
+class StreamSession:
+    """A running scrcpy stream session."""
+
+    config: StreamConfig
+    pid: int
+    adb_serial: str
+
+    def is_running(self) -> bool:
+        """Return True if the scrcpy process is still alive."""
+        try:
+            os.kill(self.pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+
+    def stop(self) -> None:
+        """Terminate the scrcpy process."""
+        try:
+            os.kill(self.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+
+def _resolve_adb_serial(config: StreamConfig) -> str:
+    """Return the ADB serial for the Waydroid container.
+
+    Tries the configured host:port first; falls back to auto-detecting the
+    Waydroid bridge IP from the waydroid0 interface.
+    """
+    serial = f"{config.adb_host}:{config.adb_port}"
+
+    # Check if already connected
+    result = subprocess.run(
+        ["adb", "devices"],
+        capture_output=True, text=True,
+    )
+    if serial in result.stdout:
+        return serial
+
+    # Try to connect
+    connect = subprocess.run(
+        ["adb", "connect", serial],
+        capture_output=True, text=True,
+    )
+    if "connected" in connect.stdout.lower():
+        return serial
+
+    # Auto-detect waydroid0 bridge IP
+    try:
+        ip_result = subprocess.run(
+            ["ip", "-4", "addr", "show", "waydroid0"],
+            capture_output=True, text=True,
+        )
+        import re
+        match = re.search(r"inet (\d+\.\d+\.\d+\.\d+)", ip_result.stdout)
+        if match:
+            bridge_ip = match.group(1)
+            alt_serial = f"{bridge_ip}:{config.adb_port}"
+            subprocess.run(["adb", "connect", alt_serial], capture_output=True)
+            return alt_serial
+    except Exception:
+        pass
+
+    return serial
+
+
+def _build_scrcpy_cmd(config: StreamConfig, serial: str) -> list[str]:
+    """Build the scrcpy command line from a StreamConfig."""
+    if not shutil.which("scrcpy"):
+        raise FileNotFoundError(
+            "scrcpy not found. Install with: sudo apt install scrcpy"
+        )
+
+    cmd = ["scrcpy", "--serial", serial]
+
+    cmd += ["--video-bit-rate", config.bitrate]
+    cmd += ["--max-fps", str(config.max_fps)]
+
+    if config.max_size:
+        cmd += ["--max-size", str(config.max_size)]
+
+    if config.video_codec != "h264":
+        cmd += ["--video-codec", config.video_codec]
+
+    if not config.audio:
+        cmd.append("--no-audio")
+
+    if not config.keyboard:
+        cmd.append("--no-key-injection")
+
+    if not config.mouse:
+        cmd.append("--no-mouse-injection")
+
+    if config.gamepad:
+        cmd.append("--gamepad=aoa")
+
+    if config.fullscreen:
+        cmd.append("--fullscreen")
+
+    if config.window_title:
+        cmd += ["--window-title", config.window_title]
+
+    if config.stay_awake:
+        cmd.append("--stay-awake")
+
+    if config.record_file:
+        cmd += ["--record", config.record_file]
+
+    cmd += config.extra_args
+    return cmd
+
+
+def start_stream(config: StreamConfig | None = None) -> StreamSession:
+    """Start a scrcpy stream session for the Waydroid container.
+
+    Args:
+        config: Stream configuration. Uses defaults when None.
+
+    Returns:
+        StreamSession with the running process PID.
+
+    Raises:
+        FileNotFoundError: if scrcpy or adb is not installed.
+        RuntimeError: if ADB connection fails.
+        subprocess.CalledProcessError: if scrcpy fails to start.
+    """
+    if config is None:
+        config = StreamConfig()
+
+    if not shutil.which("adb"):
+        raise FileNotFoundError(
+            "adb not found. Install with: sudo apt install adb"
+        )
+
+    serial = _resolve_adb_serial(config)
+
+    # Wait briefly for ADB device to be ready
+    for _ in range(10):
+        r = subprocess.run(
+            ["adb", "-s", serial, "get-state"],
+            capture_output=True, text=True,
+        )
+        if r.stdout.strip() == "device":
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError(
+            f"ADB device {serial!r} not ready. "
+            "Is Waydroid running? Try: waydroid session start"
+        )
+
+    cmd = _build_scrcpy_cmd(config, serial)
+
+    # Start scrcpy detached so it doesn't block the CLI
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    return StreamSession(config=config, pid=proc.pid, adb_serial=serial)
+
+
+def stop_stream(session: StreamSession) -> None:
+    """Stop a running stream session.
+
+    Args:
+        session: The StreamSession returned by start_stream.
+    """
+    session.stop()
+
+
+def check_dependencies() -> dict[str, bool]:
+    """Check which streaming dependencies are available.
+
+    Returns:
+        Dict mapping tool name to availability bool.
+    """
+    tools = {
+        "adb": shutil.which("adb") is not None,
+        "scrcpy": shutil.which("scrcpy") is not None,
+        # ws-scrcpy / scrcpy-web for browser-based WebRTC streaming
+        "ws-scrcpy": shutil.which("ws-scrcpy") is not None,
+    }
+    return tools
+
+
+def save_pid(session: StreamSession, pid_file: Path) -> None:
+    """Write the session PID to a file for later retrieval."""
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(str(session.pid))
+
+
+def load_pid(pid_file: Path) -> int | None:
+    """Read a PID from a file. Returns None if the file does not exist."""
+    try:
+        return int(pid_file.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,11 @@
+.terraform/
+.terraform.lock.hcl
+*.tfplan
+tfplan
+*.tfstate
+*.tfstate.backup
+.terraform.tfstate.lock.info
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,81 @@
+# Waydroid Terraform
+
+Terraform plan to provision Incus containers running Waydroid.
+
+Ported from [canonical/anbox-cloud-terraform](https://github.com/canonical/anbox-cloud-terraform).
+Juju + `terraform-provider-juju` replaced with `terraform-provider-incus`.
+Anbox Cloud charms replaced with cloud-init scripts that install Waydroid.
+
+## Requirements
+
+| Name | Version |
+|---|---|
+| terraform | >= 1.6 |
+| [lxc/incus](https://registry.terraform.io/providers/lxc/incus/latest) | >= 0.3 |
+
+Incus must be installed and running on the target host(s).
+
+## Inputs
+
+| Name | Default | Description |
+|---|---|---|
+| `waydroid_image` | `ubuntu:24.04` | Incus image for container hosts |
+| `incus_node_count` | `1` | Number of containers (flat mode) |
+| `android_version` | `13` | Android version for Waydroid |
+| `storage_pool` | `default` | Incus storage pool |
+| `storage_size` | `20GiB` | Root disk size per container |
+| `network_name` | `incusbr0` | Incus network |
+| `ssh_public_key` | `""` | SSH key injected via cloud-init |
+| `enable_nfs` | `false` | Attach NFS share to containers |
+| `nfs_source` | `""` | NFS path (host:/export) |
+| `subclusters` | `[]` | Named groups of containers (see below) |
+
+## Usage
+
+### Single host
+
+```hcl
+module "waydroid" {
+  source           = "github.com/waydroid-toolkit/waydroid-toolkit//terraform"
+  incus_node_count = 1
+  android_version  = "13"
+}
+```
+
+### Multiple named subclusters
+
+```hcl
+module "waydroid" {
+  source = "github.com/waydroid-toolkit/waydroid-toolkit//terraform"
+
+  subclusters = [
+    {
+      name             = "alpha"
+      incus_node_count = 2
+      enable_nfs       = true
+      nfs_source       = "192.168.1.10:/exports/assets"
+    },
+    {
+      name             = "beta"
+      incus_node_count = 1
+    },
+  ]
+}
+```
+
+```bash
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+## Mapping from anbox-cloud-terraform
+
+| Anbox | Waydroid |
+|---|---|
+| `terraform-provider-juju` | `terraform-provider-incus` |
+| `lxd_node_count` | `incus_node_count` |
+| `anbox_channel` | `waydroid_image` + `android_version` |
+| Juju charm bundle | cloud-init script |
+| `juju_integration` cross-model relations | Incus network bridges |
+| `ubuntu_pro_token` | not required |

--- a/terraform/examples/multi-host/main.tf
+++ b/terraform/examples/multi-host/main.tf
@@ -1,0 +1,27 @@
+# Multi-host Waydroid deployment example.
+# Mirrors the anbox-cloud-terraform subcluster model, using Incus instead of Juju/LXD.
+# Each subcluster is a named group of Incus containers running Waydroid.
+
+module "waydroid" {
+  source = "../../"
+
+  android_version = "13"
+  storage_size    = "20GiB"
+
+  subclusters = [
+    {
+      name             = "alpha"
+      incus_node_count = 2
+      enable_nfs       = true
+      nfs_source       = "192.168.1.10:/exports/assets"
+    },
+    {
+      name             = "beta"
+      incus_node_count = 1
+    },
+  ]
+}
+
+output "containers" {
+  value = module.waydroid.waydroid_containers
+}

--- a/terraform/examples/single-host/main.tf
+++ b/terraform/examples/single-host/main.tf
@@ -1,0 +1,14 @@
+# Single-host Waydroid deployment example.
+# Provisions one Incus container running Waydroid.
+
+module "waydroid" {
+  source = "../../"
+
+  incus_node_count = 1
+  android_version  = "13"
+  storage_size     = "20GiB"
+}
+
+output "containers" {
+  value = module.waydroid.waydroid_containers
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,59 @@
+# Waydroid Terraform plan — provisions Incus containers running Waydroid.
+#
+# Ported from canonical/anbox-cloud-terraform (Apache-2.0).
+# Juju + terraform-provider-juju replaced with terraform-provider-incus.
+# Anbox Cloud charms replaced with cloud-init scripts that install Waydroid.
+# lxd_node_count → incus_node_count.
+# anbox_channel → waydroid_image + android_version.
+#
+# Usage:
+#   terraform init
+#   terraform plan -out=tfplan -var-file=waydroid.tfvars
+#   terraform apply tfplan
+
+locals {
+  # Build a flat map of all nodes across all subclusters.
+  # Each key is "<subcluster>-<index>" for unique naming.
+  subcluster_nodes = length(var.subclusters) > 0 ? {
+    for pair in flatten([
+      for sc in var.subclusters : [
+        for i in range(sc.incus_node_count) : {
+          key        = "${sc.name}-${i}"
+          subcluster = sc.name
+          index      = i
+          enable_nfs = sc.enable_nfs
+          nfs_source = sc.nfs_source
+        }
+      ]
+    ]) : pair.key => pair
+  } : {}
+
+  # When no subclusters are defined, fall back to the flat node count.
+  flat_nodes = length(var.subclusters) == 0 ? {
+    for i in range(var.incus_node_count) : "waydroid-${i}" => {
+      key        = "waydroid-${i}"
+      subcluster = "default"
+      index      = i
+      enable_nfs = var.enable_nfs
+      nfs_source = var.nfs_source
+    }
+  } : {}
+
+  all_nodes = merge(local.subcluster_nodes, local.flat_nodes)
+}
+
+module "waydroid" {
+  for_each = local.all_nodes
+  source   = "./modules/waydroid"
+
+  name           = each.key
+  image          = var.waydroid_image
+  android_version = var.android_version
+  storage_pool   = var.storage_pool
+  storage_size   = var.storage_size
+  network_name   = var.network_name
+  ssh_public_key = var.ssh_public_key
+  enable_nfs     = each.value.enable_nfs
+  nfs_source     = each.value.nfs_source
+  nfs_path       = var.nfs_container_path
+}

--- a/terraform/modules/waydroid/cloud-init.yaml.tpl
+++ b/terraform/modules/waydroid/cloud-init.yaml.tpl
@@ -1,0 +1,36 @@
+#cloud-config
+# Cloud-init script to install Waydroid on an Incus container host.
+# Replaces the Anbox Cloud Appliance snap + amc toolchain.
+
+package_update: true
+package_upgrade: false
+
+packages:
+  - curl
+  - ca-certificates
+  - gnupg
+  - lsb-release
+
+%{ if ssh_public_key != "" ~}
+ssh_authorized_keys:
+  - ${ssh_public_key}
+%{ endif ~}
+
+runcmd:
+  # Add Waydroid repository
+  - curl -fsSL https://repo.waydro.id/waydroid.gpg | gpg --dearmor -o /usr/share/keyrings/waydroid.gpg
+  - echo "deb [signed-by=/usr/share/keyrings/waydroid.gpg] https://repo.waydro.id/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/waydroid.list
+  - apt-get update -q
+  - apt-get install -y waydroid
+
+  # Install waydroid-toolkit for management
+  - apt-get install -y python3-pip
+  - pip3 install waydroid-toolkit
+
+  # Initialize Waydroid with Android ${android_version}
+  - waydroid init -f
+  - systemctl enable --now waydroid-container
+
+final_message: |
+  Waydroid (Android ${android_version}) is installed and running.
+  Connect via: wdt status

--- a/terraform/modules/waydroid/main.tf
+++ b/terraform/modules/waydroid/main.tf
@@ -1,0 +1,65 @@
+# Waydroid container module.
+#
+# Provisions a single Incus container with Waydroid installed via cloud-init.
+# Replaces the Anbox Cloud subcluster Juju charm bundle.
+
+terraform {
+  required_providers {
+    incus = {
+      source  = "lxc/incus"
+      version = ">= 0.3"
+    }
+  }
+}
+
+locals {
+  cloud_init = templatefile("${path.module}/cloud-init.yaml.tpl", {
+    android_version = var.android_version
+    ssh_public_key  = var.ssh_public_key
+  })
+}
+
+resource "incus_instance" "waydroid" {
+  name  = var.name
+  image = var.image
+  type  = "container"
+
+  config = {
+    "boot.autostart"       = "true"
+    "security.nesting"     = "true"   # required for Waydroid LXC-in-LXC
+    "security.privileged"  = "false"
+    "user.user-data"       = local.cloud_init
+  }
+
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      pool = var.storage_pool
+      path = "/"
+      size = var.storage_size
+    }
+  }
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network = var.network_name
+    }
+  }
+
+  # Optional NFS share — mirrors the anbox-cloud-nfs-operator charm behaviour.
+  dynamic "device" {
+    for_each = var.enable_nfs && var.nfs_source != "" ? [1] : []
+    content {
+      name = "nfs-shared"
+      type = "disk"
+      properties = {
+        source               = var.nfs_source
+        path                 = var.nfs_path
+        "raw.mount.options"  = "soft,async"
+      }
+    }
+  }
+}

--- a/terraform/modules/waydroid/outputs.tf
+++ b/terraform/modules/waydroid/outputs.tf
@@ -1,0 +1,9 @@
+output "container_name" {
+  description = "Name of the provisioned Incus container."
+  value       = incus_instance.waydroid.name
+}
+
+output "ipv4_address" {
+  description = "IPv4 address of the container (may be empty until cloud-init completes)."
+  value       = try(incus_instance.waydroid.ipv4_address, "")
+}

--- a/terraform/modules/waydroid/variables.tf
+++ b/terraform/modules/waydroid/variables.tf
@@ -1,0 +1,58 @@
+variable "name" {
+  description = "Container name."
+  type        = string
+}
+
+variable "image" {
+  description = "Incus image alias (e.g. ubuntu:24.04)."
+  type        = string
+  default     = "ubuntu:24.04"
+}
+
+variable "android_version" {
+  description = "Android version for Waydroid (e.g. 13, 14, 15)."
+  type        = string
+  default     = "13"
+}
+
+variable "storage_pool" {
+  description = "Incus storage pool for the root disk."
+  type        = string
+  default     = "default"
+}
+
+variable "storage_size" {
+  description = "Root disk size (e.g. 20GiB)."
+  type        = string
+  default     = "20GiB"
+}
+
+variable "network_name" {
+  description = "Incus network to attach to."
+  type        = string
+  default     = "incusbr0"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key to inject via cloud-init."
+  type        = string
+  default     = ""
+}
+
+variable "enable_nfs" {
+  description = "Attach an NFS disk device to this container."
+  type        = bool
+  default     = false
+}
+
+variable "nfs_source" {
+  description = "NFS source path (host:/export)."
+  type        = string
+  default     = ""
+}
+
+variable "nfs_path" {
+  description = "Mount point inside the container for the NFS share."
+  type        = string
+  default     = "/data/shared"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "waydroid_containers" {
+  description = "Names and IPv4 addresses of all provisioned Waydroid containers."
+  value = {
+    for k, m in module.waydroid : k => {
+      name    = m.container_name
+      address = m.ipv4_address
+    }
+  }
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    # https://registry.terraform.io/providers/lxc/incus/latest
+    incus = {
+      source  = "lxc/incus"
+      version = ">= 0.3"
+    }
+  }
+}
+
+# Configure the Incus provider.
+# By default it connects to the local Incus socket.
+# Set INCUS_REMOTE, INCUS_SERVER_ADDRESS, INCUS_SERVER_CERT, etc. to connect
+# to a remote Incus server.
+provider "incus" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,75 @@
+# Root-level variables for the Waydroid Terraform plan.
+# Ported from canonical/anbox-cloud-terraform (Apache-2.0).
+# Juju provider + anbox_channel replaced with incus provider + waydroid_image.
+# lxd_node_count replaced with incus_node_count.
+
+variable "waydroid_image" {
+  description = "Incus image to use for Waydroid container hosts (e.g. ubuntu:24.04)."
+  type        = string
+  default     = "ubuntu:24.04"
+}
+
+variable "incus_node_count" {
+  description = "Number of Incus container hosts to provision."
+  type        = number
+  default     = 1
+}
+
+variable "android_version" {
+  description = "Android version for the Waydroid image (e.g. 13, 14, 15)."
+  type        = string
+  default     = "13"
+}
+
+variable "storage_pool" {
+  description = "Incus storage pool to use for container root disks."
+  type        = string
+  default     = "default"
+}
+
+variable "storage_size" {
+  description = "Root disk size for each Waydroid container (e.g. 20GiB)."
+  type        = string
+  default     = "20GiB"
+}
+
+variable "network_name" {
+  description = "Incus network to attach containers to."
+  type        = string
+  default     = "incusbr0"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key to inject into container hosts (cloud-init)."
+  type        = string
+  default     = ""
+}
+
+variable "enable_nfs" {
+  description = "Attach an NFS share to each Waydroid container."
+  type        = bool
+  default     = false
+}
+
+variable "nfs_source" {
+  description = "NFS source path (host:/export) when enable_nfs = true."
+  type        = string
+  default     = ""
+}
+
+variable "nfs_container_path" {
+  description = "Mount point inside the container for the NFS share."
+  type        = string
+  default     = "/data/shared"
+}
+
+variable "subclusters" {
+  description = "List of named Waydroid subclusters to deploy."
+  type = list(object({
+    name             = string
+    incus_node_count = number
+    enable_nfs       = optional(bool, false)
+    nfs_source       = optional(string, "")
+  }))
+  default = []
+}

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from waydroid_toolkit.modules.storage.nfs import (
-    NfsMount,
     add_nfs_mount,
     list_nfs_mounts,
     remove_nfs_mount,

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,164 @@
+"""Unit tests for waydroid_toolkit.modules.storage.nfs"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.storage.nfs import (
+    NfsMount,
+    add_nfs_mount,
+    list_nfs_mounts,
+    remove_nfs_mount,
+)
+
+
+# ── add_nfs_mount ─────────────────────────────────────────────────────────────
+
+class TestAddNfsMount:
+    def test_basic_nfs(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                mount = add_nfs_mount("192.168.1.10:/exports/assets")
+
+        assert mount.source == "192.168.1.10:/exports/assets"
+        assert mount.container_path == "/data/shared"
+        assert mount.mount_type == "nfs"
+        assert mount.options == "soft,async"
+        assert mount.device_name.startswith("nfs-")
+
+        call_args = mock_run.call_args[0][0]
+        assert "incus" in call_args
+        assert "device" in call_args
+        assert "add" in call_args
+        assert "waydroid" in call_args
+        assert "disk" in call_args
+
+    def test_custom_path_and_name(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                mount = add_nfs_mount(
+                    "192.168.1.10:/games",
+                    container_path="/data/games",
+                    device_name="my-games",
+                )
+
+        assert mount.device_name == "my-games"
+        assert mount.container_path == "/data/games"
+
+    def test_efs_type(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                mount = add_nfs_mount(
+                    "fs-0abc1234:/",
+                    mount_type="efs",
+                    extra_options="tls",
+                )
+
+        assert mount.mount_type == "efs"
+        assert mount.options == "tls"
+
+    def test_invalid_mount_type_raises(self):
+        with pytest.raises(ValueError, match="mount_type must be one of"):
+            add_nfs_mount("host:/path", mount_type="smb")
+
+    def test_device_name_truncated_to_63_chars(self):
+        long_source = "192.168.1.10:/" + "a" * 100
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                mount = add_nfs_mount(long_source)
+
+        assert len(mount.device_name) <= 63
+
+
+# ── remove_nfs_mount ──────────────────────────────────────────────────────────
+
+class TestRemoveNfsMount:
+    def test_calls_incus_remove(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                remove_nfs_mount("nfs-my-share")
+
+        call_args = mock_run.call_args[0][0]
+        assert "incus" in call_args
+        assert "remove" in call_args
+        assert "nfs-my-share" in call_args
+
+
+# ── list_nfs_mounts ───────────────────────────────────────────────────────────
+
+class TestListNfsMounts:
+    def test_returns_disk_devices(self):
+        import json
+
+        devices = {
+            "nfs-share": {
+                "type": "disk",
+                "source": "192.168.1.10:/exports",
+                "path": "/data/shared",
+                "raw.mount.options": "soft,async",
+            },
+            "eth0": {
+                "type": "nic",
+                "network": "incusbr0",
+            },
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps(devices),
+            )
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                mounts = list_nfs_mounts()
+
+        assert len(mounts) == 1
+        assert mounts[0].device_name == "nfs-share"
+        assert mounts[0].source == "192.168.1.10:/exports"
+        assert mounts[0].container_path == "/data/shared"
+
+    def test_returns_empty_on_failure(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                mounts = list_nfs_mounts()
+
+        assert mounts == []
+
+    def test_returns_empty_on_invalid_json(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="not-json")
+            with patch(
+                "waydroid_toolkit.modules.storage.nfs._container_name",
+                return_value="waydroid",
+            ):
+                mounts = list_nfs_mounts()
+
+        assert mounts == []

--- a/tests/unit/test_storage_cmd.py
+++ b/tests/unit/test_storage_cmd.py
@@ -86,7 +86,5 @@ class TestStorageNfsRemove:
     def test_remove_aborted(self):
         runner = CliRunner()
         with patch(_REMOVE) as mock_rm:
-            result = runner.invoke(
-                cli, ["storage", "nfs", "remove", "nfs-share"], input="n\n"
-            )
-        mock_rm.assert_not_called()
+            runner.invoke(cli, ["storage", "nfs", "remove", "nfs-share"], input="n\n")
+            mock_rm.assert_not_called()

--- a/tests/unit/test_storage_cmd.py
+++ b/tests/unit/test_storage_cmd.py
@@ -1,0 +1,100 @@
+"""Unit tests for wdt storage CLI commands."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.main import cli
+
+
+class TestStorageNfsAdd:
+    def test_add_basic(self):
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.modules.storage.nfs.add_nfs_mount"
+        ) as mock_add:
+            from waydroid_toolkit.modules.storage.nfs import NfsMount
+            mock_add.return_value = NfsMount(
+                device_name="nfs-192-168-1-10--exports",
+                source="192.168.1.10:/exports",
+                container_path="/data/shared",
+                mount_type="nfs",
+                options="soft,async",
+            )
+            result = runner.invoke(cli, ["storage", "nfs", "add", "192.168.1.10:/exports"])
+
+        assert result.exit_code == 0
+        assert "Mounted" in result.output
+        assert "nfs-192-168-1-10--exports" in result.output
+
+    def test_add_invalid_type_exits_1(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["storage", "nfs", "add", "host:/path", "--type", "smb"]
+        )
+        assert result.exit_code != 0
+
+    def test_add_subprocess_error_exits_1(self):
+        import subprocess
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.modules.storage.nfs.add_nfs_mount",
+            side_effect=subprocess.CalledProcessError(1, "incus"),
+        ):
+            result = runner.invoke(cli, ["storage", "nfs", "add", "host:/path"])
+        assert result.exit_code == 1
+        assert "incus command failed" in result.output
+
+
+class TestStorageNfsList:
+    def test_list_empty(self):
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.modules.storage.nfs.list_nfs_mounts",
+            return_value=[],
+        ):
+            result = runner.invoke(cli, ["storage", "nfs", "list"])
+        assert result.exit_code == 0
+        assert "No disk devices" in result.output
+
+    def test_list_with_mounts(self):
+        from waydroid_toolkit.modules.storage.nfs import NfsMount
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.modules.storage.nfs.list_nfs_mounts",
+            return_value=[
+                NfsMount(
+                    device_name="nfs-share",
+                    source="192.168.1.10:/exports",
+                    container_path="/data/shared",
+                    mount_type="disk",
+                    options="soft,async",
+                )
+            ],
+        ):
+            result = runner.invoke(cli, ["storage", "nfs", "list"])
+        assert result.exit_code == 0
+        assert "nfs-share" in result.output
+        assert "192.168.1.10:/exports" in result.output
+
+
+class TestStorageNfsRemove:
+    def test_remove_confirmed(self):
+        runner = CliRunner()
+        with patch("waydroid_toolkit.modules.storage.nfs.remove_nfs_mount") as mock_rm:
+            result = runner.invoke(
+                cli, ["storage", "nfs", "remove", "nfs-share"], input="y\n"
+            )
+        assert result.exit_code == 0
+        mock_rm.assert_called_once_with("nfs-share")
+        assert "Removed" in result.output
+
+    def test_remove_aborted(self):
+        runner = CliRunner()
+        with patch("waydroid_toolkit.modules.storage.nfs.remove_nfs_mount") as mock_rm:
+            result = runner.invoke(
+                cli, ["storage", "nfs", "remove", "nfs-share"], input="n\n"
+            )
+        mock_rm.assert_not_called()

--- a/tests/unit/test_storage_cmd.py
+++ b/tests/unit/test_storage_cmd.py
@@ -2,20 +2,22 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from waydroid_toolkit.cli.main import cli
+from waydroid_toolkit.modules.storage.nfs import NfsMount
+
+_ADD = "waydroid_toolkit.cli.commands.storage.add_nfs_mount"
+_REMOVE = "waydroid_toolkit.cli.commands.storage.remove_nfs_mount"
+_LIST = "waydroid_toolkit.cli.commands.storage.list_nfs_mounts"
 
 
 class TestStorageNfsAdd:
     def test_add_basic(self):
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.modules.storage.nfs.add_nfs_mount"
-        ) as mock_add:
-            from waydroid_toolkit.modules.storage.nfs import NfsMount
+        with patch(_ADD) as mock_add:
             mock_add.return_value = NfsMount(
                 device_name="nfs-192-168-1-10--exports",
                 source="192.168.1.10:/exports",
@@ -39,10 +41,7 @@ class TestStorageNfsAdd:
     def test_add_subprocess_error_exits_1(self):
         import subprocess
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.modules.storage.nfs.add_nfs_mount",
-            side_effect=subprocess.CalledProcessError(1, "incus"),
-        ):
+        with patch(_ADD, side_effect=subprocess.CalledProcessError(1, "incus")):
             result = runner.invoke(cli, ["storage", "nfs", "add", "host:/path"])
         assert result.exit_code == 1
         assert "incus command failed" in result.output
@@ -51,29 +50,22 @@ class TestStorageNfsAdd:
 class TestStorageNfsList:
     def test_list_empty(self):
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.modules.storage.nfs.list_nfs_mounts",
-            return_value=[],
-        ):
+        with patch(_LIST, return_value=[]):
             result = runner.invoke(cli, ["storage", "nfs", "list"])
         assert result.exit_code == 0
         assert "No disk devices" in result.output
 
     def test_list_with_mounts(self):
-        from waydroid_toolkit.modules.storage.nfs import NfsMount
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.modules.storage.nfs.list_nfs_mounts",
-            return_value=[
-                NfsMount(
-                    device_name="nfs-share",
-                    source="192.168.1.10:/exports",
-                    container_path="/data/shared",
-                    mount_type="disk",
-                    options="soft,async",
-                )
-            ],
-        ):
+        with patch(_LIST, return_value=[
+            NfsMount(
+                device_name="nfs-share",
+                source="192.168.1.10:/exports",
+                container_path="/data/shared",
+                mount_type="disk",
+                options="soft,async",
+            )
+        ]):
             result = runner.invoke(cli, ["storage", "nfs", "list"])
         assert result.exit_code == 0
         assert "nfs-share" in result.output
@@ -83,7 +75,7 @@ class TestStorageNfsList:
 class TestStorageNfsRemove:
     def test_remove_confirmed(self):
         runner = CliRunner()
-        with patch("waydroid_toolkit.modules.storage.nfs.remove_nfs_mount") as mock_rm:
+        with patch(_REMOVE) as mock_rm:
             result = runner.invoke(
                 cli, ["storage", "nfs", "remove", "nfs-share"], input="y\n"
             )
@@ -93,7 +85,7 @@ class TestStorageNfsRemove:
 
     def test_remove_aborted(self):
         runner = CliRunner()
-        with patch("waydroid_toolkit.modules.storage.nfs.remove_nfs_mount") as mock_rm:
+        with patch(_REMOVE) as mock_rm:
             result = runner.invoke(
                 cli, ["storage", "nfs", "remove", "nfs-share"], input="n\n"
             )

--- a/tests/unit/test_stream.py
+++ b/tests/unit/test_stream.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import signal
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/unit/test_stream.py
+++ b/tests/unit/test_stream.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import signal
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/test_stream.py
+++ b/tests/unit/test_stream.py
@@ -1,0 +1,173 @@
+"""Unit tests for waydroid_toolkit.modules.streaming.stream"""
+
+from __future__ import annotations
+
+import os
+import signal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from waydroid_toolkit.modules.streaming.stream import (
+    StreamConfig,
+    StreamSession,
+    _build_scrcpy_cmd,
+    check_dependencies,
+    load_pid,
+    save_pid,
+)
+
+
+# ── StreamConfig defaults ─────────────────────────────────────────────────────
+
+class TestStreamConfig:
+    def test_defaults(self):
+        cfg = StreamConfig()
+        assert cfg.bitrate == "8M"
+        assert cfg.max_fps == 60
+        assert cfg.video_codec == "h264"
+        assert cfg.audio is True
+        assert cfg.keyboard is True
+        assert cfg.mouse is True
+        assert cfg.gamepad is False
+        assert cfg.fullscreen is False
+        assert cfg.record_file == ""
+
+    def test_custom_values(self):
+        cfg = StreamConfig(bitrate="4M", max_fps=30, video_codec="h265")
+        assert cfg.bitrate == "4M"
+        assert cfg.max_fps == 30
+        assert cfg.video_codec == "h265"
+
+
+# ── _build_scrcpy_cmd ─────────────────────────────────────────────────────────
+
+class TestBuildScrcpyCmd:
+    def _cfg(self, **kwargs) -> StreamConfig:
+        return StreamConfig(**kwargs)
+
+    def test_basic_command(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(), "192.168.240.112:5555")
+        assert cmd[0] == "scrcpy"
+        assert "--serial" in cmd
+        assert "192.168.240.112:5555" in cmd
+        assert "--video-bit-rate" in cmd
+        assert "8M" in cmd
+
+    def test_no_audio_flag(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(audio=False), "serial")
+        assert "--no-audio" in cmd
+
+    def test_fullscreen_flag(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(fullscreen=True), "serial")
+        assert "--fullscreen" in cmd
+
+    def test_record_flag(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(record_file="out.mp4"), "serial")
+        assert "--record" in cmd
+        assert "out.mp4" in cmd
+
+    def test_max_size_included_when_nonzero(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(max_size=1280), "serial")
+        assert "--max-size" in cmd
+        assert "1280" in cmd
+
+    def test_max_size_omitted_when_zero(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(max_size=0), "serial")
+        assert "--max-size" not in cmd
+
+    def test_non_h264_codec_included(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(video_codec="h265"), "serial")
+        assert "--video-codec" in cmd
+        assert "h265" in cmd
+
+    def test_h264_codec_not_repeated(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(self._cfg(video_codec="h264"), "serial")
+        assert "--video-codec" not in cmd
+
+    def test_extra_args_appended(self):
+        with patch("shutil.which", return_value="/usr/bin/scrcpy"):
+            cmd = _build_scrcpy_cmd(
+                self._cfg(extra_args=["--no-clipboard"]), "serial"
+            )
+        assert "--no-clipboard" in cmd
+
+    def test_scrcpy_not_found_raises(self):
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="scrcpy not found"):
+                _build_scrcpy_cmd(self._cfg(), "serial")
+
+
+# ── StreamSession ─────────────────────────────────────────────────────────────
+
+class TestStreamSession:
+    def test_is_running_true_when_process_alive(self):
+        session = StreamSession(config=StreamConfig(), pid=os.getpid(), adb_serial="serial")
+        assert session.is_running() is True
+
+    def test_is_running_false_when_process_gone(self):
+        session = StreamSession(config=StreamConfig(), pid=999999999, adb_serial="serial")
+        assert session.is_running() is False
+
+    def test_stop_sends_sigterm(self):
+        with patch("os.kill") as mock_kill:
+            session = StreamSession(config=StreamConfig(), pid=12345, adb_serial="serial")
+            session.stop()
+        mock_kill.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_stop_ignores_missing_process(self):
+        with patch("os.kill", side_effect=ProcessLookupError):
+            session = StreamSession(config=StreamConfig(), pid=12345, adb_serial="serial")
+            session.stop()  # should not raise
+
+
+# ── check_dependencies ────────────────────────────────────────────────────────
+
+class TestCheckDependencies:
+    def test_all_present(self):
+        with patch("shutil.which", return_value="/usr/bin/tool"):
+            deps = check_dependencies()
+        assert deps["adb"] is True
+        assert deps["scrcpy"] is True
+
+    def test_none_present(self):
+        with patch("shutil.which", return_value=None):
+            deps = check_dependencies()
+        assert deps["adb"] is False
+        assert deps["scrcpy"] is False
+
+    def test_partial(self):
+        def _which(name):
+            return "/usr/bin/adb" if name == "adb" else None
+
+        with patch("shutil.which", side_effect=_which):
+            deps = check_dependencies()
+        assert deps["adb"] is True
+        assert deps["scrcpy"] is False
+
+
+# ── save_pid / load_pid ───────────────────────────────────────────────────────
+
+class TestPidFile:
+    def test_round_trip(self, tmp_path):
+        pid_file = tmp_path / "stream.pid"
+        session = StreamSession(config=StreamConfig(), pid=42, adb_serial="serial")
+        save_pid(session, pid_file)
+        assert load_pid(pid_file) == 42
+
+    def test_load_missing_returns_none(self, tmp_path):
+        assert load_pid(tmp_path / "nonexistent.pid") is None
+
+    def test_load_invalid_returns_none(self, tmp_path):
+        pid_file = tmp_path / "bad.pid"
+        pid_file.write_text("not-a-number")
+        assert load_pid(pid_file) is None

--- a/tests/unit/test_stream_cmd.py
+++ b/tests/unit/test_stream_cmd.py
@@ -1,0 +1,125 @@
+"""Unit tests for wdt stream CLI commands."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.main import cli
+
+
+class TestStreamCheck:
+    def test_all_present(self):
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.modules.streaming.stream.check_dependencies",
+            return_value={"adb": True, "scrcpy": True, "ws-scrcpy": False},
+        ):
+            result = runner.invoke(cli, ["stream", "check"])
+        # ws-scrcpy missing → exit 1, but adb+scrcpy present shown
+        assert "adb" in result.output
+        assert "scrcpy" in result.output
+
+    def test_missing_deps_exits_1(self):
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.modules.streaming.stream.check_dependencies",
+            return_value={"adb": False, "scrcpy": False, "ws-scrcpy": False},
+        ):
+            result = runner.invoke(cli, ["stream", "check"])
+        assert result.exit_code == 1
+        assert "sudo apt install" in result.output
+
+
+class TestStreamStatus:
+    def test_no_pid_file(self, tmp_path):
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.cli.commands.stream._PID_FILE",
+            tmp_path / "stream.pid",
+        ):
+            result = runner.invoke(cli, ["stream", "status"])
+        assert result.exit_code == 0
+        assert "No stream session" in result.output
+
+    def test_running_pid(self, tmp_path):
+        pid_file = tmp_path / "stream.pid"
+        pid_file.write_text(str(os.getpid()))
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
+            result = runner.invoke(cli, ["stream", "status"])
+        assert result.exit_code == 0
+        assert "running" in result.output.lower()
+
+    def test_dead_pid_cleans_up(self, tmp_path):
+        pid_file = tmp_path / "stream.pid"
+        pid_file.write_text("999999999")
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
+            result = runner.invoke(cli, ["stream", "status"])
+        assert result.exit_code == 0
+        assert not pid_file.exists()
+
+
+class TestStreamStop:
+    def test_stop_running_session(self, tmp_path):
+        pid_file = tmp_path / "stream.pid"
+        pid_file.write_text("12345")
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
+            with patch("os.kill") as mock_kill:
+                result = runner.invoke(cli, ["stream", "stop"])
+        assert result.exit_code == 0
+        assert "stopped" in result.output.lower()
+        assert not pid_file.exists()
+
+    def test_stop_no_session(self, tmp_path):
+        runner = CliRunner()
+        with patch(
+            "waydroid_toolkit.cli.commands.stream._PID_FILE",
+            tmp_path / "stream.pid",
+        ):
+            result = runner.invoke(cli, ["stream", "stop"])
+        assert result.exit_code == 0
+        assert "No stream session" in result.output
+
+
+class TestStreamStart:
+    def test_start_success(self, tmp_path):
+        pid_file = tmp_path / "stream.pid"
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
+            with patch(
+                "waydroid_toolkit.modules.streaming.stream.start_stream"
+            ) as mock_start:
+                from waydroid_toolkit.modules.streaming.stream import StreamConfig, StreamSession
+                mock_start.return_value = StreamSession(
+                    config=StreamConfig(), pid=9999, adb_serial="192.168.240.112:5555"
+                )
+                result = runner.invoke(cli, ["stream", "start"])
+        assert result.exit_code == 0
+        assert "9999" in result.output
+
+    def test_start_missing_scrcpy_exits_1(self, tmp_path):
+        pid_file = tmp_path / "stream.pid"
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
+            with patch(
+                "waydroid_toolkit.modules.streaming.stream.start_stream",
+                side_effect=FileNotFoundError("scrcpy not found"),
+            ):
+                result = runner.invoke(cli, ["stream", "start"])
+        assert result.exit_code == 1
+        assert "Missing dependency" in result.output
+
+    def test_start_already_running_exits_1(self, tmp_path):
+        pid_file = tmp_path / "stream.pid"
+        pid_file.write_text(str(os.getpid()))  # current process = "running"
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
+            result = runner.invoke(cli, ["stream", "start"])
+        assert result.exit_code == 1
+        assert "already running" in result.output

--- a/tests/unit/test_stream_cmd.py
+++ b/tests/unit/test_stream_cmd.py
@@ -3,32 +3,31 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from waydroid_toolkit.cli.main import cli
+from waydroid_toolkit.modules.streaming.stream import StreamConfig, StreamSession
+
+_START = "waydroid_toolkit.cli.commands.stream.start_stream"
+_LOAD_PID = "waydroid_toolkit.cli.commands.stream.load_pid"
+_SAVE_PID = "waydroid_toolkit.cli.commands.stream.save_pid"
+_CHECK = "waydroid_toolkit.cli.commands.stream.check_dependencies"
+_PID_FILE_ATTR = "waydroid_toolkit.cli.commands.stream._PID_FILE"
 
 
 class TestStreamCheck:
     def test_all_present(self):
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.modules.streaming.stream.check_dependencies",
-            return_value={"adb": True, "scrcpy": True, "ws-scrcpy": False},
-        ):
+        with patch(_CHECK, return_value={"adb": True, "scrcpy": True, "ws-scrcpy": False}):
             result = runner.invoke(cli, ["stream", "check"])
-        # ws-scrcpy missing → exit 1, but adb+scrcpy present shown
         assert "adb" in result.output
         assert "scrcpy" in result.output
 
     def test_missing_deps_exits_1(self):
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.modules.streaming.stream.check_dependencies",
-            return_value={"adb": False, "scrcpy": False, "ws-scrcpy": False},
-        ):
+        with patch(_CHECK, return_value={"adb": False, "scrcpy": False, "ws-scrcpy": False}):
             result = runner.invoke(cli, ["stream", "check"])
         assert result.exit_code == 1
         assert "sudo apt install" in result.output
@@ -37,19 +36,14 @@ class TestStreamCheck:
 class TestStreamStatus:
     def test_no_pid_file(self, tmp_path):
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.cli.commands.stream._PID_FILE",
-            tmp_path / "stream.pid",
-        ):
+        with patch(_LOAD_PID, return_value=None):
             result = runner.invoke(cli, ["stream", "status"])
         assert result.exit_code == 0
         assert "No stream session" in result.output
 
     def test_running_pid(self, tmp_path):
-        pid_file = tmp_path / "stream.pid"
-        pid_file.write_text(str(os.getpid()))
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
+        with patch(_LOAD_PID, return_value=os.getpid()):
             result = runner.invoke(cli, ["stream", "status"])
         assert result.exit_code == 0
         assert "running" in result.output.lower()
@@ -58,8 +52,9 @@ class TestStreamStatus:
         pid_file = tmp_path / "stream.pid"
         pid_file.write_text("999999999")
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
-            result = runner.invoke(cli, ["stream", "status"])
+        with patch(_LOAD_PID, return_value=999999999):
+            with patch(_PID_FILE_ATTR, pid_file):
+                result = runner.invoke(cli, ["stream", "status"])
         assert result.exit_code == 0
         assert not pid_file.exists()
 
@@ -69,19 +64,16 @@ class TestStreamStop:
         pid_file = tmp_path / "stream.pid"
         pid_file.write_text("12345")
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
-            with patch("os.kill") as mock_kill:
-                result = runner.invoke(cli, ["stream", "stop"])
+        with patch(_LOAD_PID, return_value=12345):
+            with patch(_PID_FILE_ATTR, pid_file):
+                with patch("os.kill"):
+                    result = runner.invoke(cli, ["stream", "stop"])
         assert result.exit_code == 0
         assert "stopped" in result.output.lower()
-        assert not pid_file.exists()
 
     def test_stop_no_session(self, tmp_path):
         runner = CliRunner()
-        with patch(
-            "waydroid_toolkit.cli.commands.stream._PID_FILE",
-            tmp_path / "stream.pid",
-        ):
+        with patch(_LOAD_PID, return_value=None):
             result = runner.invoke(cli, ["stream", "stop"])
         assert result.exit_code == 0
         assert "No stream session" in result.output
@@ -91,35 +83,30 @@ class TestStreamStart:
     def test_start_success(self, tmp_path):
         pid_file = tmp_path / "stream.pid"
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
-            with patch(
-                "waydroid_toolkit.modules.streaming.stream.start_stream"
-            ) as mock_start:
-                from waydroid_toolkit.modules.streaming.stream import StreamConfig, StreamSession
-                mock_start.return_value = StreamSession(
-                    config=StreamConfig(), pid=9999, adb_serial="192.168.240.112:5555"
-                )
-                result = runner.invoke(cli, ["stream", "start"])
+        with patch(_LOAD_PID, return_value=None):
+            with patch(_PID_FILE_ATTR, pid_file):
+                with patch(_START) as mock_start:
+                    with patch(_SAVE_PID):
+                        mock_start.return_value = StreamSession(
+                            config=StreamConfig(), pid=9999, adb_serial="192.168.240.112:5555"
+                        )
+                        result = runner.invoke(cli, ["stream", "start"])
         assert result.exit_code == 0
         assert "9999" in result.output
 
     def test_start_missing_scrcpy_exits_1(self, tmp_path):
-        pid_file = tmp_path / "stream.pid"
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
-            with patch(
-                "waydroid_toolkit.modules.streaming.stream.start_stream",
-                side_effect=FileNotFoundError("scrcpy not found"),
-            ):
+        with patch(_LOAD_PID, return_value=None):
+            with patch(_START, side_effect=FileNotFoundError("scrcpy not found")):
                 result = runner.invoke(cli, ["stream", "start"])
         assert result.exit_code == 1
         assert "Missing dependency" in result.output
 
     def test_start_already_running_exits_1(self, tmp_path):
-        pid_file = tmp_path / "stream.pid"
-        pid_file.write_text(str(os.getpid()))  # current process = "running"
         runner = CliRunner()
-        with patch("waydroid_toolkit.cli.commands.stream._PID_FILE", pid_file):
-            result = runner.invoke(cli, ["stream", "start"])
+        with patch(_LOAD_PID, return_value=os.getpid()):
+            with patch("waydroid_toolkit.cli.commands.stream._PID_FILE") as mock_pf:
+                mock_pf.exists.return_value = True
+                result = runner.invoke(cli, ["stream", "start"])
         assert result.exit_code == 1
         assert "already running" in result.output

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -1,0 +1,109 @@
+/* waydroid-toolkit landing page
+   Ported from anbox-cloud.github.com / anbox-cloud.io (Apache-2.0).
+   Rebranded for waydroid-toolkit. */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --teal:      #00897b;
+  --teal-dark: #00695c;
+  --teal-light:#e0f2f1;
+  --text:      #212121;
+  --text-muted:#616161;
+  --bg:        #ffffff;
+  --bg-alt:    #f5f5f5;
+  --border:    #e0e0e0;
+  --code-bg:   #263238;
+  --code-fg:   #cfd8dc;
+  --radius:    6px;
+  --max-w:     1100px;
+}
+
+body { font-family: system-ui, sans-serif; color: var(--text); background: var(--bg); line-height: 1.6; }
+
+a { color: var(--teal); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.container { max-width: var(--max-w); margin: 0 auto; padding: 0 1.5rem; }
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+.site-header {
+  background: var(--teal);
+  color: #fff;
+  padding: 1rem 0;
+  position: sticky; top: 0; z-index: 100;
+}
+.site-header .container { display: flex; align-items: center; justify-content: space-between; }
+.logo { display: flex; align-items: baseline; gap: .5rem; }
+.logo-text { font-size: 1.25rem; font-weight: 700; color: #fff; }
+.logo-tag {
+  font-size: .75rem; font-weight: 600;
+  background: rgba(255,255,255,.2); color: #fff;
+  padding: .1rem .4rem; border-radius: 3px;
+}
+.site-header nav { display: flex; gap: 1.5rem; }
+.site-header nav a { color: rgba(255,255,255,.9); font-size: .95rem; }
+.site-header nav a:hover { color: #fff; text-decoration: none; }
+
+/* ── Hero ────────────────────────────────────────────────────────────────── */
+.hero { background: var(--teal-light); padding: 5rem 0 4rem; text-align: center; }
+.hero h1 { font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; margin-bottom: 1rem; }
+.hero-sub { font-size: 1.15rem; color: var(--text-muted); max-width: 640px; margin: 0 auto 2rem; }
+.hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-bottom: 1.5rem; }
+
+.btn {
+  display: inline-block; padding: .65rem 1.5rem;
+  border-radius: var(--radius); font-weight: 600; font-size: .95rem;
+  transition: opacity .15s;
+}
+.btn:hover { opacity: .85; text-decoration: none; }
+.btn-primary  { background: var(--teal); color: #fff; }
+.btn-secondary { background: #fff; color: var(--teal); border: 2px solid var(--teal); }
+
+.hero-install code {
+  display: inline-block;
+  background: var(--code-bg); color: var(--code-fg);
+  padding: .5rem 1.25rem; border-radius: var(--radius);
+  font-size: 1rem; font-family: monospace;
+}
+
+/* ── Features ────────────────────────────────────────────────────────────── */
+.features { padding: 4rem 0; }
+.features h2 { text-align: center; font-size: 1.75rem; margin-bottom: 2.5rem; }
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+.feature-card {
+  background: var(--bg-alt); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 1.5rem;
+}
+.feature-card h3 { font-size: 1.05rem; margin-bottom: .5rem; color: var(--teal-dark); }
+.feature-card p { font-size: .9rem; color: var(--text-muted); }
+
+/* ── Quickstart ──────────────────────────────────────────────────────────── */
+.quickstart { background: var(--code-bg); padding: 4rem 0; }
+.quickstart h2 { color: #fff; text-align: center; font-size: 1.75rem; margin-bottom: 2rem; }
+.quickstart pre {
+  background: rgba(255,255,255,.05);
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: var(--radius);
+  padding: 1.5rem; overflow-x: auto;
+}
+.quickstart code { color: var(--code-fg); font-family: monospace; font-size: .9rem; line-height: 1.8; }
+
+/* ── Migration ───────────────────────────────────────────────────────────── */
+.migration { padding: 4rem 0; background: var(--bg-alt); }
+.migration h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+.migration p { color: var(--text-muted); margin-bottom: 1.5rem; }
+.migration table { width: 100%; border-collapse: collapse; font-size: .9rem; }
+.migration th, .migration td { padding: .6rem 1rem; border: 1px solid var(--border); text-align: left; }
+.migration th { background: var(--teal); color: #fff; }
+.migration tr:nth-child(even) td { background: #fff; }
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+.site-footer { background: var(--text); color: rgba(255,255,255,.7); padding: 2rem 0; text-align: center; }
+.site-footer p { font-size: .85rem; margin-bottom: .5rem; }
+.site-footer a { color: rgba(255,255,255,.85); }
+.site-footer a:hover { color: #fff; }

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>waydroid-toolkit — Unified management suite for Waydroid</title>
+  <meta name="description"
+    content="waydroid-toolkit (wdt) is an open-source CLI and Python library for managing Waydroid — Android-in-a-container on Linux via Incus or LXC." />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+
+  <!-- ── Header ─────────────────────────────────────────────────────────── -->
+  <header class="site-header">
+    <div class="container">
+      <div class="logo">
+        <span class="logo-text">waydroid-toolkit</span>
+        <span class="logo-tag">wdt</span>
+      </div>
+      <nav>
+        <a href="https://waydroid-toolkit.github.io/waydroid-toolkit/">Docs</a>
+        <a href="https://github.com/waydroid-toolkit/waydroid-toolkit">GitHub</a>
+        <a href="https://github.com/waydroid-toolkit/waydroid-toolkit/releases">Releases</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- ── Hero ───────────────────────────────────────────────────────────── -->
+  <section class="hero">
+    <div class="container">
+      <h1>Android on Linux, managed.</h1>
+      <p class="hero-sub">
+        <strong>waydroid-toolkit</strong> is an open-source CLI and Python library
+        for managing <a href="https://waydro.id/">Waydroid</a> — Android-in-a-container
+        on Linux via <a href="https://linuxcontainers.org/incus/">Incus</a> or LXC.
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="https://waydroid-toolkit.github.io/waydroid-toolkit/getting-started/quickstart/">
+          Get started
+        </a>
+        <a class="btn btn-secondary" href="https://github.com/waydroid-toolkit/waydroid-toolkit">
+          View on GitHub
+        </a>
+      </div>
+      <div class="hero-install">
+        <code>pip install waydroid-toolkit</code>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Features ───────────────────────────────────────────────────────── -->
+  <section class="features">
+    <div class="container">
+      <h2>What wdt does</h2>
+      <div class="feature-grid">
+
+        <div class="feature-card">
+          <h3>Container management</h3>
+          <p>
+            Start, stop, snapshot, export, and import the Waydroid container.
+            Supports both Incus and native LXC backends.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3>Extensions</h3>
+          <p>
+            Install GApps, Magisk, ARM translation, microG, Widevine, and
+            keymapper with a single command.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3>Images</h3>
+          <p>
+            Manage Waydroid image profiles, OTA updates, and AndroidTV images.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3>Streaming</h3>
+          <p>
+            Mirror the Waydroid display via <a href="https://github.com/Genymobile/scrcpy">scrcpy</a>
+            over ADB. Record sessions, forward audio, and control from the host.
+            Ported from <a href="https://github.com/canonical/anbox-streaming-sdk">anbox-streaming-sdk</a>.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3>Shared storage</h3>
+          <p>
+            Mount NFS shares and local directories into the Waydroid container
+            via <code>incus config device</code>.
+            Ported from <a href="https://github.com/canonical/anbox-cloud-nfs-operator">anbox-cloud-nfs-operator</a>.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3>CI / GitHub Actions</h3>
+          <p>
+            Run Android UI screenshot tests and E2E instrumented tests on GitHub
+            runners using Waydroid as the Android backend.
+            Ported from <a href="https://github.com/canonical/anbox-cloud-github-action">anbox-cloud-github-action</a>
+            and <a href="https://github.com/canonical/anbox-cloud-demos">anbox-cloud-demos</a>.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3>Terraform</h3>
+          <p>
+            Provision Incus containers running Waydroid with the
+            <a href="https://registry.terraform.io/providers/lxc/incus/latest">incus Terraform provider</a>.
+            Ported from <a href="https://github.com/canonical/anbox-cloud-terraform">anbox-cloud-terraform</a>.
+          </p>
+        </div>
+
+        <div class="feature-card">
+          <h3>Packages &amp; ADB</h3>
+          <p>
+            Install and remove APKs, manage F-Droid repos, run ADB commands,
+            and forward USB devices into the container.
+          </p>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Quick example ──────────────────────────────────────────────────── -->
+  <section class="quickstart">
+    <div class="container">
+      <h2>Quick start</h2>
+      <pre><code># Install
+pip install waydroid-toolkit
+
+# Check status
+wdt status
+
+# Install GApps
+wdt extensions install gapps
+
+# Mirror display
+wdt stream start
+
+# Mount NFS share
+wdt storage nfs add 192.168.1.10:/exports/assets
+
+# Snapshot
+wdt container snapshot create before-update</code></pre>
+    </div>
+  </section>
+
+  <!-- ── Anbox migration note ───────────────────────────────────────────── -->
+  <section class="migration">
+    <div class="container">
+      <h2>Migrating from Anbox Cloud?</h2>
+      <p>
+        waydroid-toolkit incorporates tooling ported from nine
+        <a href="https://github.com/canonical">Canonical</a> Anbox Cloud repositories,
+        replacing LXD with Incus and Anbox with Waydroid throughout.
+      </p>
+      <table>
+        <thead>
+          <tr><th>Anbox Cloud repo</th><th>waydroid-toolkit equivalent</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>anbox-cloud-github-action</td><td>.github/actions/waydroid-cloud</td></tr>
+          <tr><td>anbox-cloud-nfs-operator</td><td>wdt storage nfs</td></tr>
+          <tr><td>anbox-cloud-demos</td><td>demos/nowinandroid</td></tr>
+          <tr><td>anbox-cloud-terraform</td><td>terraform/ (incus provider)</td></tr>
+          <tr><td>anbox-streaming-sdk</td><td>wdt stream (scrcpy)</td></tr>
+          <tr><td>anbox-cloud-templates</td><td>.github/ISSUE_TEMPLATE</td></tr>
+          <tr><td>anbox-cloud-docs</td><td>docs/</td></tr>
+          <tr><td>anbox-cloud.github.com</td><td>site/</td></tr>
+          <tr><td>anbox-cloud.io</td><td>site/</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ── Footer ─────────────────────────────────────────────────────────── -->
+  <footer class="site-footer">
+    <div class="container">
+      <p>
+        waydroid-toolkit is licensed under
+        <a href="https://github.com/waydroid-toolkit/waydroid-toolkit/blob/main/LICENSE">GPL-3.0</a>.
+        Ported Canonical code was Apache-2.0; relicensed under GPL-3.0 per
+        Apache-2.0 / GPL-3.0 compatibility.
+      </p>
+      <p>
+        <a href="https://github.com/waydroid-toolkit/waydroid-toolkit">GitHub</a> ·
+        <a href="https://waydroid-toolkit.github.io/waydroid-toolkit/">Documentation</a> ·
+        <a href="https://github.com/waydroid-toolkit/waydroid-toolkit/issues">Issues</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Migrates tooling from 9 canonical/anbox-cloud-* repositories into waydroid-toolkit, replacing LXD→Incus and Anbox→Waydroid throughout. All ported code was Apache-2.0; relicensed GPL-3.0 (compatible).

## New CLI commands

| Command | Source repo |
|---|---|
| `wdt storage nfs add/remove/list` | anbox-cloud-nfs-operator |
| `wdt stream start/stop/status/check` | anbox-streaming-sdk |

## New modules

- `modules/storage/nfs.py` — NFS/EFS/disk device management via `incus config device`
- `modules/streaming/stream.py` — scrcpy-backed display mirroring over ADB

## New infrastructure

| Directory | Source repo |
|---|---|
| `.github/actions/waydroid-cloud/` | anbox-cloud-github-action |
| `demos/nowinandroid/` | anbox-cloud-demos |
| `terraform/` | anbox-cloud-terraform |

## Repo hygiene

- `.github/ISSUE_TEMPLATE/` — bug report + feature request forms (anbox-cloud-templates)
- `CONTRIBUTING.md`
- `www/` — landing page (anbox-cloud.github.com + anbox-cloud.io)
- `docs/` — new pages for all new commands and modules
- `mkdocs.yml` — nav updated

## Migration mapping

| Anbox Cloud | waydroid-toolkit |
|---|---|
| anbox-cloud-github-action | .github/actions/waydroid-cloud |
| anbox-cloud-nfs-operator | wdt storage nfs |
| anbox-cloud-demos | demos/nowinandroid |
| anbox-cloud-terraform | terraform/ (incus provider) |
| anbox-streaming-sdk | wdt stream (scrcpy) |
| anbox-cloud-templates | .github/ISSUE_TEMPLATE |
| anbox-cloud-docs | docs/ |
| anbox-cloud.github.com | www/ |
| anbox-cloud.io | www/ |

## Tests

- `tests/unit/test_storage.py` — NfsMount, add/remove/list
- `tests/unit/test_storage_cmd.py` — wdt storage nfs CLI
- `tests/unit/test_stream.py` — StreamConfig, StreamSession, scrcpy cmd builder
- `tests/unit/test_stream_cmd.py` — wdt stream CLI