### PR TITLE
feat: add wdt demo and wdt winesapos subcommands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,18 @@ jobs:
       - name: wdt stream check (no scrcpy — must not crash)
         run: wdt stream check || true
 
+      - name: wdt demo --help
+        run: wdt demo --help
+
+      - name: wdt demo status (not running — must not crash)
+        run: wdt demo status
+
+      - name: wdt winesapos --help
+        run: wdt winesapos --help
+
+      - name: wdt winesapos versions (network — must not crash)
+        run: wdt winesapos versions || true
+
   # ── Docs build ─────────────────────────────────────────────────────────────
   docs:
     name: Build docs (MkDocs)

--- a/src/waydroid_toolkit/cli/commands/demo.py
+++ b/src/waydroid_toolkit/cli/commands/demo.py
@@ -273,7 +273,7 @@ def demo_test() -> None:
             console.print(f"  [green]✓[/green] {endpoint}")
         except subprocess.CalledProcessError:
             console.print(f"  [red]✗[/red] {endpoint} — not responding")
-            console.print(f"Is the server running? Try: wdt demo start")
+            console.print("Is the server running? Try: wdt demo start")
             raise SystemExit(1)
 
     console.print()

--- a/src/waydroid_toolkit/cli/commands/demo.py
+++ b/src/waydroid_toolkit/cli/commands/demo.py
@@ -1,0 +1,281 @@
+"""wdt demo — manage a local incus-demo-server instance.
+
+incus-demo-server is a Go daemon that exposes a REST API for spinning up
+short-lived, resource-capped Incus instances on demand — the backend behind
+linuxcontainers.org/incus/try-it.
+
+References:
+  https://github.com/lxc/incus-demo-server
+  https://linuxcontainers.org/incus/try-it
+
+Sub-commands
+------------
+  wdt demo install          Install the binary via go install
+  wdt demo config [--edit]  Show or edit the generated config.yaml
+  wdt demo start            Start the server in the background
+  wdt demo stop             Stop the running server
+  wdt demo restart          Stop then start
+  wdt demo status           Show whether the server is running
+  wdt demo logs [--follow]  Show server logs
+  wdt demo url              Print the API base URL
+  wdt demo test             Smoke-test the running server via curl
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_DEFAULT_DIR = Path.home() / ".local" / "share" / "waydroid-toolkit" / "demo-server"
+_MODULE = "github.com/lxc/incus-demo-server/cmd/incus-demo-server@latest"
+
+
+def _demo_dir() -> Path:
+    return Path(os.environ.get("WDT_DEMO_DIR", str(_DEFAULT_DIR)))
+
+
+def _demo_bin() -> Path:
+    return _demo_dir() / "incus-demo-server"
+
+
+def _demo_cfg() -> Path:
+    return _demo_dir() / "config.yaml"
+
+
+def _demo_pid() -> Path:
+    return _demo_dir() / "demo-server.pid"
+
+
+def _demo_log() -> Path:
+    return _demo_dir() / "demo-server.log"
+
+
+def _demo_addr() -> str:
+    return os.environ.get("WDT_DEMO_ADDR", "[::]:8080")
+
+
+def _demo_port() -> str:
+    return _demo_addr().rsplit(":", 1)[-1]
+
+
+def _demo_url() -> str:
+    return f"http://localhost:{_demo_port()}"
+
+
+def _is_running() -> bool:
+    pid_file = _demo_pid()
+    if not pid_file.exists():
+        return False
+    try:
+        pid = int(pid_file.read_text().strip())
+        os.kill(pid, 0)
+        return True
+    except (ValueError, ProcessLookupError, OSError):
+        return False
+
+
+def _write_config() -> None:
+    cfg = _demo_cfg()
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    expiry = os.environ.get("WDT_DEMO_EXPIRY", "3600")
+    image = os.environ.get("WDT_DEMO_IMAGE", "ubuntu/24.04")
+    addr = _demo_addr()
+    cfg.write_text(f"""\
+server:
+  api:
+    address: "{addr}"
+  limits:
+    total: {os.environ.get("WDT_DEMO_TOTAL", "10")}
+    ip: {os.environ.get("WDT_DEMO_IP_LIMIT", "2")}
+  terms: |
+    This is a local wdt demo server.
+    Instances expire after {expiry} seconds.
+incus:
+  instance:
+    allocate:
+      count: {os.environ.get("WDT_DEMO_PREALLOCATE", "2")}
+    expiry: {expiry}
+    source:
+      image: "{image}"
+      type: "container"
+    profiles:
+      - default
+    limits:
+      cpu: {os.environ.get("WDT_DEMO_CPU", "1")}
+      disk: {os.environ.get("WDT_DEMO_DISK", "5GiB")}
+      memory: {os.environ.get("WDT_DEMO_MEMORY", "512MiB")}
+  session:
+    command: ["bash"]
+    expiry: {expiry}
+    console_only: true
+""")
+
+
+@click.group("demo")
+def cmd() -> None:
+    """Manage a local incus-demo-server instance.
+
+    incus-demo-server is the backend behind linuxcontainers.org/incus/try-it.
+    See https://github.com/lxc/incus-demo-server
+    """
+
+
+@cmd.command("install")
+def demo_install() -> None:
+    """Install the incus-demo-server binary via go install."""
+    if not shutil.which("go"):
+        console.print("[red]go is required.[/red] See https://go.dev/dl/")
+        raise SystemExit(1)
+    _demo_dir().mkdir(parents=True, exist_ok=True)
+    env = {**os.environ, "GOBIN": str(_demo_dir())}
+    console.print(f"Installing [bold]{_MODULE}[/bold]...")
+    try:
+        subprocess.run(["go", "install", _MODULE], env=env, check=True)
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]go install failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+    console.print(f"[green]Installed:[/green] {_demo_bin()}")
+    console.print("Generate config with: wdt demo config")
+
+
+@cmd.command("config")
+@click.option("--edit", "-e", is_flag=True, help="Open config in $EDITOR.")
+def demo_config(edit: bool) -> None:
+    """Show or generate the demo server config.yaml."""
+    cfg = _demo_cfg()
+    if not cfg.exists():
+        _write_config()
+        console.print(f"[green]Config written:[/green] {cfg}")
+
+    if edit:
+        editor = os.environ.get("EDITOR", "vi")
+        os.execvp(editor, [editor, str(cfg)])
+    else:
+        console.print(cfg.read_text())
+
+
+@cmd.command("start")
+def demo_start() -> None:
+    """Start the demo server in the background."""
+    if not _demo_bin().exists():
+        console.print("[red]Not installed.[/red] Run: wdt demo install")
+        raise SystemExit(1)
+
+    if not _demo_cfg().exists():
+        _write_config()
+        console.print(f"Generated config: {_demo_cfg()}")
+
+    if _is_running():
+        pid = int(_demo_pid().read_text().strip())
+        console.print(f"[yellow]Already running (PID {pid}).[/yellow]")
+        return
+
+    _demo_dir().mkdir(parents=True, exist_ok=True)
+    log_file = _demo_log().open("a")
+    proc = subprocess.Popen(
+        [str(_demo_bin())],
+        cwd=str(_demo_dir()),
+        stdout=log_file,
+        stderr=log_file,
+        start_new_session=True,
+    )
+    _demo_pid().write_text(str(proc.pid))
+    time.sleep(1)
+
+    if _is_running():
+        console.print(f"[green]Demo server started[/green] (PID {proc.pid})")
+        console.print(f"  API : {_demo_url()}")
+        console.print("Test with: wdt demo test")
+    else:
+        console.print("[red]Failed to start.[/red] Check: wdt demo logs")
+        raise SystemExit(1)
+
+
+@cmd.command("stop")
+def demo_stop() -> None:
+    """Stop the running demo server."""
+    if not _is_running():
+        console.print("[yellow]Not running.[/yellow]")
+        return
+    pid = int(_demo_pid().read_text().strip())
+    os.kill(pid, signal.SIGTERM)
+    _demo_pid().unlink(missing_ok=True)
+    console.print(f"[green]Demo server stopped[/green] (was PID {pid})")
+
+
+@cmd.command("restart")
+@click.pass_context
+def demo_restart(ctx: click.Context) -> None:
+    """Stop then start the demo server."""
+    ctx.invoke(demo_stop)
+    time.sleep(1)
+    ctx.invoke(demo_start)
+
+
+@cmd.command("status")
+def demo_status() -> None:
+    """Show whether the demo server is running."""
+    if _is_running():
+        pid = int(_demo_pid().read_text().strip())
+        console.print(f"[green]Running[/green] (PID {pid})")
+        console.print(f"  API : {_demo_url()}")
+        console.print(f"  Log : {_demo_log()}")
+    else:
+        console.print("[yellow]Stopped[/yellow]")
+
+
+@cmd.command("logs")
+@click.option("--follow", "-f", is_flag=True, help="Follow log output (tail -f).")
+def demo_logs(follow: bool) -> None:
+    """Show demo server logs."""
+    log = _demo_log()
+    if not log.exists():
+        console.print(f"[yellow]No log file:[/yellow] {log}")
+        return
+    if follow:
+        subprocess.run(["tail", "-f", str(log)])
+    else:
+        console.print(log.read_text())
+
+
+@cmd.command("url")
+def demo_url() -> None:
+    """Print the demo server API base URL."""
+    console.print(_demo_url())
+
+
+@cmd.command("test")
+def demo_test() -> None:
+    """Smoke-test the running demo server via curl."""
+    if not shutil.which("curl"):
+        console.print("[red]curl is required.[/red]")
+        raise SystemExit(1)
+
+    url = _demo_url()
+    console.print(f"Testing demo server at [bold]{url}[/bold]...")
+
+    for endpoint in ["/1.0", "/1.0/terms"]:
+        try:
+            subprocess.run(
+                ["curl", "--silent", "--fail", "--max-time", "5", f"{url}{endpoint}"],
+                check=True,
+                capture_output=True,
+            )
+            console.print(f"  [green]✓[/green] {endpoint}")
+        except subprocess.CalledProcessError:
+            console.print(f"  [red]✗[/red] {endpoint} — not responding")
+            console.print(f"Is the server running? Try: wdt demo start")
+            raise SystemExit(1)
+
+    console.print()
+    console.print("[green]Server is healthy.[/green]")
+    console.print(f"Start a session: curl -X POST {url}/1.0/start")

--- a/src/waydroid_toolkit/cli/commands/winesapos.py
+++ b/src/waydroid_toolkit/cli/commands/winesapos.py
@@ -262,7 +262,7 @@ def ws_list() -> None:
         ["incus", "list", "--format", "table"],
         capture_output=True, text=True,
     )
-    lines = [l for l in result.stdout.splitlines() if "winesapos" in l.lower()]
+    lines = [ln for ln in result.stdout.splitlines() if "winesapos" in ln.lower()]
     if lines:
         for line in lines:
             console.print(line)

--- a/src/waydroid_toolkit/cli/commands/winesapos.py
+++ b/src/waydroid_toolkit/cli/commands/winesapos.py
@@ -1,0 +1,293 @@
+"""wdt winesapos — fetch, import, and launch winesapOS gaming VMs.
+
+winesapOS is an Arch Linux-based gaming OS (Steam Deck-compatible) distributed
+as raw disk images. This command downloads the image, converts it to qcow2,
+imports it into Incus, and launches it as a virtual machine.
+
+References:
+  https://github.com/winesapOS/winesapOS
+  https://github.com/winesapOS/winesapOS/releases
+
+Sub-commands
+------------
+  wdt winesapos fetch   [VERSION] [--edition ...]
+  wdt winesapos import  [VERSION] [--edition ...]
+  wdt winesapos launch  NAME [options]
+  wdt winesapos list
+  wdt winesapos versions
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_GITHUB_BASE = "https://github.com/winesapOS/winesapOS/releases/download"
+_GITHUB_API = "https://api.github.com/repos/winesapOS/winesapOS/releases"
+_DEFAULT_VERSION = "4.5.0"
+_DEFAULT_EDITION = "minimal"
+_DEFAULT_DIR = Path.home() / ".local" / "share" / "waydroid-toolkit" / "winesapos"
+
+
+def _ws_dir() -> Path:
+    return Path(os.environ.get("WDT_WINESAPOS_DIR", str(_DEFAULT_DIR)))
+
+
+def _ws_filename(version: str, edition: str) -> str:
+    return f"winesapos-{version}-{edition}.img.zst"
+
+
+def _ws_alias(version: str, edition: str) -> str:
+    return f"winesapos/{version}/{edition}"
+
+
+def _ws_img_exists(version: str, edition: str) -> bool:
+    alias = _ws_alias(version, edition)
+    try:
+        result = subprocess.run(
+            ["incus", "image", "list", "--format", "csv"],
+            capture_output=True, text=True,
+        )
+        return alias in result.stdout
+    except FileNotFoundError:
+        return False
+
+
+@click.group("winesapos")
+def cmd() -> None:
+    """Fetch, import, and launch winesapOS gaming VMs via Incus.
+
+    winesapOS is an Arch Linux-based gaming OS (Steam Deck-compatible).
+    See https://github.com/winesapOS/winesapOS
+    """
+
+
+@cmd.command("fetch")
+@click.argument("version", default="")
+@click.option("--edition", "-e",
+              type=click.Choice(["minimal", "performance", "secure"]),
+              default="", help="Image edition (default: minimal).")
+def ws_fetch(version: str, edition: str) -> None:
+    """Download the winesapOS disk image from GitHub Releases.
+
+    VERSION defaults to the value of WDT_WINESAPOS_VERSION (or 4.5.0).
+    """
+    version = version or os.environ.get("WDT_WINESAPOS_VERSION", _DEFAULT_VERSION)
+    edition = edition or os.environ.get("WDT_WINESAPOS_EDITION", _DEFAULT_EDITION)
+
+    if not shutil.which("curl"):
+        console.print("[red]curl is required.[/red]")
+        raise SystemExit(1)
+    if not shutil.which("zstd"):
+        console.print("[red]zstd is required.[/red] Install: sudo apt install zstd")
+        raise SystemExit(1)
+
+    fname = _ws_filename(version, edition)
+    dest_zst = _ws_dir() / fname
+    dest_img = _ws_dir() / fname.removesuffix(".zst")
+
+    _ws_dir().mkdir(parents=True, exist_ok=True)
+
+    if dest_img.exists():
+        console.print(f"[yellow]Already fetched:[/yellow] {dest_img}")
+        return
+
+    if not dest_zst.exists():
+        url = f"{_GITHUB_BASE}/{version}/{fname}"
+        console.print(f"Downloading [bold]{fname}[/bold]...")
+        console.print(f"  URL: {url}")
+        try:
+            subprocess.run(
+                ["curl", "-L", "--progress-bar", "--fail", "-o", str(dest_zst), url],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            console.print("[red]Download failed.[/red] Check version/edition at:")
+            console.print("  https://github.com/winesapOS/winesapOS/releases")
+            raise SystemExit(1) from exc
+    else:
+        console.print(f"[yellow]Archive already downloaded:[/yellow] {dest_zst}")
+
+    console.print("Decompressing...")
+    try:
+        subprocess.run(
+            ["zstd", "--decompress", "--rm", str(dest_zst), "-o", str(dest_img)],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]Decompression failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[green]Image ready:[/green] {dest_img}")
+
+
+@cmd.command("import")
+@click.argument("version", default="")
+@click.option("--edition", "-e",
+              type=click.Choice(["minimal", "performance", "secure"]),
+              default="", help="Image edition.")
+def ws_import(version: str, edition: str) -> None:
+    """Import a fetched winesapOS image into the Incus image store."""
+    version = version or os.environ.get("WDT_WINESAPOS_VERSION", _DEFAULT_VERSION)
+    edition = edition or os.environ.get("WDT_WINESAPOS_EDITION", _DEFAULT_EDITION)
+
+    if not shutil.which("qemu-img"):
+        console.print("[red]qemu-img is required.[/red] Install: sudo apt install qemu-utils")
+        raise SystemExit(1)
+
+    fname = _ws_filename(version, edition).removesuffix(".zst")
+    img = _ws_dir() / fname
+    qcow2 = _ws_dir() / fname.replace(".img", ".qcow2")
+    alias = _ws_alias(version, edition)
+
+    if not img.exists():
+        console.print(f"[red]Image not found:[/red] {img}")
+        console.print(f"Run: wdt winesapos fetch {version} --edition {edition}")
+        raise SystemExit(1)
+
+    if _ws_img_exists(version, edition):
+        console.print(f"[yellow]Already imported:[/yellow] {alias}")
+        return
+
+    if not qcow2.exists():
+        console.print("Converting raw image to qcow2...")
+        try:
+            subprocess.run(
+                ["qemu-img", "convert", "-f", "raw", "-O", "qcow2", "-p",
+                 str(img), str(qcow2)],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            console.print(f"[red]Conversion failed:[/red] {exc}")
+            raise SystemExit(1) from exc
+
+    console.print(f"Importing [bold]{alias}[/bold] into Incus...")
+    try:
+        subprocess.run(
+            ["incus", "image", "import", str(qcow2),
+             "--alias", alias, "--type", "virtual-machine"],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]Import failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[green]Imported:[/green] {alias}")
+    console.print("Launch with: wdt winesapos launch my-gaming-vm")
+
+
+@cmd.command("launch")
+@click.argument("name")
+@click.option("--version", "-v", default="", help="winesapOS version.")
+@click.option("--edition", "-e",
+              type=click.Choice(["minimal", "performance", "secure"]),
+              default="", help="Image edition.")
+@click.option("--cpus", "-c", default=0, help="vCPU count (default: 4).")
+@click.option("--memory", "-m", default=0, help="Memory in MiB (default: 8192).")
+@click.option("--disk", "-d", default="", help="Root disk size (default: 64GiB).")
+def ws_launch(
+    name: str,
+    version: str,
+    edition: str,
+    cpus: int,
+    memory: int,
+    disk: str,
+) -> None:
+    """Launch a winesapOS VM in Incus.
+
+    Fetches and imports the image automatically if not already present.
+
+    \b
+    Examples:
+      wdt winesapos launch my-gaming-vm
+      wdt winesapos launch my-gaming-vm --cpus 8 --memory 16384
+      wdt winesapos launch my-gaming-vm --edition performance
+    """
+    version = version or os.environ.get("WDT_WINESAPOS_VERSION", _DEFAULT_VERSION)
+    edition = edition or os.environ.get("WDT_WINESAPOS_EDITION", _DEFAULT_EDITION)
+    cpus = cpus or int(os.environ.get("WDT_WINESAPOS_CPUS", "4"))
+    memory = memory or int(os.environ.get("WDT_WINESAPOS_MEMORY", "8192"))
+    disk = disk or os.environ.get("WDT_WINESAPOS_DISK", "64GiB")
+
+    alias = _ws_alias(version, edition)
+
+    if not _ws_img_exists(version, edition):
+        console.print(f"Image [bold]{alias}[/bold] not found — fetching and importing...")
+        subprocess.run(
+            ["wdt", "winesapos", "fetch", version, "--edition", edition],
+            check=True,
+        )
+        subprocess.run(
+            ["wdt", "winesapos", "import", version, "--edition", edition],
+            check=True,
+        )
+
+    console.print(f"Launching [bold]{name}[/bold] ({alias})")
+    console.print(f"  CPUs   : {cpus}")
+    console.print(f"  Memory : {memory} MiB")
+    console.print(f"  Disk   : {disk}")
+
+    try:
+        subprocess.run(
+            [
+                "incus", "launch", alias, name,
+                "--vm",
+                f"--config=limits.cpu={cpus}",
+                f"--config=limits.memory={memory}MiB",
+                f"--device=root,size={disk}",
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]Launch failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[green]VM launched:[/green] {name}")
+    console.print(f"Console: incus console {name}")
+    console.print(f"Stop   : incus stop {name}")
+
+
+@cmd.command("list")
+def ws_list() -> None:
+    """List winesapOS VMs in Incus."""
+    result = subprocess.run(
+        ["incus", "list", "--format", "table"],
+        capture_output=True, text=True,
+    )
+    lines = [l for l in result.stdout.splitlines() if "winesapos" in l.lower()]
+    if lines:
+        for line in lines:
+            console.print(line)
+    else:
+        console.print("[yellow]No winesapOS VMs found.[/yellow]")
+        console.print("Launch with: wdt winesapos launch NAME")
+
+
+@cmd.command("versions")
+def ws_versions() -> None:
+    """List available winesapOS releases from GitHub."""
+    if not shutil.which("curl"):
+        console.print("[red]curl is required.[/red]")
+        raise SystemExit(1)
+
+    console.print("Fetching winesapOS releases...")
+    try:
+        result = subprocess.run(
+            ["curl", "--silent", "--fail",
+             f"{_GITHUB_API}?per_page=10"],
+            capture_output=True, text=True, check=True,
+        )
+        releases = json.loads(result.stdout)
+        for r in releases:
+            console.print(f"  {r['tag_name']}")
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError) as exc:
+        console.print(f"[red]Failed to fetch releases:[/red] {exc}")
+        raise SystemExit(1) from exc

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -17,6 +17,8 @@ Commands:
     maintenance   Display settings, screenshots, logcat, file transfer, debloat
     storage       Manage shared storage (NFS/EFS/disk) for the container
     stream        Mirror the Waydroid display via scrcpy
+    demo          Manage a local incus-demo-server instance
+    winesapos     Fetch, import, and launch winesapOS gaming VMs
 """
 
 import click
@@ -32,6 +34,7 @@ from .commands import (
     cloud_sync,
     container,
     dbus,
+    demo,
     doctor,
     extensions,
     gpu,
@@ -49,6 +52,7 @@ from .commands import (
     template,
     update,
     usb,
+    winesapos,
 )
 
 console = Console()
@@ -104,3 +108,5 @@ cli.add_command(gpu.cmd, name="gpu")
 cli.add_command(dbus.cmd, name="dbus")
 cli.add_command(storage.cmd, name="storage")
 cli.add_command(stream.cmd, name="stream")
+cli.add_command(demo.cmd, name="demo")
+cli.add_command(winesapos.cmd, name="winesapos")


### PR DESCRIPTION
## wdt demo
Manages a local [incus-demo-server](https://github.com/lxc/incus-demo-server) instance.

```
wdt demo install
wdt demo start
wdt demo status
wdt demo test
wdt demo logs --follow
wdt demo stop
```

## wdt winesapos
Fetches, imports, and launches [winesapOS](https://github.com/winesapOS/winesapOS) gaming VMs.

```
wdt winesapos fetch
wdt winesapos import
wdt winesapos launch my-gaming-vm
wdt winesapos launch my-gaming-vm --cpus 8 --memory 16384 --edition performance
wdt winesapos versions
```