### PR TITLE
feat(wdt): add setup-rootless, tui, dashboard commands

### DIFF
--- a/src/waydroid_toolkit/cli/commands/dashboard.py
+++ b/src/waydroid_toolkit/cli/commands/dashboard.py
@@ -1,0 +1,278 @@
+# ruff: noqa: E501
+"""wdt dashboard — lightweight web monitoring dashboard for Waydroid.
+
+Serves a single-page HTML dashboard with live Waydroid container status.
+Requires python3 (stdlib only — no extra dependencies).
+
+Usage:
+  wdt dashboard [--port PORT] [--bind ADDR]
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import subprocess
+import threading
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>wdt Dashboard</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+         background: #0d1117; color: #c9d1d9; padding: 20px; }
+  h1 { color: #58a6ff; margin-bottom: 5px; font-size: 1.4em; }
+  .subtitle { color: #8b949e; margin-bottom: 20px; font-size: 0.9em; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+           gap: 12px; margin-bottom: 20px; }
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 16px; }
+  .card h3 { color: #58a6ff; font-size: 0.85em; margin-bottom: 8px; text-transform: uppercase; }
+  .card .value { font-size: 1.6em; font-weight: bold; }
+  table { width: 100%; border-collapse: collapse; background: #161b22;
+          border: 1px solid #30363d; border-radius: 6px; overflow: hidden; }
+  th { background: #21262d; color: #8b949e; text-align: left; padding: 10px 14px;
+       font-size: 0.8em; text-transform: uppercase; }
+  td { padding: 10px 14px; border-top: 1px solid #21262d; font-size: 0.9em; }
+  tr:hover { background: #1c2128; }
+  .status-running { color: #3fb950; }
+  .status-stopped { color: #8b949e; }
+  .refresh { color: #8b949e; font-size: 0.8em; margin-top: 15px; }
+  .actions { margin-top: 15px; }
+  .actions button { background: #21262d; color: #c9d1d9; border: 1px solid #30363d;
+                    padding: 6px 14px; border-radius: 4px; cursor: pointer; margin-right: 6px;
+                    font-size: 0.85em; }
+  .actions button:hover { background: #30363d; }
+</style>
+</head>
+<body>
+<h1>wdt Dashboard</h1>
+<p class="subtitle">Waydroid Container Monitor</p>
+
+<div class="cards" id="system-cards"></div>
+
+<table>
+  <thead>
+    <tr><th>Name</th><th>Status</th><th>CPU</th><th>Memory</th><th>Disk</th><th>IP</th></tr>
+  </thead>
+  <tbody id="ct-table"></tbody>
+</table>
+
+<div class="actions">
+  <button onclick="refresh()">Refresh</button>
+</div>
+<p class="refresh" id="last-refresh"></p>
+
+<script>
+async function refresh() {
+  try {
+    const res = await fetch('/api/containers');
+    const data = await res.json();
+
+    const cards = document.getElementById('system-cards');
+    cards.innerHTML = `
+      <div class="card"><h3>Running</h3><div class="value">${data.system.running} / ${data.system.total}</div></div>
+      <div class="card"><h3>Host Memory</h3><div class="value" style="font-size:1em">${data.system.host_memory}</div></div>
+      <div class="card"><h3>Host Disk</h3><div class="value" style="font-size:1em">${data.system.host_disk}</div></div>
+      <div class="card"><h3>Version</h3><div class="value" style="font-size:1em">v${data.system.version}</div></div>
+    `;
+
+    const tbody = document.getElementById('ct-table');
+    if (data.containers.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;color:#8b949e">No containers found</td></tr>';
+    } else {
+      tbody.innerHTML = data.containers.map(ct => `
+        <tr>
+          <td><strong>${ct.name}</strong></td>
+          <td class="status-${ct.status.toLowerCase()}">${ct.status}</td>
+          <td>${ct.cpu || '-'}</td>
+          <td>${ct.memory || '-'}</td>
+          <td>${ct.disk || '-'}</td>
+          <td>${ct.ip}</td>
+        </tr>
+      `).join('');
+    }
+
+    document.getElementById('last-refresh').textContent =
+      'Last refresh: ' + new Date().toLocaleTimeString();
+  } catch (e) {
+    console.error('Refresh failed:', e);
+  }
+}
+
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>
+"""
+
+
+def _containers_json() -> dict:
+    """Collect container data from incus for the API response."""
+    result = subprocess.run(
+        ["incus", "list", "--format", "json"],
+        capture_output=True,
+        text=True,
+    )
+    containers = []
+    if result.returncode == 0:
+        try:
+            instances = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            instances = []
+        for inst in instances:
+            if inst.get("type") != "container":
+                continue
+            name = inst.get("name", "")
+            status = inst.get("status", "unknown")
+
+            cpu = _incus_config(name, "limits.cpu")
+            mem = _incus_config(name, "limits.memory")
+            disk = _incus_device(name, "root", "size")
+
+            ip = "-"
+            if status == "Running":
+                for iface in inst.get("state", {}).get("network", {}).values():
+                    for addr in iface.get("addresses", []):
+                        if addr.get("family") == "inet" and not addr["address"].startswith("127."):
+                            ip = addr["address"]
+                            break
+                    if ip != "-":
+                        break
+
+            containers.append(
+                {
+                    "name": name,
+                    "status": status,
+                    "cpu": cpu,
+                    "memory": mem,
+                    "disk": disk,
+                    "ip": ip,
+                }
+            )
+
+    total = len(containers)
+    running = sum(1 for c in containers if c["status"] == "Running")
+
+    host_memory = _host_memory()
+    host_disk = _host_disk()
+    version = _wdt_version()
+
+    return {
+        "containers": containers,
+        "system": {
+            "total": total,
+            "running": running,
+            "host_memory": host_memory,
+            "host_disk": host_disk,
+            "version": version,
+        },
+    }
+
+
+def _incus_config(name: str, key: str) -> str:
+    r = subprocess.run(
+        ["incus", "config", "get", name, key],
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout.strip() or "?"
+
+
+def _incus_device(name: str, device: str, key: str) -> str:
+    r = subprocess.run(
+        ["incus", "config", "device", "get", name, device, key],
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout.strip() or "?"
+
+
+def _host_memory() -> str:
+    try:
+        r = subprocess.run(["free", "-h"], capture_output=True, text=True)
+        for line in r.stdout.splitlines():
+            if line.startswith("Mem:"):
+                parts = line.split()
+                return f"{parts[2]} / {parts[1]}"
+    except Exception:
+        pass
+    return "?"
+
+
+def _host_disk() -> str:
+    try:
+        r = subprocess.run(["df", "-h", "/"], capture_output=True, text=True)
+        lines = r.stdout.splitlines()
+        if len(lines) >= 2:
+            parts = lines[1].split()
+            return f"{parts[2]} / {parts[1]} ({parts[4]})"
+    except Exception:
+        pass
+    return "?"
+
+
+def _wdt_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("waydroid-toolkit")
+    except Exception:
+        return "?"
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/api/containers":
+            data = json.dumps(_containers_json()).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(data)
+        elif self.path in ("/", "/index.html"):
+            body = _HTML.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "9")
+            self.end_headers()
+            self.wfile.write(b"Not Found")
+
+    def log_message(self, *_args: object) -> None:  # silence access log
+        pass
+
+
+@click.command("dashboard")
+@click.option("--port", default=8421, show_default=True, help="Listen port.")
+@click.option("--bind", default="127.0.0.1", show_default=True, help="Bind address.")
+def cmd(port: int, bind: str) -> None:
+    """Serve a web monitoring dashboard for Waydroid containers."""
+    server = http.server.HTTPServer((bind, port), _Handler)
+    console.print("[bold cyan]wdt Web Dashboard[/bold cyan]")
+    console.print(f"Listening on [link]http://{bind}:{port}[/link]")
+    console.print("Press [bold]Ctrl+C[/bold] to stop\n")
+
+    # Run in a daemon thread so KeyboardInterrupt on the main thread shuts it down.
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        t.join()
+    except KeyboardInterrupt:
+        server.shutdown()
+        console.print("\n[yellow]Dashboard stopped.[/yellow]")

--- a/src/waydroid_toolkit/cli/commands/setup_rootless.py
+++ b/src/waydroid_toolkit/cli/commands/setup_rootless.py
@@ -1,0 +1,252 @@
+"""wdt setup-rootless — configure the system for rootless Waydroid operation.
+
+Checks and optionally fixes prerequisites for running the Waydroid
+container as a non-root user via incus-user:
+
+  1. User is not root
+  2. incus-user daemon (systemd user service + socket)
+  3. Waydroid binder kernel module (binder_linux / ashmem_linux)
+  4. UID/GID delegation (subuid/subgid)
+  5. waydroid-container Incus profile registered in incus-user
+  6. Waydroid service (waydroid-container.service) enabled
+
+Sub-commands
+------------
+  wdt setup-rootless          Run all checks (report only)
+  wdt setup-rootless --fix    Attempt to fix detected issues
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+def _run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, **kwargs)
+
+
+def _ok(msg: str) -> None:
+    console.print(f"  [green]✔[/green]  {msg}")
+
+
+def _warn(msg: str) -> None:
+    console.print(f"  [yellow]⚠[/yellow]  {msg}")
+
+
+def _fail(msg: str) -> None:
+    console.print(f"  [red]✘[/red]  {msg}")
+
+
+def _section(title: str) -> None:
+    console.print(f"\n[bold]{title}[/bold]")
+
+
+def _ask_fix(msg: str, cmd: list[str], fix: bool, issues: list) -> None:
+    if fix:
+        console.print(f"  Fixing: {msg}")
+        result = _run(cmd)
+        if result.returncode == 0:
+            _ok(f"Fixed: {msg}")
+        else:
+            _fail(f"Failed to fix: {msg}")
+            console.print(f"    [dim]{result.stderr.strip()}[/dim]")
+            issues.append(msg)
+    else:
+        _warn(msg)
+        console.print(f"    Run: [cyan]{' '.join(cmd)}[/cyan]")
+        issues.append(msg)
+
+
+@click.command("setup-rootless")
+@click.option("--fix", is_flag=True, help="Attempt to automatically fix detected issues.")
+@click.option("-Y", "--yes", "yes", is_flag=True,
+              help="Non-interactive mode (implies --fix).")
+def cmd(fix: bool, yes: bool) -> None:
+    """Configure the system for rootless Waydroid operation via incus-user.
+
+    Checks prerequisites and optionally fixes them with --fix.
+
+    \b
+    Checks:
+      1. Not running as root
+      2. incus-user daemon (systemd user service + socket)
+      3. Waydroid binder kernel module
+      4. UID/GID delegation (subuid/subgid)
+      5. waydroid-container Incus profile in incus-user
+      6. waydroid-container.service enabled
+
+    \b
+    Examples:
+      wdt setup-rootless
+      wdt setup-rootless --fix
+      wdt setup-rootless --yes
+    """
+    if yes:
+        fix = True
+
+    issues: list[str] = []
+    uid = os.getuid()
+    user = os.environ.get("USER", "")
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{uid}")
+    incus_socket = Path(xdg_runtime) / "incus" / "incus.socket"
+
+    # 1. Not root
+    _section("1. User check")
+    if uid == 0:
+        console.print("[red]Run as a regular user, not root.[/red]")
+        raise SystemExit(1)
+    _ok(f"Running as {user} (uid={uid})")
+
+    # 2. incus-user daemon
+    _section("2. incus-user daemon")
+    incus_result = _run(["incus", "--version"])
+    if incus_result.returncode != 0:
+        _fail("incus not found — install Incus: https://linuxcontainers.org/incus/")
+        issues.append("incus not installed")
+    else:
+        _ok(f"incus found: {incus_result.stdout.strip()}")
+
+    if incus_socket.exists():
+        _ok(f"incus-user socket: {incus_socket}")
+    else:
+        svc_check = _run(
+            ["systemctl", "--user", "list-unit-files", "incus-user.service"]
+        )
+        if svc_check.returncode == 0 and "incus-user.service" in svc_check.stdout:
+            active = _run(["systemctl", "--user", "is-active", "incus-user.service"])
+            if active.returncode == 0:
+                _warn("incus-user.service active but socket not found")
+                console.print("    Check: [cyan]systemctl --user status incus-user.service[/cyan]")
+                issues.append("incus-user socket missing")
+            else:
+                _ask_fix(
+                    "Start and enable incus-user.service",
+                    ["systemctl", "--user", "enable", "--now", "incus-user.service"],
+                    fix, issues,
+                )
+        else:
+            _fail("incus-user.service not found — install incus-user package")
+            issues.append("incus-user not installed")
+
+    # 3. Binder kernel module
+    _section("3. Waydroid binder kernel module")
+    binder_ok = False
+    for mod in ("binder_linux", "ashmem_linux"):
+        lsmod = _run(["lsmod"])
+        if mod in lsmod.stdout:
+            _ok(f"Kernel module loaded: {mod}")
+            binder_ok = True
+            break
+    if not binder_ok:
+        # Check if binder is built-in
+        builtin = _run(["grep", "-r", "binder", "/sys/module/"], check=False)
+        if builtin.returncode == 0:
+            _ok("binder: built into kernel")
+        else:
+            _ask_fix(
+                "Load binder_linux kernel module",
+                ["sudo", "modprobe", "binder_linux"],
+                fix, issues,
+            )
+
+    # 4. subuid/subgid
+    _section("4. UID/GID delegation (subuid/subgid)")
+    for fname in ("/etc/subuid", "/etc/subgid"):
+        label = Path(fname).name
+        try:
+            content = Path(fname).read_text()
+            if user and f"{user}:" in content:
+                line = next(ln for ln in content.splitlines() if ln.startswith(f"{user}:"))
+                _ok(f"{label}: {line}")
+            else:
+                _ask_fix(
+                    f"Add {user} to {fname}",
+                    ["sudo", "usermod", f"--add-sub{'uid' if 'uid' in fname else 'gid'}s",
+                     "65536-131071", user],
+                    fix, issues,
+                )
+        except OSError:
+            _warn(f"{fname} not found")
+            issues.append(f"{fname} missing")
+
+    # 5. waydroid-container Incus profile
+    _section("5. waydroid-container Incus profile")
+    env = os.environ.copy()
+    if incus_socket.exists():
+        env["INCUS_SOCKET"] = str(incus_socket)
+
+    profile_check = subprocess.run(
+        ["incus", "profile", "show", "waydroid"],
+        capture_output=True, text=True, env=env,
+    )
+    if profile_check.returncode == 0:
+        _ok("waydroid profile registered in incus-user")
+    else:
+        # Look for a profile YAML in common locations
+        profile_yaml: Path | None = None
+        for candidate in [
+            Path(__file__).parents[4] / "data" / "profiles" / "waydroid.yaml",
+            Path.home() / ".local" / "share" / "waydroid-toolkit" / "profiles" / "waydroid.yaml",
+            Path("/usr/share/waydroid-toolkit/profiles/waydroid.yaml"),
+        ]:
+            if candidate.exists():
+                profile_yaml = candidate
+                break
+
+        if profile_yaml:
+            _ask_fix(
+                "Register waydroid profile",
+                ["sh", "-c",
+                 f"incus profile create waydroid && "
+                 f"incus profile edit waydroid < {profile_yaml}"],
+                fix, issues,
+            )
+        else:
+            _warn("waydroid profile not registered")
+            console.print("    Run: [cyan]wdt profiles install[/cyan]")
+            issues.append("waydroid profile not registered")
+
+    # 6. waydroid-container.service
+    _section("6. waydroid-container.service")
+    svc_enabled = _run(
+        ["systemctl", "--user", "is-enabled", "waydroid-container.service"]
+    )
+    if svc_enabled.returncode == 0:
+        _ok("waydroid-container.service enabled")
+    else:
+        svc_exists = _run(
+            ["systemctl", "--user", "list-unit-files", "waydroid-container.service"]
+        )
+        if svc_exists.returncode == 0 and "waydroid-container" in svc_exists.stdout:
+            _ask_fix(
+                "Enable waydroid-container.service",
+                ["systemctl", "--user", "enable", "waydroid-container.service"],
+                fix, issues,
+            )
+        else:
+            _warn("waydroid-container.service not found (may not be needed for your setup)")
+
+    # Summary
+    console.print()
+    if not issues:
+        console.print("[green]All checks passed. Rootless wdt is ready.[/green]")
+        console.print()
+        console.print("Quick start:")
+        console.print("  [cyan]wdt install[/cyan]")
+        console.print("  [cyan]wdt status[/cyan]")
+    else:
+        console.print(f"[yellow]{len(issues)} issue(s) found.[/yellow]")
+        if not fix:
+            console.print("Re-run with --fix to attempt automatic fixes:")
+            console.print("  [cyan]wdt setup-rootless --fix[/cyan]")
+        else:
+            console.print("Some issues could not be fixed automatically.")
+            console.print("Review the output above and resolve them manually.")
+        raise SystemExit(1)

--- a/src/waydroid_toolkit/cli/commands/tui.py
+++ b/src/waydroid_toolkit/cli/commands/tui.py
@@ -1,0 +1,358 @@
+"""wdt tui — interactive terminal UI for waydroid-toolkit.
+
+Menu-driven interface for common wdt operations.
+Requires: dialog or whiptail.
+
+Sub-commands
+------------
+  wdt tui    Launch the interactive menu
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_WDT = [sys.executable, "-m", "waydroid_toolkit"] if "__main__" not in sys.modules else ["wdt"]
+
+
+def _wdt(*args: str) -> list[str]:
+    """Build a wdt sub-command invocation."""
+    return ["wdt", *args]
+
+
+def _detect_dialog() -> str:
+    for prog in ("dialog", "whiptail"):
+        if shutil.which(prog):
+            return prog
+    return ""
+
+
+def _dlg(dialog: str, *args: str) -> str:
+    """Run dialog/whiptail, return selected value or raise on cancel."""
+    result = subprocess.run(
+        [dialog, "--backtitle", "wdt — Waydroid Toolkit", *args],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise KeyboardInterrupt
+    return result.stderr.strip()
+
+
+def _menu(dialog: str, title: str, text: str, *items: str) -> str:
+    return _dlg(dialog, "--title", title, "--menu", text, "0", "0", "0", *items)
+
+
+def _input(dialog: str, title: str, text: str, default: str = "") -> str:
+    return _dlg(dialog, "--title", title, "--inputbox", text, "0", "60", default)
+
+
+def _yesno(dialog: str, title: str, text: str) -> bool:
+    result = subprocess.run(
+        [dialog, "--backtitle", "wdt — Waydroid Toolkit",
+         "--title", title, "--yesno", text, "0", "0"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _msgbox(dialog: str, title: str, text: str) -> None:
+    subprocess.run(
+        [dialog, "--backtitle", "wdt — Waydroid Toolkit",
+         "--title", title, "--msgbox", text, "0", "0"],
+        capture_output=True,
+    )
+
+
+def _run_cmd(dialog: str, title: str, *args: str) -> None:
+    result = subprocess.run(list(args), capture_output=True, text=True)
+    output = result.stdout + result.stderr
+    # Strip ANSI codes
+    import re
+    output = re.sub(r"\x1b\[[0-9;]*m", "", output)
+    _msgbox(dialog, title, output.strip() or "Done.")
+
+
+def _run_interactive(*args: str) -> None:
+    """Drop out of dialog and run a command interactively in the terminal."""
+    subprocess.call(list(args))
+    input("\nPress Enter to continue...")
+
+
+# ── menus ─────────────────────────────────────────────────────────────────────
+
+def _menu_main(d: str) -> None:
+    while True:
+        try:
+            choice = _menu(d, "wdt", "Select an action:",
+                           "status",         "Show Waydroid status",
+                           "container",      "Container lifecycle",
+                           "backup",         "Backup and restore",
+                           "images",         "Image profiles and OTA",
+                           "fleet",          "Multi-instance orchestration",
+                           "publish",        "Publish container as image",
+                           "disk",           "Disk resize",
+                           "config",         "Configuration",
+                           "doctor",         "Check prerequisites",
+                           "setup-rootless", "Rootless setup",
+                           "quit",           "Exit")
+        except KeyboardInterrupt:
+            break
+
+        if choice == "status":
+            _run_cmd(d, "Status", *_wdt("status"))
+        elif choice == "container":
+            _menu_container(d)
+        elif choice == "backup":
+            _menu_backup(d)
+        elif choice == "images":
+            _menu_images(d)
+        elif choice == "fleet":
+            _menu_fleet(d)
+        elif choice == "publish":
+            _menu_publish(d)
+        elif choice == "disk":
+            _menu_disk(d)
+        elif choice == "config":
+            _menu_config(d)
+        elif choice == "doctor":
+            _run_cmd(d, "Doctor", *_wdt("doctor"))
+        elif choice == "setup-rootless":
+            _run_cmd(d, "Setup Rootless", *_wdt("setup-rootless"))
+        elif choice == "quit":
+            break
+
+
+def _menu_container(d: str) -> None:
+    while True:
+        try:
+            choice = _menu(d, "Container", "Select an action:",
+                           "status",  "Show container status",
+                           "start",   "Start container",
+                           "stop",    "Stop container",
+                           "shell",   "Open shell",
+                           "upgrade", "Upgrade Android image (OTA)",
+                           "back",    "Back")
+        except KeyboardInterrupt:
+            break
+
+        if choice == "status":
+            _run_cmd(d, "Container Status", *_wdt("status"))
+        elif choice == "start":
+            _run_cmd(d, "Start", *_wdt("container", "start"))
+        elif choice == "stop":
+            _run_cmd(d, "Stop", *_wdt("container", "stop"))
+        elif choice == "shell":
+            os.system("clear")
+            _run_interactive(*_wdt("shell", "enter"))
+        elif choice == "upgrade":
+            _menu_upgrade(d)
+        elif choice == "back":
+            break
+
+
+def _menu_upgrade(d: str) -> None:
+    try:
+        choice = _menu(d, "Upgrade", "Select action:",
+                       "check", "Check for updates",
+                       "apply", "Download and apply updates")
+    except KeyboardInterrupt:
+        return
+
+    if choice == "check":
+        _run_cmd(d, "Upgrade Check", *_wdt("upgrade", "check"))
+    elif choice == "apply":
+        if _yesno(d, "Apply Updates", "Download and apply the latest Waydroid images?"):
+            _run_cmd(d, "Applying Updates", *_wdt("upgrade", "apply", "--yes"))
+
+
+def _menu_backup(d: str) -> None:
+    while True:
+        try:
+            choice = _menu(d, "Backup", "Select an action:",
+                           "create",  "Create a backup",
+                           "list",    "List backups",
+                           "delete",  "Delete a backup",
+                           "restore", "Restore from backup",
+                           "back",    "Back")
+        except KeyboardInterrupt:
+            break
+
+        if choice == "create":
+            _run_cmd(d, "Creating Backup", *_wdt("backup", "create"))
+        elif choice == "list":
+            _run_cmd(d, "Backups", *_wdt("backup", "list"))
+        elif choice == "delete":
+            try:
+                name = _input(d, "Delete Backup", "Backup archive name:")
+            except KeyboardInterrupt:
+                continue
+            if name and _yesno(d, "Delete", f"Delete backup '{name}'?"):
+                _run_cmd(d, "Deleting", *_wdt("backup", "delete", name, "--yes"))
+        elif choice == "restore":
+            try:
+                src = _input(d, "Restore", "Backup archive path:")
+            except KeyboardInterrupt:
+                continue
+            if src:
+                _run_cmd(d, "Restoring", *_wdt("backup", "restore", src))
+        elif choice == "back":
+            break
+
+
+def _menu_images(d: str) -> None:
+    while True:
+        try:
+            choice = _menu(d, "Images", "Select an action:",
+                           "list",   "List profiles",
+                           "active", "Show active profile",
+                           "switch", "Switch profile",
+                           "check",  "Check for OTA updates",
+                           "back",   "Back")
+        except KeyboardInterrupt:
+            break
+
+        if choice == "list":
+            _run_cmd(d, "Profiles", *_wdt("profiles", "list"))
+        elif choice == "active":
+            _run_cmd(d, "Active Profile", *_wdt("profiles", "active"))
+        elif choice == "switch":
+            try:
+                name = _input(d, "Switch Profile", "Profile name:")
+            except KeyboardInterrupt:
+                continue
+            if name:
+                _run_cmd(d, f"Switching to {name}", *_wdt("profiles", "switch", name))
+        elif choice == "check":
+            _run_cmd(d, "OTA Check", *_wdt("upgrade", "check"))
+        elif choice == "back":
+            break
+
+
+def _menu_fleet(d: str) -> None:
+    while True:
+        try:
+            choice = _menu(d, "Fleet", "Select an action:",
+                           "list",       "List all instances",
+                           "status",     "Show fleet status",
+                           "start-all",  "Start all stopped instances",
+                           "stop-all",   "Stop all running instances",
+                           "backup-all", "Backup all instances",
+                           "back",       "Back")
+        except KeyboardInterrupt:
+            break
+
+        if choice == "list":
+            _run_cmd(d, "Fleet List", *_wdt("fleet", "list"))
+        elif choice == "status":
+            _run_cmd(d, "Fleet Status", *_wdt("fleet", "status"))
+        elif choice == "start-all":
+            _run_cmd(d, "Starting All", *_wdt("fleet", "start-all"))
+        elif choice == "stop-all":
+            if _yesno(d, "Stop All", "Stop all running Waydroid instances?"):
+                _run_cmd(d, "Stopping All", *_wdt("fleet", "stop-all"))
+        elif choice == "backup-all":
+            _run_cmd(d, "Backing Up All", *_wdt("fleet", "backup-all"))
+        elif choice == "back":
+            break
+
+
+def _menu_publish(d: str) -> None:
+    try:
+        choice = _menu(d, "Publish", "Select action:",
+                       "create", "Publish container as image",
+                       "list",   "List published images",
+                       "delete", "Delete a published image")
+    except KeyboardInterrupt:
+        return
+
+    if choice == "create":
+        try:
+            alias = _input(d, "Publish", "Image alias (e.g. waydroid/golden):",
+                           "waydroid/published")
+        except KeyboardInterrupt:
+            return
+        if alias:
+            _run_cmd(d, "Publishing", *_wdt("publish", "create", "--alias", alias))
+    elif choice == "list":
+        _run_cmd(d, "Published Images", *_wdt("publish", "list"))
+    elif choice == "delete":
+        try:
+            alias = _input(d, "Delete Image", "Image alias:")
+        except KeyboardInterrupt:
+            return
+        if alias and _yesno(d, "Delete", f"Delete image '{alias}'?"):
+            _run_cmd(d, "Deleting", *_wdt("publish", "delete", alias, "--yes"))
+
+
+def _menu_disk(d: str) -> None:
+    try:
+        choice = _menu(d, "Disk", "Select action:",
+                       "info",   "Show disk info",
+                       "resize", "Resize root disk")
+    except KeyboardInterrupt:
+        return
+
+    if choice == "info":
+        _run_cmd(d, "Disk Info", *_wdt("disk", "info"))
+    elif choice == "resize":
+        try:
+            size = _input(d, "Resize Disk", "New size (e.g. 20GB, +5GB):")
+        except KeyboardInterrupt:
+            return
+        if size:
+            _run_cmd(d, f"Resizing to {size}", *_wdt("disk", "resize", size))
+
+
+def _menu_config(d: str) -> None:
+    while True:
+        try:
+            choice = _menu(d, "Config", "Select action:",
+                           "show", "Show current config",
+                           "init", "Create default config",
+                           "edit", "Edit config file",
+                           "back", "Back")
+        except KeyboardInterrupt:
+            break
+
+        if choice == "show":
+            _run_cmd(d, "Config", *_wdt("config", "show"))
+        elif choice == "init":
+            _run_cmd(d, "Init Config", *_wdt("config", "init"))
+        elif choice == "edit":
+            os.system("clear")
+            _run_interactive(*_wdt("config", "edit"))
+        elif choice == "back":
+            break
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+@click.command("tui")
+def cmd() -> None:
+    """Launch the interactive terminal UI (requires dialog or whiptail).
+
+    \b
+    Examples:
+      wdt tui
+    """
+    dialog = _detect_dialog()
+    if not dialog:
+        console.print("[red]Neither dialog nor whiptail found.[/red]")
+        console.print("Install with: [cyan]sudo apt install dialog[/cyan]")
+        raise SystemExit(1)
+
+    try:
+        os.system("clear")
+        _menu_main(dialog)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        os.system("clear")

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -17,6 +17,9 @@ Commands:
     publish       Create and manage Incus images from the Waydroid container
     shell         Open an interactive shell inside the Waydroid container
     config        Manage wdt configuration
+    setup-rootless  Configure the system for rootless Waydroid operation
+    tui             Launch interactive terminal UI (requires dialog or whiptail)
+    dashboard       Serve a web monitoring dashboard for Waydroid containers
     disk          Live disk resize for the Waydroid container
     profiles      Manage Waydroid image profiles
     upgrade       Upgrade the Waydroid Android image via OTA
@@ -41,6 +44,7 @@ from .commands import (
     cloud_sync,
     config,
     container,
+    dashboard,
     dbus,
     demo,
     disk,
@@ -57,12 +61,14 @@ from .commands import (
     performance,
     profiles,
     publish,
+    setup_rootless,
     shell,
     snapshot,
     status,
     storage,
     stream,
     template,
+    tui,
     update,
     upgrade,
     usb,
@@ -113,6 +119,9 @@ cli.add_command(fleet.cmd, name="fleet")
 cli.add_command(publish.cmd, name="publish")
 cli.add_command(shell.cmd, name="shell")
 cli.add_command(config.cmd, name="config")
+cli.add_command(setup_rootless.cmd, name="setup-rootless")
+cli.add_command(tui.cmd, name="tui")
+cli.add_command(dashboard.cmd, name="dashboard")
 cli.add_command(disk.cmd, name="disk")
 cli.add_command(profiles.cmd, name="profiles")
 cli.add_command(upgrade.cmd, name="upgrade")

--- a/tests/unit/test_dashboard_cmd.py
+++ b/tests/unit/test_dashboard_cmd.py
@@ -1,0 +1,174 @@
+"""Tests for wdt dashboard."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from waydroid_toolkit.cli.commands.dashboard import (
+    _containers_json,
+    _host_disk,
+    _host_memory,
+    _wdt_version,
+    _Handler,
+)
+
+
+def _make_run(returncode: int = 0, stdout: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    return m
+
+
+class TestContainersJson:
+    def test_empty_when_incus_fails(self) -> None:
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   return_value=_make_run(1)):
+            data = _containers_json()
+        assert data["containers"] == []
+        assert data["system"]["total"] == 0
+        assert data["system"]["running"] == 0
+
+    def test_empty_when_invalid_json(self) -> None:
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   return_value=_make_run(0, "not-json")):
+            data = _containers_json()
+        assert data["containers"] == []
+
+    def test_filters_non_containers(self) -> None:
+        instances = json.dumps([
+            {"name": "vm1", "type": "virtual-machine", "status": "Running"},
+            {"name": "ct1", "type": "container", "status": "Running",
+             "state": {"network": {}}},
+        ])
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   return_value=_make_run(0, instances)) as mock_run:
+            # stub config/device calls
+            mock_run.side_effect = None
+            mock_run.return_value = _make_run(0, instances)
+
+            def _run_side(args, **_kw):
+                if args[:2] == ["incus", "list"]:
+                    return _make_run(0, instances)
+                return _make_run(0, "")
+
+            mock_run.side_effect = _run_side
+            data = _containers_json()
+
+        assert len(data["containers"]) == 1
+        assert data["containers"][0]["name"] == "ct1"
+
+    def test_system_keys_present(self) -> None:
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   return_value=_make_run(1)):
+            data = _containers_json()
+        assert {"total", "running", "host_memory", "host_disk", "version"} <= data["system"].keys()
+
+    def test_running_count(self) -> None:
+        instances = json.dumps([
+            {"name": "ct1", "type": "container", "status": "Running",
+             "state": {"network": {}}},
+            {"name": "ct2", "type": "container", "status": "Stopped",
+             "state": {"network": {}}},
+        ])
+
+        def _run_side(args, **_kw):
+            if args[:2] == ["incus", "list"]:
+                return _make_run(0, instances)
+            return _make_run(0, "")
+
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   side_effect=_run_side):
+            data = _containers_json()
+
+        assert data["system"]["total"] == 2
+        assert data["system"]["running"] == 1
+
+
+class TestHostHelpers:
+    def test_host_memory_parses_free_output(self) -> None:
+        free_out = "              total        used        free\nMem:           15Gi       8.0Gi       7.0Gi\n"
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   return_value=_make_run(0, free_out)):
+            result = _host_memory()
+        assert "/" in result
+
+    def test_host_memory_fallback_on_error(self) -> None:
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   side_effect=Exception("no free")):
+            result = _host_memory()
+        assert result == "?"
+
+    def test_host_disk_parses_df_output(self) -> None:
+        df_out = "Filesystem      Size  Used Avail Use% Mounted on\n/dev/sda1        50G   20G   30G  40% /\n"
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   return_value=_make_run(0, df_out)):
+            result = _host_disk()
+        assert "/" in result
+
+    def test_host_disk_fallback_on_error(self) -> None:
+        with patch("waydroid_toolkit.cli.commands.dashboard.subprocess.run",
+                   side_effect=Exception("no df")):
+            result = _host_disk()
+        assert result == "?"
+
+    def test_wdt_version_fallback(self) -> None:
+        with patch("importlib.metadata.version", side_effect=Exception("not found")):
+            result = _wdt_version()
+        assert result == "?"
+
+
+class TestHttpHandler:
+    """Unit-test the HTTP handler routing logic."""
+
+    def _make_handler(self, path: str) -> _Handler:
+        handler = _Handler.__new__(_Handler)
+        handler.path = path
+        handler._headers_sent = []
+        handler._response_code = None
+        handler._body = b""
+
+        def send_response(code):
+            handler._response_code = code
+
+        def send_header(k, v):
+            handler._headers_sent.append((k, v))
+
+        def end_headers():
+            pass
+
+        class _FakeWfile:
+            def write(self, data):
+                handler._body += data
+
+        handler.send_response = send_response
+        handler.send_header = send_header
+        handler.end_headers = end_headers
+        handler.wfile = _FakeWfile()
+        return handler
+
+    def test_root_returns_html(self) -> None:
+        handler = self._make_handler("/")
+        with patch("waydroid_toolkit.cli.commands.dashboard._containers_json",
+                   return_value={"containers": [], "system": {}}):
+            handler.do_GET()
+        assert handler._response_code == 200
+        assert b"wdt Dashboard" in handler._body
+
+    def test_api_returns_json(self) -> None:
+        payload = {"containers": [], "system": {"total": 0, "running": 0,
+                                                 "host_memory": "?", "host_disk": "?",
+                                                 "version": "?"}}
+        handler = self._make_handler("/api/containers")
+        with patch("waydroid_toolkit.cli.commands.dashboard._containers_json",
+                   return_value=payload):
+            handler.do_GET()
+        assert handler._response_code == 200
+        data = json.loads(handler._body)
+        assert "containers" in data
+
+    def test_unknown_path_returns_404(self) -> None:
+        handler = self._make_handler("/nonexistent")
+        handler.do_GET()
+        assert handler._response_code == 404

--- a/tests/unit/test_setup_rootless.py
+++ b/tests/unit/test_setup_rootless.py
@@ -1,0 +1,126 @@
+"""Tests for wdt setup-rootless."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.setup_rootless import cmd
+
+
+def _make_run(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def _base_patches(
+    *,
+    uid: int = 1000,
+    user: str = "alice",
+    socket_exists: bool = True,
+    incus_ok: bool = True,
+    incus_user_svc: bool = True,
+    incus_user_active: bool = True,
+    binder_loaded: bool = True,
+    subuid_content: str = "alice:100000:65536",
+    subgid_content: str = "alice:100000:65536",
+    profile_ok: bool = True,
+    waydroid_svc_enabled: bool = True,
+) -> list:
+    def _run_side_effect(args, **_kwargs):
+        cmd_str = " ".join(str(a) for a in args)
+        if "incus" in cmd_str and "--version" in cmd_str:
+            return _make_run(0 if incus_ok else 1, "6.0.0")
+        if "list-unit-files" in cmd_str and "incus-user" in cmd_str:
+            return _make_run(0 if incus_user_svc else 1,
+                             "incus-user.service enabled" if incus_user_svc else "")
+        if "is-active" in cmd_str and "incus-user" in cmd_str:
+            return _make_run(0 if incus_user_active else 1)
+        if "lsmod" in cmd_str:
+            return _make_run(0, "binder_linux 12345 0" if binder_loaded else "")
+        if "grep" in cmd_str and "binder" in cmd_str:
+            # Simulate binder not built-in when binder_loaded is False
+            return _make_run(1 if not binder_loaded else 0)
+        if "profile" in cmd_str and "show" in cmd_str:
+            return _make_run(0 if profile_ok else 1)
+        if "is-enabled" in cmd_str and "waydroid-container" in cmd_str:
+            return _make_run(0 if waydroid_svc_enabled else 1)
+        if "list-unit-files" in cmd_str and "waydroid-container" in cmd_str:
+            return _make_run(0, "waydroid-container.service enabled")
+        return _make_run(0)
+
+    def _read_text_side_effect(self):
+        if "subuid" in str(self):
+            return subuid_content
+        if "subgid" in str(self):
+            return subgid_content
+        return ""
+
+    return [
+        patch("os.getuid", return_value=uid),
+        patch.dict("os.environ", {"USER": user, "XDG_RUNTIME_DIR": f"/run/user/{uid}"}),
+        patch("waydroid_toolkit.cli.commands.setup_rootless._run", side_effect=_run_side_effect),
+        patch("subprocess.run", side_effect=_run_side_effect),
+        patch("pathlib.Path.exists", return_value=socket_exists),
+        patch("pathlib.Path.read_text", _read_text_side_effect),
+    ]
+
+
+class TestSetupRootless:
+    def _invoke(self, args: list[str] | None = None, **kwargs) -> object:
+        runner = CliRunner()
+        patches = _base_patches(**kwargs)
+        for p in patches:
+            p.start()
+        try:
+            result = runner.invoke(cmd, args or [])
+        finally:
+            for p in patches:
+                p.stop()
+        return result
+
+    def test_all_ok_exits_zero(self) -> None:
+        result = self._invoke()
+        assert result.exit_code == 0
+        assert "All checks passed" in result.output
+
+    def test_root_user_exits_nonzero(self) -> None:
+        result = self._invoke(uid=0)
+        assert result.exit_code != 0
+
+    def test_missing_incus_reports_issue(self) -> None:
+        result = self._invoke(incus_ok=False)
+        assert result.exit_code != 0
+
+    def test_missing_binder_reports_issue(self) -> None:
+        result = self._invoke(binder_loaded=False)
+        assert result.exit_code != 0
+
+    def test_missing_subuid_entry_reports_issue(self) -> None:
+        result = self._invoke(subuid_content="otheruser:100000:65536")
+        assert result.exit_code != 0
+
+    def test_missing_profile_reports_issue(self) -> None:
+        result = self._invoke(profile_ok=False)
+        assert result.exit_code != 0
+
+    def test_fix_flag_accepted(self) -> None:
+        result = self._invoke(args=["--fix"])
+        assert result.exit_code == 0
+
+    def test_yes_flag_implies_fix(self) -> None:
+        result = self._invoke(args=["--yes"])
+        assert result.exit_code == 0
+
+    def test_issues_count_shown_on_failure(self) -> None:
+        result = self._invoke(incus_ok=False)
+        assert "issue" in result.output.lower()
+
+    def test_rerun_hint_shown_without_fix(self) -> None:
+        result = self._invoke(profile_ok=False)
+        assert "--fix" in result.output

--- a/tests/unit/test_setup_rootless.py
+++ b/tests/unit/test_setup_rootless.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from waydroid_toolkit.cli.commands.setup_rootless import cmd

--- a/tests/unit/test_tui_cmd.py
+++ b/tests/unit/test_tui_cmd.py
@@ -1,0 +1,42 @@
+"""Tests for wdt tui."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.tui import cmd, _detect_dialog
+
+
+class TestDetectDialog:
+    def test_finds_dialog(self) -> None:
+        with patch("shutil.which", side_effect=lambda p: "/usr/bin/dialog" if p == "dialog" else None):
+            assert _detect_dialog() == "dialog"
+
+    def test_falls_back_to_whiptail(self) -> None:
+        with patch("shutil.which", side_effect=lambda p: "/usr/bin/whiptail" if p == "whiptail" else None):
+            assert _detect_dialog() == "whiptail"
+
+    def test_returns_empty_when_neither_found(self) -> None:
+        with patch("shutil.which", return_value=None):
+            assert _detect_dialog() == ""
+
+
+class TestTuiCommand:
+    def test_no_dialog_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.tui._detect_dialog", return_value=""):
+            result = runner.invoke(cmd, [])
+        assert result.exit_code != 0
+        assert "dialog" in result.output.lower() or "whiptail" in result.output.lower()
+
+    def test_keyboard_interrupt_exits_cleanly(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.tui._detect_dialog", return_value="dialog"), \
+             patch("waydroid_toolkit.cli.commands.tui._menu", side_effect=KeyboardInterrupt):
+            result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+
+    def test_cmd_has_correct_name(self) -> None:
+        assert cmd.name == "tui"


### PR DESCRIPTION
## Changes

### New commands

- `wdt setup-rootless` — checks/fixes incus-user daemon, binder module, subuid/subgid, waydroid profile, and waydroid-container.service. Supports `--fix` and `--yes` flags.
- `wdt tui` — dialog/whiptail menu covering status, container lifecycle, backup, images/profiles, fleet, publish, disk, config, doctor, and setup-rootless.
- `wdt dashboard` — stdlib HTTP server (no extra deps) serving a single-page HTML dashboard with live container status, auto-refreshing every 5 s. Supports `--port` and `--bind` options.

### Tests

29 new tests across the three commands. Full suite: **981 passed, 0 failures**.

Brings wdt to feature parity with incusbox and imt.