### PR TITLE
feat(wdt): parity gaps — container start/stop/list, net nic, usb VID:PID, host-exec

### DIFF
--- a/src/waydroid_toolkit/cli/commands/container.py
+++ b/src/waydroid_toolkit/cli/commands/container.py
@@ -27,7 +27,87 @@ def _backend() -> object:
 
 @click.group("container")
 def cmd() -> None:
-    """Manage the Waydroid container (snapshot, console)."""
+    """Manage the Waydroid container (start, stop, list, snapshot, console)."""
+
+
+# ── start / stop / list ───────────────────────────────────────────────────────
+
+@cmd.command("start")
+def container_start() -> None:
+    """Start the Waydroid container."""
+    import subprocess
+    b = _backend()
+    ct = b.get_info().container_name  # type: ignore[attr-defined]
+    console.print(f"Starting container [bold]{ct}[/bold] ...")
+    r = subprocess.run(["incus", "start", ct])
+    if r.returncode != 0:
+        console.print(f"[red]Failed to start '{ct}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]Started:[/green] {ct}")
+
+
+@cmd.command("stop")
+@click.option("--force", is_flag=True, help="Force-stop (incus stop --force).")
+def container_stop(force: bool) -> None:
+    """Stop the Waydroid container."""
+    import subprocess
+    b = _backend()
+    ct = b.get_info().container_name  # type: ignore[attr-defined]
+    console.print(f"Stopping container [bold]{ct}[/bold] ...")
+    cmd_args = ["incus", "stop", ct]
+    if force:
+        cmd_args.append("--force")
+    r = subprocess.run(cmd_args)
+    if r.returncode != 0:
+        console.print(f"[red]Failed to stop '{ct}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]Stopped:[/green] {ct}")
+
+
+@cmd.command("list")
+def container_list() -> None:
+    """List Waydroid containers managed by the active backend."""
+    import json
+    import subprocess
+
+    from rich.table import Table
+
+    r = subprocess.run(
+        ["incus", "list", "--format", "json"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        console.print("[yellow]Could not query Incus.[/yellow]")
+        raise SystemExit(1)
+
+    try:
+        instances = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        instances = []
+
+    containers = [i for i in instances if i.get("type") == "container"]
+    if not containers:
+        console.print("[yellow]No containers found.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("NAME", style="cyan")
+    table.add_column("STATUS")
+    table.add_column("IPV4")
+    for inst in containers:
+        name = inst.get("name", "")
+        status = inst.get("status", "unknown")
+        status_str = f"[green]{status}[/green]" if status == "Running" else status
+        ip = "-"
+        for iface in inst.get("state", {}).get("network", {}).values():
+            for addr in iface.get("addresses", []):
+                if addr.get("family") == "inet" and not addr["address"].startswith("127."):
+                    ip = addr["address"]
+                    break
+            if ip != "-":
+                break
+        table.add_row(name, status_str, ip)
+    console.print(table)
 
 
 # ── snapshot ──────────────────────────────────────────────────────────────────

--- a/src/waydroid_toolkit/cli/commands/host_exec.py
+++ b/src/waydroid_toolkit/cli/commands/host_exec.py
@@ -1,0 +1,86 @@
+"""wdt host-exec — run a host command from inside the Waydroid container.
+
+Executes a command on the host by running it inside the Waydroid container
+via `incus exec`, using nsenter to escape into the host's namespaces.
+Mirrors the incusbox-host-exec pattern.
+
+Usage:
+  wdt host-exec COMMAND [ARGS...]
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import click
+from rich.console import Console
+
+console = Console()
+
+
+def _container_name() -> str:
+    try:
+        from waydroid_toolkit.core.container import get_active as get_backend
+        b = get_backend()
+        return b.get_info().container_name  # type: ignore[attr-defined]
+    except Exception:
+        return "waydroid"
+
+
+@click.command("host-exec")
+@click.argument("command", nargs=-1, required=True)
+@click.option(
+    "--container", "-c", default="",
+    help="Container name (default: active Waydroid container).",
+)
+def cmd(command: tuple[str, ...], container: str) -> None:
+    """Run a host command from inside the Waydroid container via nsenter.
+
+    The command is executed in the host's mount, network, PID, and UTS
+    namespaces by running nsenter inside the container.
+
+    \b
+    Examples:
+      wdt host-exec systemctl --user status
+      wdt host-exec flatpak run org.mozilla.firefox
+      wdt host-exec bash
+    """
+    ct = container or _container_name()
+
+    # Build the nsenter invocation that runs inside the container.
+    # /proc/1/ns/* inside the container points to the host's PID 1 namespaces
+    # when the container shares the host PID namespace (Incus default for
+    # privileged containers). For unprivileged containers the fallback is
+    # chroot /run/host.
+    nsenter_cmd = [
+        "nsenter",
+        "--mount=/proc/1/ns/mnt",
+        "--uts=/proc/1/ns/uts",
+        "--ipc=/proc/1/ns/ipc",
+        "--net=/proc/1/ns/net",
+        "--pid=/proc/1/ns/pid",
+        "--target=1",
+        "--",
+        *command,
+    ]
+
+    incus_exec = [
+        "incus", "exec", ct,
+        "--",
+        "sh", "-c",
+        # Try nsenter first; fall back to chroot /run/host if /proc/1/ns/mnt
+        # is not readable (unprivileged container without SYS_PTRACE).
+        f"if [ -r /proc/1/ns/mnt ]; then "
+        f"exec {' '.join(_shell_quote(a) for a in nsenter_cmd)}; "
+        f"else exec chroot /run/host {' '.join(_shell_quote(a) for a in command)}; fi",
+    ]
+
+    result = subprocess.run(incus_exec)
+    sys.exit(result.returncode)
+
+
+def _shell_quote(s: str) -> str:
+    """Minimal shell quoting for embedding in a sh -c string."""
+    import shlex
+    return shlex.quote(s)

--- a/src/waydroid_toolkit/cli/commands/net.py
+++ b/src/waydroid_toolkit/cli/commands/net.py
@@ -122,6 +122,86 @@ def net_list() -> None:
     console.print(table)
 
 
+@cmd.group("nic")
+def net_nic() -> None:
+    """Manage network interfaces (NICs) on the Waydroid container."""
+
+
+@net_nic.command("add")
+@click.argument("nic_name")
+@click.option("--network", default="incusbr0", show_default=True,
+              help="Incus network bridge to attach to.")
+@click.option("--type", "nic_type", default="bridged",
+              type=click.Choice(["bridged", "macvlan", "ipvlan", "p2p", "routed"]),
+              show_default=True, help="NIC device type.")
+def nic_add(nic_name: str, network: str, nic_type: str) -> None:
+    """Add a network interface to the Waydroid container.
+
+    NIC_NAME is the device name inside Incus (e.g. eth1).
+    """
+    ct = _container_name()
+    console.print(f"Adding NIC [bold]{nic_name}[/bold] ({nic_type}, network={network}) to '{ct}' ..."  # noqa: E501
+                  )
+    result = subprocess.run([
+        "incus", "config", "device", "add", ct, nic_name, "nic",
+        f"nictype={nic_type}",
+        f"parent={network}",
+        f"name={nic_name}",
+    ])
+    if result.returncode != 0:
+        console.print(f"[red]Failed to add NIC '{nic_name}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]NIC added:[/green] {nic_name} → {network}")
+
+
+@net_nic.command("remove")
+@click.argument("nic_name")
+def nic_remove(nic_name: str) -> None:
+    """Remove a network interface from the Waydroid container."""
+    ct = _container_name()
+    result = subprocess.run(["incus", "config", "device", "remove", ct, nic_name])
+    if result.returncode != 0:
+        console.print(f"[red]Failed to remove NIC '{nic_name}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]NIC removed:[/green] {nic_name}")
+
+
+@net_nic.command("list")
+def nic_list() -> None:
+    """List network interface devices on the Waydroid container."""
+    ct = _container_name()
+    list_r = subprocess.run(
+        ["incus", "config", "device", "list", ct],
+        capture_output=True, text=True,
+    )
+    if list_r.returncode != 0:
+        console.print("[yellow]Could not list devices.[/yellow]")
+        return
+    nic_devices = [
+        line.split()[0] for line in list_r.stdout.splitlines()
+        if "nic" in line
+    ]
+    if not nic_devices:
+        console.print("[yellow]No NIC devices configured.[/yellow]")
+        return
+    from rich.table import Table as _Table
+    table = _Table(show_header=True, header_style="bold")
+    table.add_column("DEVICE", style="cyan")
+    table.add_column("TYPE")
+    table.add_column("NETWORK")
+    for dev in nic_devices:
+        t_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "nictype"],
+            capture_output=True, text=True,
+        )
+        n_r = subprocess.run(
+            ["incus", "config", "device", "get", ct, dev, "parent"],
+            capture_output=True, text=True,
+        )
+        table.add_row(dev, t_r.stdout.strip() or "?", n_r.stdout.strip() or "?")
+    console.print(table)
+
+
 @cmd.command("status")
 def net_status() -> None:
     """Show network interfaces and port forwards for the container."""

--- a/src/waydroid_toolkit/cli/commands/usb.py
+++ b/src/waydroid_toolkit/cli/commands/usb.py
@@ -69,13 +69,23 @@ def usb_list_host() -> None:
 
 @cmd.command("attach")
 @click.argument("vendor_id")
-@click.argument("product_id")
+@click.argument("product_id", required=False, default=None)
 @click.option("--dev-name", default="", help="Device name (default: usb-<VID>-<PID>).")
-def usb_attach(vendor_id: str, product_id: str, dev_name: str) -> None:
+def usb_attach(vendor_id: str, product_id: str | None, dev_name: str) -> None:
     """Attach a USB device to the container by vendor and product ID.
 
-    VENDOR_ID and PRODUCT_ID are 4-digit hex values (e.g. 046d c52b).
+    Accepts either two separate arguments (VENDOR_ID PRODUCT_ID) or a single
+    VID:PID string (e.g. 046d:c52b).
     """
+    # Support VID:PID shorthand as a single argument
+    if product_id is None:
+        if ":" in vendor_id:
+            vendor_id, product_id = vendor_id.split(":", 1)
+        else:
+            raise click.UsageError(
+                "Provide VENDOR_ID PRODUCT_ID or a single VID:PID string (e.g. 046d:c52b)."
+            )
+
     ct = _container_name()
     pname = dev_name or f"usb-{vendor_id}-{product_id}"
 

--- a/src/waydroid_toolkit/cli/main.py
+++ b/src/waydroid_toolkit/cli/main.py
@@ -20,6 +20,7 @@ Commands:
     setup-rootless  Configure the system for rootless Waydroid operation
     tui             Launch interactive terminal UI (requires dialog or whiptail)
     dashboard       Serve a web monitoring dashboard for Waydroid containers
+    host-exec       Run a host command from inside the Waydroid container
     disk          Live disk resize for the Waydroid container
     profiles      Manage Waydroid image profiles
     upgrade       Upgrade the Waydroid Android image via OTA
@@ -52,6 +53,7 @@ from .commands import (
     extensions,
     fleet,
     gpu,
+    host_exec,
     images,
     install,
     maintenance,
@@ -122,6 +124,7 @@ cli.add_command(config.cmd, name="config")
 cli.add_command(setup_rootless.cmd, name="setup-rootless")
 cli.add_command(tui.cmd, name="tui")
 cli.add_command(dashboard.cmd, name="dashboard")
+cli.add_command(host_exec.cmd, name="host-exec")
 cli.add_command(disk.cmd, name="disk")
 cli.add_command(profiles.cmd, name="profiles")
 cli.add_command(upgrade.cmd, name="upgrade")

--- a/tests/unit/test_container_lifecycle.py
+++ b/tests/unit/test_container_lifecycle.py
@@ -1,0 +1,129 @@
+"""Tests for wdt container start/stop/list."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.container import container_start, container_stop, container_list
+
+
+def _make_run(returncode: int = 0, stdout: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    return m
+
+
+def _patch_backend(ct_name: str = "waydroid") -> list:
+    info = MagicMock()
+    info.container_name = ct_name
+    backend = MagicMock()
+    backend.get_info.return_value = info
+    return [patch("waydroid_toolkit.cli.commands.container.get_backend", return_value=backend)]
+
+
+class TestContainerStart:
+    def test_start_success(self) -> None:
+        runner = CliRunner()
+        patches = _patch_backend()
+        for p in patches:
+            p.start()
+        with patch("subprocess.run", return_value=_make_run(0)):
+            result = runner.invoke(container_start, [])
+        for p in patches:
+            p.stop()
+        assert result.exit_code == 0
+        assert "Started" in result.output
+
+    def test_start_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        patches = _patch_backend()
+        for p in patches:
+            p.start()
+        with patch("subprocess.run", return_value=_make_run(1)):
+            result = runner.invoke(container_start, [])
+        for p in patches:
+            p.stop()
+        assert result.exit_code != 0
+
+
+class TestContainerStop:
+    def test_stop_success(self) -> None:
+        runner = CliRunner()
+        patches = _patch_backend()
+        for p in patches:
+            p.start()
+        with patch("subprocess.run", return_value=_make_run(0)):
+            result = runner.invoke(container_stop, [])
+        for p in patches:
+            p.stop()
+        assert result.exit_code == 0
+        assert "Stopped" in result.output
+
+    def test_stop_force_flag(self) -> None:
+        runner = CliRunner()
+        patches = _patch_backend()
+        for p in patches:
+            p.start()
+        calls = []
+        def _run(args, **_kw):
+            calls.append(args)
+            return _make_run(0)
+        with patch("subprocess.run", side_effect=_run):
+            result = runner.invoke(container_stop, ["--force"])
+        for p in patches:
+            p.stop()
+        assert result.exit_code == 0
+        assert "--force" in calls[0]
+
+    def test_stop_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        patches = _patch_backend()
+        for p in patches:
+            p.start()
+        with patch("subprocess.run", return_value=_make_run(1)):
+            result = runner.invoke(container_stop, [])
+        for p in patches:
+            p.stop()
+        assert result.exit_code != 0
+
+
+class TestContainerList:
+    def test_empty_when_no_containers(self) -> None:
+        runner = CliRunner()
+        with patch("subprocess.run", return_value=_make_run(0, "[]")):
+            result = runner.invoke(container_list, [])
+        assert result.exit_code == 0
+        assert "No containers" in result.output
+
+    def test_lists_containers(self) -> None:
+        import json
+        instances = json.dumps([
+            {"name": "waydroid", "type": "container", "status": "Running",
+             "state": {"network": {}}},
+        ])
+        runner = CliRunner()
+        with patch("subprocess.run", return_value=_make_run(0, instances)):
+            result = runner.invoke(container_list, [])
+        assert result.exit_code == 0
+        assert "waydroid" in result.output
+
+    def test_filters_vms(self) -> None:
+        import json
+        instances = json.dumps([
+            {"name": "vm1", "type": "virtual-machine", "status": "Running",
+             "state": {"network": {}}},
+        ])
+        runner = CliRunner()
+        with patch("subprocess.run", return_value=_make_run(0, instances)):
+            result = runner.invoke(container_list, [])
+        assert result.exit_code == 0
+        assert "No containers" in result.output
+
+    def test_incus_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with patch("subprocess.run", return_value=_make_run(1)):
+            result = runner.invoke(container_list, [])
+        assert result.exit_code != 0

--- a/tests/unit/test_host_exec.py
+++ b/tests/unit/test_host_exec.py
@@ -1,0 +1,67 @@
+"""Tests for wdt host-exec."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.host_exec import cmd
+
+
+def _make_run(returncode: int = 0) -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    return m
+
+
+class TestHostExec:
+    def test_runs_command_in_container(self) -> None:
+        runner = CliRunner()
+        calls = []
+        def _run(args, **_kw):
+            calls.append(args)
+            return _make_run(0)
+        with patch("waydroid_toolkit.cli.commands.host_exec._container_name",
+                   return_value="waydroid"), \
+             patch("waydroid_toolkit.cli.commands.host_exec.subprocess.run", side_effect=_run):
+            # Use -- to prevent Click treating subsequent args as options
+            runner.invoke(cmd, ["--", "ls", "-la"])
+        assert len(calls) == 1
+        assert "incus" in calls[0]
+        assert "exec" in calls[0]
+        assert "waydroid" in calls[0]
+
+    def test_custom_container_flag(self) -> None:
+        runner = CliRunner()
+        calls = []
+        def _run(args, **_kw):
+            calls.append(args)
+            return _make_run(0)
+        with patch("waydroid_toolkit.cli.commands.host_exec._container_name",
+                   return_value="waydroid"), \
+             patch("waydroid_toolkit.cli.commands.host_exec.subprocess.run", side_effect=_run):
+            runner.invoke(cmd, ["--container", "myct", "ls"])
+        assert "myct" in calls[0]
+
+    def test_no_command_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cmd, [])
+        assert result.exit_code != 0
+
+    def test_exit_code_propagated(self) -> None:
+        runner = CliRunner()
+        exit_codes: list[int] = []
+        real_exit = __import__("sys").exit
+
+        def _capturing_exit(code: int) -> None:
+            exit_codes.append(code)
+            real_exit(code)
+
+        with patch("waydroid_toolkit.cli.commands.host_exec._container_name",
+                   return_value="waydroid"), \
+             patch("subprocess.run", return_value=_make_run(42)), \
+             patch("waydroid_toolkit.cli.commands.host_exec.sys.exit",
+                   side_effect=_capturing_exit):
+            runner.invoke(cmd, ["false"])
+        assert exit_codes[0] == 42

--- a/tests/unit/test_net_nic.py
+++ b/tests/unit/test_net_nic.py
@@ -1,0 +1,87 @@
+"""Tests for wdt net nic add/remove/list."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.net import nic_add, nic_remove, nic_list
+
+
+def _make_run(returncode: int = 0, stdout: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    return m
+
+
+class TestNicAdd:
+    def test_add_success(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.net._container_name", return_value="waydroid"), \
+             patch("subprocess.run", return_value=_make_run(0)):
+            result = runner.invoke(nic_add, ["eth1"])
+        assert result.exit_code == 0
+        assert "added" in result.output.lower()
+
+    def test_add_custom_network(self) -> None:
+        runner = CliRunner()
+        calls = []
+        def _run(args, **_kw):
+            calls.append(args)
+            return _make_run(0)
+        with patch("waydroid_toolkit.cli.commands.net._container_name", return_value="waydroid"), \
+             patch("subprocess.run", side_effect=_run):
+            result = runner.invoke(nic_add, ["eth1", "--network", "mybr0"])
+        assert result.exit_code == 0
+        assert any("parent=mybr0" in a for a in calls[0])
+
+    def test_add_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.net._container_name", return_value="waydroid"), \
+             patch("subprocess.run", return_value=_make_run(1)):
+            result = runner.invoke(nic_add, ["eth1"])
+        assert result.exit_code != 0
+
+
+class TestNicRemove:
+    def test_remove_success(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.net._container_name", return_value="waydroid"), \
+             patch("subprocess.run", return_value=_make_run(0)):
+            result = runner.invoke(nic_remove, ["eth1"])
+        assert result.exit_code == 0
+        assert "removed" in result.output.lower()
+
+    def test_remove_failure_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.net._container_name", return_value="waydroid"), \
+             patch("subprocess.run", return_value=_make_run(1)):
+            result = runner.invoke(nic_remove, ["eth1"])
+        assert result.exit_code != 0
+
+
+class TestNicList:
+    def test_no_nics(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.net._container_name", return_value="waydroid"), \
+             patch("subprocess.run", return_value=_make_run(0, "")):
+            result = runner.invoke(nic_list, [])
+        assert result.exit_code == 0
+        assert "No NIC" in result.output
+
+    def test_lists_nics(self) -> None:
+        runner = CliRunner()
+        device_list = "eth1  nic\n"
+
+        def _run(args, **_kw):
+            if "list" in args:
+                return _make_run(0, device_list)
+            return _make_run(0, "bridged")
+
+        with patch("waydroid_toolkit.cli.commands.net._container_name", return_value="waydroid"), \
+             patch("subprocess.run", side_effect=_run):
+            result = runner.invoke(nic_list, [])
+        assert result.exit_code == 0
+        assert "eth1" in result.output

--- a/tests/unit/test_usb_vidpid.py
+++ b/tests/unit/test_usb_vidpid.py
@@ -1,0 +1,61 @@
+"""Tests for wdt usb attach VID:PID shorthand."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from waydroid_toolkit.cli.commands.usb import usb_attach
+
+
+def _make_run(returncode: int = 0) -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    return m
+
+
+class TestUsbAttachShorthand:
+    def test_vidpid_shorthand_accepted(self) -> None:
+        runner = CliRunner()
+        calls = []
+        def _run(args, **_kw):
+            calls.append(args)
+            return _make_run(0)
+        with patch("waydroid_toolkit.cli.commands.usb._container_name", return_value="waydroid"), \
+             patch("subprocess.run", side_effect=_run):
+            result = runner.invoke(usb_attach, ["046d:c52b"])
+        assert result.exit_code == 0
+        assert any("vendorid=046d" in a for a in calls[0])
+        assert any("productid=c52b" in a for a in calls[0])
+
+    def test_two_arg_form_still_works(self) -> None:
+        runner = CliRunner()
+        calls = []
+        def _run(args, **_kw):
+            calls.append(args)
+            return _make_run(0)
+        with patch("waydroid_toolkit.cli.commands.usb._container_name", return_value="waydroid"), \
+             patch("subprocess.run", side_effect=_run):
+            result = runner.invoke(usb_attach, ["046d", "c52b"])
+        assert result.exit_code == 0
+        assert any("vendorid=046d" in a for a in calls[0])
+        assert any("productid=c52b" in a for a in calls[0])
+
+    def test_missing_product_id_errors(self) -> None:
+        runner = CliRunner()
+        with patch("waydroid_toolkit.cli.commands.usb._container_name", return_value="waydroid"):
+            result = runner.invoke(usb_attach, ["046d"])
+        assert result.exit_code != 0
+
+    def test_custom_dev_name(self) -> None:
+        runner = CliRunner()
+        calls = []
+        def _run(args, **_kw):
+            calls.append(args)
+            return _make_run(0)
+        with patch("waydroid_toolkit.cli.commands.usb._container_name", return_value="waydroid"), \
+             patch("subprocess.run", side_effect=_run):
+            result = runner.invoke(usb_attach, ["046d:c52b", "--dev-name", "myusb"])
+        assert result.exit_code == 0
+        assert "myusb" in calls[0]


### PR DESCRIPTION
## Changes

- `wdt container start/stop/list`: explicit lifecycle commands for the Waydroid container
- `wdt net nic add/remove/list`: NIC management subgroup (present in iwt)
- `wdt usb attach`: accept `VID:PID` as a single argument (e.g. `046d:c52b`) in addition to the existing two-argument form
- `wdt host-exec COMMAND`: run a host command from inside the container via `incus exec` + nsenter, mirroring `incusbox host-exec`

## Tests

24 new tests. Full suite: **1005 passed, 0 failures**.