### PR TITLE
feat(wdt): add snapshot auto subcommand

### DIFF
--- a/src/waydroid_toolkit/cli/commands/snapshot.py
+++ b/src/waydroid_toolkit/cli/commands/snapshot.py
@@ -14,6 +14,63 @@ def cmd() -> None:
     """Create, list, restore, and delete Waydroid snapshots."""
 
 
+# ── auto subgroup ─────────────────────────────────────────────────────────────
+
+@cmd.group("auto")
+def snapshot_auto() -> None:
+    """Manage automatic snapshot schedules (Incus backend only)."""
+
+
+@snapshot_auto.command("set")
+@click.argument("schedule")
+@click.option("--expiry", default="", help="Auto-delete snapshots after this duration (e.g. 7d, 30d, 24h).")
+@click.option("--pattern", default="snap-%d", show_default=True,
+              help="Naming pattern for auto-snapshots (%d replaced by a counter).")
+def auto_set(schedule: str, expiry: str, pattern: str) -> None:
+    """Configure a cron-style schedule for automatic snapshots.
+
+    SCHEDULE accepts cron expressions or shorthand:
+    @hourly, @daily, @weekly, @monthly, or "0 6 * * *".
+    """
+    backend = _get_incus_backend()
+    try:
+        backend.snapshot_auto_set(schedule, expiry=expiry, pattern=pattern)
+    except (RuntimeError, NotImplementedError) as e:
+        console.print(f"[red]{e}[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]Auto-snapshot configured[/green]")
+    console.print(f"  Schedule : {schedule}")
+    console.print(f"  Pattern  : {pattern}")
+    if expiry:
+        console.print(f"  Expiry   : {expiry}")
+
+
+@snapshot_auto.command("show")
+def auto_show() -> None:
+    """Display the current auto-snapshot schedule, expiry, and pattern."""
+    backend = _get_incus_backend()
+    try:
+        info = backend.snapshot_auto_show()
+    except (RuntimeError, NotImplementedError) as e:
+        console.print(f"[red]{e}[/red]")
+        raise SystemExit(1)
+    console.print(f"  Schedule : {info.get('schedule', '(not set)')}")
+    console.print(f"  Expiry   : {info.get('expiry', '(not set)')}")
+    console.print(f"  Pattern  : {info.get('pattern', '(not set)')}")
+
+
+@snapshot_auto.command("disable")
+def auto_disable() -> None:
+    """Remove the automatic snapshot schedule."""
+    backend = _get_incus_backend()
+    try:
+        backend.snapshot_auto_disable()
+    except (RuntimeError, NotImplementedError) as e:
+        console.print(f"[red]{e}[/red]")
+        raise SystemExit(1)
+    console.print("[green]Auto-snapshot disabled.[/green]")
+
+
 @cmd.command("create")
 @click.argument("label", default="", required=False)
 @click.option("--backend", type=click.Choice(["zfs", "btrfs", "auto"]),
@@ -114,3 +171,17 @@ def _get_backend(choice: str):  # type: ignore[return]
     except RuntimeError as e:
         console.print(f"[red]{e}[/red]")
         raise SystemExit(1)
+
+
+def _get_incus_backend():  # type: ignore[return]
+    """Return the IncusBackend, or exit with an error if unavailable."""
+    from waydroid_toolkit.core.container import IncusBackend
+
+    backend = IncusBackend()
+    if not backend.is_available():
+        console.print(
+            "[red]Auto-snapshot scheduling requires the Incus backend.[/red]\n"
+            "Switch with: wdt backend switch incus"
+        )
+        raise SystemExit(1)
+    return backend

--- a/src/waydroid_toolkit/cli/commands/snapshot.py
+++ b/src/waydroid_toolkit/cli/commands/snapshot.py
@@ -23,7 +23,8 @@ def snapshot_auto() -> None:
 
 @snapshot_auto.command("set")
 @click.argument("schedule")
-@click.option("--expiry", default="", help="Auto-delete snapshots after this duration (e.g. 7d, 30d, 24h).")
+@click.option("--expiry", default="",
+              help="Auto-delete snapshots after this duration (e.g. 7d, 30d, 24h).")
 @click.option("--pattern", default="snap-%d", show_default=True,
               help="Naming pattern for auto-snapshots (%d replaced by a counter).")
 def auto_set(schedule: str, expiry: str, pattern: str) -> None:
@@ -38,7 +39,7 @@ def auto_set(schedule: str, expiry: str, pattern: str) -> None:
     except (RuntimeError, NotImplementedError) as e:
         console.print(f"[red]{e}[/red]")
         raise SystemExit(1)
-    console.print(f"[green]Auto-snapshot configured[/green]")
+    console.print("[green]Auto-snapshot configured[/green]")
     console.print(f"  Schedule : {schedule}")
     console.print(f"  Pattern  : {pattern}")
     if expiry:


### PR DESCRIPTION
Adds `wdt snapshot auto set/show/disable` subcommands backed by the existing `IncusBackend.snapshot_auto_{set,show,disable}` methods. Requires the Incus backend; exits with a clear error message on LXC.