### PR TITLE
feat(wdt): add profiles incus subgroup

### DIFF
--- a/data/profiles/waydroid.yaml
+++ b/data/profiles/waydroid.yaml
@@ -1,0 +1,33 @@
+# Incus profile for Waydroid containers.
+# Install with: wdt profiles incus install
+# Apply with:   wdt profiles incus apply <container> waydroid
+description: Waydroid Android container (binder, ashmem, tmpfs mounts)
+config:
+  raw.lxc: |
+    lxc.apparmor.profile=unconfined
+    lxc.cap.drop=
+    lxc.cgroup.devices.allow=a
+    lxc.mount.auto=proc:rw sys:rw cgroup:rw
+  security.nesting: "true"
+  security.privileged: "true"
+devices:
+  binder:
+    path: /dev/binder
+    source: /dev/binder
+    type: unix-char
+  vndbinder:
+    path: /dev/vndbinder
+    source: /dev/vndbinder
+    type: unix-char
+  hwbinder:
+    path: /dev/hwbinder
+    source: /dev/hwbinder
+    type: unix-char
+  ashmem:
+    path: /dev/ashmem
+    source: /dev/ashmem
+    type: unix-char
+  fuse:
+    path: /dev/fuse
+    source: /dev/fuse
+    type: unix-char

--- a/src/waydroid_toolkit/cli/commands/profiles.py
+++ b/src/waydroid_toolkit/cli/commands/profiles.py
@@ -1,19 +1,25 @@
-"""wdt profiles — manage Waydroid image profiles.
+"""wdt profiles — manage Waydroid image profiles and Incus profiles.
 
-An image profile is a directory containing a system.img + vendor.img pair.
-Profiles live under ~/waydroid-images/ by default.
+Image profiles (system.img + vendor.img pairs):
+  wdt profiles list              List available image profiles
+  wdt profiles show <name>       Show details for an image profile
+  wdt profiles switch <name>     Switch the active image profile
+  wdt profiles active            Print the currently active image profile
+  wdt profiles add <path>        Register a directory as a named image profile
 
-Sub-commands
-------------
-  wdt profiles list              List available profiles
-  wdt profiles show <name>       Show details for a profile
-  wdt profiles switch <name>     Switch the active profile
-  wdt profiles active            Print the currently active profile
-  wdt profiles add <path>        Register a directory as a named profile
+Incus profiles (YAML config applied to containers):
+  wdt profiles incus list              List available Incus profile files
+  wdt profiles incus show <name>       Print a profile's YAML
+  wdt profiles incus install [--all] [name]  Install profile(s) into Incus
+  wdt profiles incus diff              Compare local files with Incus
+  wdt profiles incus apply <ct> <name> Apply a profile to a container
+  wdt profiles incus remove <ct> <name> Remove a profile from a container
 """
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
 
 import click
@@ -29,6 +35,54 @@ from waydroid_toolkit.modules.images import (
 console = Console()
 
 _DEFAULT_BASE = Path.home() / "waydroid-images"
+
+# Search order for bundled Incus profile YAML files
+_INCUS_PROFILE_DIRS = [
+    Path(__file__).parents[4] / "data" / "profiles",
+    Path.home() / ".local" / "share" / "waydroid-toolkit" / "profiles",
+    Path("/usr/local/share/waydroid-toolkit/profiles"),
+    Path("/usr/share/waydroid-toolkit/profiles"),
+]
+
+
+def _find_incus_profile_dir() -> Path:
+    for d in _INCUS_PROFILE_DIRS:
+        if d.is_dir():
+            return d
+    raise RuntimeError(
+        "No Incus profile directory found. "
+        "Expected one of: " + ", ".join(str(d) for d in _INCUS_PROFILE_DIRS)
+    )
+
+
+def _find_incus_profile_file(name: str) -> Path:
+    for d in _INCUS_PROFILE_DIRS:
+        f = d / f"{name}.yaml"
+        if f.exists():
+            return f
+    raise FileNotFoundError(f"Incus profile not found: {name}")
+
+
+def _require_incus() -> None:
+    if not shutil.which("incus"):
+        console.print("[red]incus is not installed or not in PATH.[/red]")
+        raise SystemExit(1)
+
+
+def _install_one(name: str, path: Path) -> None:
+    exists = subprocess.run(
+        ["incus", "profile", "show", name],
+        capture_output=True,
+    ).returncode == 0
+    if exists:
+        with path.open() as fh:
+            subprocess.run(["incus", "profile", "edit", name], stdin=fh, check=True)
+        console.print(f"  [cyan]updated[/cyan] : {name}")
+    else:
+        subprocess.run(["incus", "profile", "create", name], check=True)
+        with path.open() as fh:
+            subprocess.run(["incus", "profile", "edit", name], stdin=fh, check=True)
+        console.print(f"  [green]created[/green] : {name}")
 
 
 @click.group("profiles")
@@ -158,7 +212,7 @@ def profiles_switch(name: str, base: str | None) -> None:
 @click.argument("path")
 @click.option("--name", "-n", default="",
               help="Profile name (default: directory basename).")
-def profiles_add(path: str, name: str) -> None:
+def profiles_add(path: str, name: str) -> None:  # noqa: A002
     """Register PATH as a named profile by symlinking it under ~/waydroid-images.
 
     PATH must contain system.img and vendor.img.
@@ -190,3 +244,164 @@ def profiles_add(path: str, name: str) -> None:
     console.print(f"[green]Registered profile '{profile_name}'[/green]")
     console.print(f"  {dest} → {src}")
     console.print(f"Switch with: wdt profiles switch {profile_name}")
+
+
+# ── incus subgroup ────────────────────────────────────────────────────────────
+
+@cmd.group("incus")
+def profiles_incus() -> None:
+    """Manage Incus profiles for Waydroid containers."""
+
+
+@profiles_incus.command("list")
+def incus_list() -> None:
+    """List available Incus profile files."""
+    try:
+        profile_dir = _find_incus_profile_dir()
+    except RuntimeError as e:
+        console.print(f"[red]{e}[/red]")
+        raise SystemExit(1)
+
+    files = sorted(profile_dir.glob("*.yaml"))
+    if not files:
+        console.print(f"[yellow]No profile files found in {profile_dir}[/yellow]")
+        return
+
+    console.print(f"Available profiles ({profile_dir}):\n")
+    for f in files:
+        pname = f.stem
+        desc = ""
+        for line in f.read_text().splitlines():
+            if line.startswith("description:"):
+                desc = line.split(":", 1)[-1].strip().strip('"')
+                break
+        if desc:
+            console.print(f"  [cyan]{pname:<30}[/cyan]  {desc}")
+        else:
+            console.print(f"  [cyan]{pname}[/cyan]")
+
+    console.print("\nInstall with: wdt profiles incus install")
+
+
+@profiles_incus.command("show")
+@click.argument("name")
+def incus_show(name: str) -> None:
+    """Print the YAML for a named Incus profile."""
+    try:
+        path = _find_incus_profile_file(name)
+    except FileNotFoundError as e:
+        console.print(f"[red]{e}[/red]")
+        raise SystemExit(1)
+    console.print(path.read_text(), end="")
+
+
+@profiles_incus.command("install")
+@click.argument("names", nargs=-1)
+@click.option("--all", "install_all", is_flag=True,
+              help="Install all available profiles.")
+def incus_install(names: tuple[str, ...], install_all: bool) -> None:
+    """Install Incus profile(s) into the local Incus daemon.
+
+    With no arguments, installs all profiles found in the profile directory.
+    """
+    _require_incus()
+    try:
+        profile_dir = _find_incus_profile_dir()
+    except RuntimeError as e:
+        console.print(f"[red]{e}[/red]")
+        raise SystemExit(1)
+
+    if install_all or not names:
+        files = sorted(profile_dir.glob("*.yaml"))
+        if not files:
+            console.print(f"[yellow]No profile files found in {profile_dir}[/yellow]")
+            return
+        for f in files:
+            _install_one(f.stem, f)
+    else:
+        for name in names:
+            try:
+                path = _find_incus_profile_file(name)
+            except FileNotFoundError as e:
+                console.print(f"[red]{e}[/red]")
+                raise SystemExit(1)
+            _install_one(name, path)
+
+
+@profiles_incus.command("diff")
+def incus_diff() -> None:
+    """Compare local profile files with what is installed in Incus."""
+    _require_incus()
+    try:
+        profile_dir = _find_incus_profile_dir()
+    except RuntimeError as e:
+        console.print(f"[red]{e}[/red]")
+        raise SystemExit(1)
+
+    files = sorted(profile_dir.glob("*.yaml"))
+    if not files:
+        console.print(f"[yellow]No profile files found in {profile_dir}[/yellow]")
+        return
+
+    for f in files:
+        pname = f.stem
+        result = subprocess.run(
+            ["incus", "profile", "show", pname],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            console.print(
+                f"  [yellow]{pname}[/yellow]: not installed in Incus "
+                f"(run: wdt profiles incus install {pname})"
+            )
+            continue
+
+        import difflib
+        incus_lines = result.stdout.splitlines(keepends=True)
+        local_lines = f.read_text().splitlines(keepends=True)
+        diff = list(difflib.unified_diff(
+            incus_lines, local_lines,
+            fromfile=f"incus:{pname}", tofile=f"local:{f}",
+        ))
+        if diff:
+            console.print(f"[bold]--- {pname} (incus vs local) ---[/bold]")
+            for line in diff:
+                line = line.rstrip("\n")
+                if line.startswith("+"):
+                    console.print(f"[green]{line}[/green]")
+                elif line.startswith("-"):
+                    console.print(f"[red]{line}[/red]")
+                else:
+                    console.print(line)
+        else:
+            console.print(f"  [green]{pname}[/green]: in sync")
+
+
+@profiles_incus.command("apply")
+@click.argument("container")
+@click.argument("profile")
+def incus_apply(container: str, profile: str) -> None:
+    """Apply PROFILE to CONTAINER."""
+    _require_incus()
+    exists = subprocess.run(
+        ["incus", "profile", "show", profile],
+        capture_output=True,
+    ).returncode == 0
+    if not exists:
+        console.print(
+            f"[red]Profile '{profile}' not installed in Incus.[/red]\n"
+            f"Run: wdt profiles incus install {profile}"
+        )
+        raise SystemExit(1)
+    subprocess.run(["incus", "profile", "add", container, profile], check=True)
+    console.print(f"[green]Applied profile '{profile}' to '{container}'[/green]")
+
+
+@profiles_incus.command("remove")
+@click.argument("container")
+@click.argument("profile")
+def incus_remove(container: str, profile: str) -> None:
+    """Remove PROFILE from CONTAINER."""
+    _require_incus()
+    subprocess.run(["incus", "profile", "remove", container, profile], check=True)
+    console.print(f"[green]Removed profile '{profile}' from '{container}'[/green]")


### PR DESCRIPTION
Adds `wdt profiles incus list/show/install/diff/apply/remove` subcommands, matching the `profiles` command in incusbox, imt, and iwt.

The existing `wdt profiles` commands manage Waydroid image profiles (system.img/vendor.img pairs). The new `incus` subgroup manages Incus profiles (YAML config applied to containers), which is a distinct concept.

Also adds `data/profiles/waydroid.yaml` — the bundled Incus profile for Waydroid containers, already referenced by `setup_rootless.py` but missing from the repo.