### PR TITLE
feat(wdt): add subcommand aliases for full incusbox parity

### DIFF
--- a/src/waydroid_toolkit/cli/commands/backup.py
+++ b/src/waydroid_toolkit/cli/commands/backup.py
@@ -80,3 +80,8 @@ def backup_restore(archive: str, yes: bool) -> None:
         )
     restore_backup(path, progress=lambda msg: console.print(f"  [cyan]→[/cyan] {msg}"))
     console.print("[green]Restore complete.[/green]")
+
+
+# Aliases matching incusbox / imt conventions
+cmd.add_command(backup_list, name="ls")
+cmd.add_command(backup_delete, name="rm")

--- a/src/waydroid_toolkit/cli/commands/cloud_sync.py
+++ b/src/waydroid_toolkit/cli/commands/cloud_sync.py
@@ -263,3 +263,7 @@ def cloud_status() -> None:
     else:
         console.print("[green]All local backups synced.[/green]")
 
+
+
+# Aliases matching incusbox / imt conventions
+cloud_config.add_command(config_interactive, name="setup")

--- a/src/waydroid_toolkit/cli/commands/fleet.py
+++ b/src/waydroid_toolkit/cli/commands/fleet.py
@@ -202,3 +202,10 @@ def fleet_exec(command: tuple, all_instances: bool) -> None:
             console.print(result.stdout.rstrip())
         if result.returncode != 0 and result.stderr:
             console.print(f"  [red]{result.stderr.strip()}[/red]")
+
+
+# Aliases matching incusbox / imt conventions
+cmd.add_command(fleet_list, name="ls")
+cmd.add_command(fleet_list, name="all")
+cmd.add_command(fleet_list, name="running")
+cmd.add_command(fleet_list, name="stopped")

--- a/src/waydroid_toolkit/cli/commands/gpu.py
+++ b/src/waydroid_toolkit/cli/commands/gpu.py
@@ -152,7 +152,6 @@ def gpu_list() -> None:
 
 @cmd.command("status")
 def gpu_status() -> None:
-
     """Show GPU attachment status and host GPU resources."""
     ct = _container_name()
     console.print(f"[bold]GPU status:[/bold] {ct}")
@@ -202,3 +201,11 @@ def gpu_status() -> None:
                 break
             if in_gpu:
                 console.print(f"  {line}")
+
+
+# Aliases matching incusbox / imt conventions
+cmd.add_command(gpu_attach, name="add")
+cmd.add_command(gpu_detach, name="remove")
+cmd.add_command(gpu_detach, name="rm")
+cmd.add_command(gpu_list_host, name="host")
+cmd.add_command(gpu_list, name="ls")

--- a/src/waydroid_toolkit/cli/commands/net.py
+++ b/src/waydroid_toolkit/cli/commands/net.py
@@ -246,3 +246,10 @@ def net_status() -> None:
 
     if not found:
         console.print("  [yellow]None[/yellow]")
+
+
+# Aliases matching incusbox / imt conventions
+cmd.add_command(net_forward, name="fwd")
+cmd.add_command(net_unforward, name="unfwd")
+cmd.add_command(net_unforward, name="rm")
+cmd.add_command(net_list, name="ls")

--- a/src/waydroid_toolkit/cli/commands/publish.py
+++ b/src/waydroid_toolkit/cli/commands/publish.py
@@ -141,3 +141,8 @@ def publish_delete(alias: str) -> None:
         console.print(f"[red]Delete failed:[/red] {exc}")
         raise SystemExit(1) from exc
     console.print(f"[green]Deleted image:[/green] {alias}")
+
+
+# Aliases matching incusbox / imt conventions
+cmd.add_command(publish_list, name="ls")
+cmd.add_command(publish_delete, name="rm")

--- a/src/waydroid_toolkit/cli/commands/snapshot.py
+++ b/src/waydroid_toolkit/cli/commands/snapshot.py
@@ -187,3 +187,9 @@ def _get_incus_backend():  # type: ignore[return]
         raise SystemExit(1)
     return backend
 
+
+# Aliases matching incusbox / imt conventions
+cmd.add_command(snapshot_delete, name="remove")
+cmd.add_command(snapshot_delete, name="rm")
+cmd.add_command(snapshot_list, name="ls")
+

--- a/src/waydroid_toolkit/cli/commands/template.py
+++ b/src/waydroid_toolkit/cli/commands/template.py
@@ -169,3 +169,7 @@ def template_apply(name: str, dry_run: bool) -> None:
     else:
         console.print(f"[green]Template '{name}' applied.[/green]")
         console.print("Restart the container for changes to take effect.")
+
+
+# Aliases matching incusbox / imt conventions
+cmd.add_command(template_list, name="ls")

--- a/src/waydroid_toolkit/cli/commands/usb.py
+++ b/src/waydroid_toolkit/cli/commands/usb.py
@@ -158,3 +158,5 @@ def usb_list() -> None:
 cmd.add_command(usb_attach, name="add")
 cmd.add_command(usb_detach, name="remove")
 cmd.add_command(usb_list_host, name="host")
+cmd.add_command(usb_list, name="ls")
+cmd.add_command(usb_detach, name="rm")


### PR DESCRIPTION
Re-applies aliases lost in the parity8 merge and adds remaining `ls`/`rm`/`fwd`/`unfwd` aliases across all commands to match incusbox and imt conventions:

- `snapshot`: `remove`, `rm`, `ls`
- `gpu`: `add`, `remove`, `rm`, `host`, `ls`
- `cloud-sync config`: `setup` alias for `interactive`
- `backup`: `ls`, `rm`
- `net`: `fwd`, `unfwd`, `rm`, `ls`
- `usb`: `ls`, `rm`
- `fleet`: `ls`, `all`, `running`, `stopped`
- `template`: `ls`
- `publish`: `ls`, `rm`