### PR TITLE
chore(deps): update 1 workflow dependency

### DIFF
--- a/.github/workflows/mirror-osp-to-ooc.yaml
+++ b/.github/workflows/mirror-osp-to-ooc.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'OpenOS-Project-OSP/waydroid-toolkit'
     steps:
       - name: Checkout full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
Upstreamed from OpenOS-Project-OSP/waydroid-toolkit#3.

---

Automated dependency update for GitHub Actions workflow files.

**`.github/workflows/mirror-osp-to-ooc.yaml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)


---
*Generated by [update-infra-deps.yml](/.github/workflows/update-infra-deps.yml) on 2026-05-18.*
*EOL data sourced from [endoflife.date](https://endoflife.date).*